### PR TITLE
General: Adopt CAPod PR-based workflow for changes to main

### DIFF
--- a/.claude/rules/commit-guidelines.md
+++ b/.claude/rules/commit-guidelines.md
@@ -1,10 +1,12 @@
 # Commit & Pull Request Guidelines
 
-## Pre-launch workflow
+## Workflow
 
-Amply is **pre-launch**. Until it launches, feature branches are **merged directly into `main`** — do not open PRs for
-routine work. (Recorded in project memory: "No PRs pre-launch".) The PR sections below apply once that changes, or for
-any change where a review is explicitly requested.
+All changes go through a **pull request** into `main` — the same flow CAPod uses. Direct pushes to `main` are
+blocked by a branch ruleset (no force-push, no deletion) that requires an open PR with passing CI status checks and
+resolved review threads before a change can land; version tags (`v*`) are protected the same way. Only the
+`d4rken-org-releaser` app bypasses these rules, for the automated release/tag workflows. Work on a feature branch or
+worktree, open a PR, let CI go green, then merge — see the PR sections below.
 
 ## Commit Message Format
 
@@ -47,7 +49,7 @@ until the HAL confirms or a budget expires, persisting the pending
 target so a killed service resumes.
 ```
 
-## Pull Requests (when used)
+## Pull Requests
 
 Follow the project's global PR rules: one PR per coherent change, no known-flaw PRs, open as **draft** if more work is
 still landing in the same PR.


### PR DESCRIPTION
**What changed**

The contributor docs now describe the PR-based workflow instead of the old "pre-launch: merge directly into `main`" convention. No user-facing or code behavior change.

**Technical Context**

The repo now carries capod-parity protection rulesets (added out-of-band):
- **`main` branch ruleset** — blocks deletion + force-push, requires an open PR with resolved review threads and 11 passing CI status checks. Org admins bypass in the PR context; the `d4rken-org-releaser` app bypasses always (release automation).
- **Tag ruleset** (`refs/tags/v*`) — blocks create/update/delete/force-push, `d4rken-org-releaser` bypasses.

This PR aligns `.claude/rules/commit-guidelines.md` with that enforced reality: the `## Pre-launch workflow` section (which said "merge directly into `main` — do not open PRs") is replaced by a `## Workflow` section describing the PR flow, and the stale `(when used)` qualifier is dropped from the `## Pull Requests` heading. This PR is itself the first change landing under the new flow.