### PR TITLE
FullCharge: Shorten the reconnect-gesture notification and note it can be turned off

### DIFF
--- a/app/src/main/java/eu/darken/amply/fullcharge/core/SessionNotifications.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/SessionNotifications.kt
@@ -134,19 +134,19 @@ object SessionNotifications {
             Intent(context, MainActivity::class.java),
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
-        return NotificationCompat.Builder(context, GESTURE_CHANNEL)
+        // Armed copy is the same regardless of arming basis; only the passive "waiting" copy
+        // distinguishes any-level from limit-hold.
+        val contentText = context.getString(
+            when {
+                armed -> R.string.gesture_notification_armed
+                anyLevel -> R.string.gesture_notification_waiting_any_level
+                else -> R.string.gesture_notification_waiting
+            },
+        )
+        val builder = NotificationCompat.Builder(context, GESTURE_CHANNEL)
             .setSmallIcon(R.drawable.ic_launcher_monochrome)
             .setContentTitle(context.getString(R.string.gesture_notification_title))
-            .setContentText(
-                context.getString(
-                    when {
-                        armed && anyLevel -> R.string.gesture_notification_armed_any_level
-                        armed -> R.string.gesture_notification_armed
-                        anyLevel -> R.string.gesture_notification_waiting_any_level
-                        else -> R.string.gesture_notification_waiting
-                    },
-                ),
-            )
+            .setContentText(contentText)
             .setContentIntent(openPendingIntent)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
@@ -154,7 +154,17 @@ object SessionNotifications {
             // Show at once instead of the ~10s foreground-service deferral, so the armed
             // "reconnect now" cue is visible within its 10-second window.
             .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
-            .build()
+        // The persistent waiting notification carries the "you can turn this off" hint in its
+        // expanded view — kept out of the collapsed line so it stays short, and off the armed
+        // cue so the time-sensitive reconnect instruction isn't diluted.
+        if (!armed) {
+            builder.setStyle(
+                NotificationCompat.BigTextStyle().bigText(
+                    contentText + "\n\n" + context.getString(R.string.gesture_notification_disable_hint),
+                ),
+            )
+        }
+        return builder.build()
     }
 
     fun recovering(context: Context): Notification {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,10 +11,10 @@
     <string name="session_notification_restore">Restore now</string>
     <string name="gesture_channel_name">Reconnect gesture</string>
     <string name="gesture_notification_title">Quick full charge is on</string>
-    <string name="gesture_notification_waiting">When the 80% limit pauses charging, unplug for a few seconds and reconnect to charge fully once.</string>
-    <string name="gesture_notification_armed">80% limit reached. Unplug for at least 2 seconds, then reconnect within 10 to charge fully once.</string>
-    <string name="gesture_notification_waiting_any_level">While a protective policy is set, unplug for a few seconds and reconnect to charge fully once.</string>
-    <string name="gesture_notification_armed_any_level">Ready at any charge level. Unplug for at least 2 seconds, then reconnect within 10 to charge fully once.</string>
+    <string name="gesture_notification_waiting">Waiting for a quick unplug and reconnect.</string>
+    <string name="gesture_notification_armed">Reconnect now: unplug 2s, then replug within 10s to charge fully.</string>
+    <string name="gesture_notification_waiting_any_level">Waiting for a quick unplug and reconnect at any charge level.</string>
+    <string name="gesture_notification_disable_hint">You can turn this notification off (long-press it) without stopping the gesture.</string>
     <string name="recovery_channel_name">Charge policy recovery</string>
     <string name="recovery_notification_title">Charge limit needs attention</string>
     <string name="recovery_notification_body">Open Amply and restart Shizuku to restore your protective policy.</string>


### PR DESCRIPTION
**What changed**

The ongoing notification for the "Reconnect for 100%" gesture had a long body that got cut off, and it wasn't obvious it could be turned off. Now:

- The persistent "waiting" text is short and no longer truncates. Expanding the notification shows the full explanation plus a note that you can turn it off (long-press it) without stopping the gesture.
- The time-sensitive "reconnect now" cue keeps its unplug/replug instructions unchanged.

The notification already had its own dedicated channel, so turning it off never affected Amply's other notifications, and it never affected the gesture itself — the background service keeps running and still triggers a full charge on replug.

**Technical Context**

- The gesture notification (`SessionNotifications.gesture()`) sits on its own `reconnect_gesture` channel already; no new channel was needed. The reported truncation came from a ~90-char content string with no `BigTextStyle` — collapsed to one ellipsized line with no way to expand.
- Fix: short `setContentText` for the passive states, and a `BigTextStyle` expanded view that appends `gesture_notification_disable_hint`. The `BigTextStyle`/hint are applied only to the non-armed states so the armed "reconnect now" cue stays a clean, single actionable line within its 10s window.
- The armed copy no longer varies by arming basis, so the redundant `gesture_notification_armed_any_level` string was removed and the state selection reduced from four cases to three.
- No change to the foreground service, gesture state machine, or channel importance.

**Checks**: `testFossDebugUnitTest testGplayDebugUnitTest lintVitalFossRelease lintVitalGplayRelease assembleFossDebug assembleGplayDebug` — all pass (321 tests, lint clean).