### PR TITLE
Charging: Read sync-readback adapters direct-first to stop phantom settling

### DIFF
--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -3,6 +3,7 @@ package eu.darken.amply.charging.core
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.amply.R
+import eu.darken.amply.charging.core.access.AccessBackend
 import eu.darken.amply.charging.core.access.AccessResolver
 import eu.darken.amply.charging.core.access.AccessSnapshot
 import eu.darken.amply.charging.core.access.shizuku.ShizukuController
@@ -194,23 +195,16 @@ class ChargingRepository @Inject constructor(
     }
 
     /**
-     * Sync-readback adapters use world-readable keys, so a nominally "ready" but misbehaving
-     * Shizuku service (main binder up, user service broken) must not block verification —
-     * fall back to the direct provider backend on a non-verified read.
+     * Sync-readback adapters use world-readable / unprivileged keys, so the DIRECT provider read is
+     * authoritative and — unlike a Shizuku user-service bind, which can block up to ~15s on a cold process
+     * ([ShizukuController.service]) — never stalls. Read direct first so that bind is never on the critical
+     * path (the widget/tile refresh after a tap); consult Shizuku only as a fallback when the direct read is
+     * not authoritative on some ROM. A nominally "ready" but misbehaving Shizuku service therefore can no
+     * longer delay verification.
      */
     private suspend fun readSyncWithFallback(adapter: ChargingAdapter): ChargeObservation? {
-        val primary = accessResolver.readBackend() ?: return null
-        val first = runCatching { adapter.read(primary) }.getOrNull()
-        if (first is ChargeObservation.Verified || primary === accessResolver.direct) return first
-        val second = runCatching { adapter.read(accessResolver.direct) }.getOrNull()
-        // Signal strength: Verified > readable-but-unrecognized (must survive the fallback so
-        // session start can refuse) > generic unreadable.
-        return when {
-            second is ChargeObservation.Verified -> second
-            first is ChargeObservation.Unknown && first.unrecognizedValue -> first
-            second is ChargeObservation.Unknown && second.unrecognizedValue -> second
-            else -> first ?: second
-        }
+        val shizuku = accessResolver.shizuku.takeIf { accessResolver.shizuku.status().ready }
+        return readSyncDirectFirst(adapter, accessResolver.direct, shizuku)
     }
 
     fun shizukuManagerPackage(): String? = shizukuController.managerPackage()
@@ -355,8 +349,13 @@ class ChargingRepository @Inject constructor(
             !selection.support.controlEnabled -> ChargeObservation.Unsupported(selection.support.detail.toCaString())
             !access.canControl -> ChargeObservation.NeedsSetup(R.string.charging_reason_needs_setup.toCaString())
             else -> {
-                val backend = accessResolver.readBackend()
-                val read = if (backend != null) adapter.read(backend) else null
+                // Sync-readback adapters read the direct provider first (authoritative, never stalls on a
+                // cold Shizuku bind); async (Pixel) keeps the preferred-backend + hardware path.
+                val read = when (adapter.verification) {
+                    VerificationStrategy.SYNC_READBACK -> readSyncWithFallback(adapter)
+                    VerificationStrategy.ASYNC_HARDWARE ->
+                        accessResolver.readBackend()?.let { adapter.read(it) }
+                }
                 when {
                     read is ChargeObservation.Verified -> read
                     // A readable-but-unrecognized OEM value must not be masked by a stale last
@@ -408,43 +407,105 @@ class ChargingRepository @Inject constructor(
             val accessState = published.access
                 ?.let { "direct=${it.direct.ready},shizuku=${it.shizuku.ready}" }
                 ?: "none"
-            "refresh(adapter=${published.adapterId}, access=$accessState, observation=${published.observation})"
+            "refresh(adapter=${published.adapterId}, access=$accessState, " +
+                "observation=${published.observation}, pending=${published.pending?.target})"
         }
         return published
-    }
-
-    /**
-     * Reconstruct the pending settling request from the persisted target+timestamp, clearing it once the
-     * window elapses, the hardware confirms the target, or access is lost. Deliberately does NOT clear on
-     * "hardware reports a different policy": mid-transition the hardware legitimately still shows the old
-     * policy, so that is not evidence of a native change. A genuine native change within the window shows a
-     * stale cue for at most one window before expiry corrects it.
-     */
-    private fun computeRefreshPending(
-        reqPolicy: ChargePolicy?,
-        reqAt: Long,
-        now: Long,
-        observation: ChargeObservation,
-        hardware: ChargeObservation?,
-        verification: VerificationStrategy,
-    ): PendingRequest? {
-        if (reqPolicy == null || reqAt <= 0L) return null
-        if (now - reqAt !in 0 until SETTLING_WINDOW_MILLIS) return null
-        if (observation is ChargeObservation.Unsupported || observation is ChargeObservation.NeedsSetup) return null
-        val confirmed = when (verification) {
-            // Settings readback IS confirmation when writes apply synchronously.
-            VerificationStrategy.SYNC_READBACK ->
-                observation is ChargeObservation.Verified && observation.policy == reqPolicy
-            VerificationStrategy.ASYNC_HARDWARE ->
-                hardware is ChargeObservation.Verified &&
-                    hardware.backend == BackendKind.BATTERY_HARDWARE &&
-                    hardware.policy == reqPolicy
-        }
-        if (confirmed) return null
-        return PendingRequest(reqPolicy, reqAt)
     }
 
     private companion object {
         val TAG = logTag("Charging", "Repository")
     }
+}
+
+/**
+ * Read a sync-readback adapter's configured state, preferring the [direct] provider and consulting
+ * [shizuku] (may be null when not ready) only as a fallback. Direct reads of these adapters' world-readable
+ * keys are authoritative and cannot stall, so an *authoritative* direct read — [ChargeObservation.Verified]
+ * or a readable-but-unrecognized OEM value — short-circuits without ever binding the Shizuku user service
+ * (both backends read the same settings provider, so Shizuku could not report anything stronger). Only a
+ * genuinely unreadable direct result falls back to Shizuku.
+ */
+internal suspend fun readSyncDirectFirst(
+    adapter: ChargingAdapter,
+    direct: AccessBackend,
+    shizuku: AccessBackend?,
+): ChargeObservation? {
+    val primary = readObservationOrNull(adapter, direct)
+    if (primary.isAuthoritativeSyncRead()) return primary
+    val fallback = shizuku?.let { readObservationOrNull(adapter, it) }
+    return chooseSyncObservation(primary, fallback)
+}
+
+/**
+ * A sync read that resolves the pending transition on its own: a confirmed policy or a readable-but-
+ * unrecognized OEM value (the setting *was* read, we just don't map the value). Mirrors the SYNC_READBACK
+ * arm of [computeRefreshPending] — what clears pending is exactly what makes the Shizuku fallback redundant.
+ */
+private fun ChargeObservation?.isAuthoritativeSyncRead(): Boolean =
+    this is ChargeObservation.Verified ||
+        (this is ChargeObservation.Unknown && unrecognizedValue)
+
+/** Read via one backend, turning ordinary failures into null but never swallowing cancellation. */
+internal suspend fun readObservationOrNull(
+    adapter: ChargingAdapter,
+    backend: AccessBackend,
+): ChargeObservation? = try {
+    adapter.read(backend)
+} catch (e: CancellationException) {
+    throw e
+} catch (e: Exception) {
+    null
+}
+
+/**
+ * Pick the strongest of a [primary] (direct) and [fallback] (Shizuku) sync read: Verified beats a
+ * readable-but-unrecognized value (which must survive so a session start can refuse) beats a generic
+ * unreadable one. Primary wins ties at each tier.
+ */
+internal fun chooseSyncObservation(
+    primary: ChargeObservation?,
+    fallback: ChargeObservation?,
+): ChargeObservation? = when {
+    primary is ChargeObservation.Verified -> primary
+    fallback is ChargeObservation.Verified -> fallback
+    primary is ChargeObservation.Unknown && primary.unrecognizedValue -> primary
+    fallback is ChargeObservation.Unknown && fallback.unrecognizedValue -> fallback
+    else -> primary ?: fallback
+}
+
+/**
+ * Reconstruct the pending settling request from the persisted target+timestamp, clearing it once the window
+ * elapses or the request is confirmed resolved.
+ *
+ * The confirmation signal differs by strategy. For [VerificationStrategy.ASYNC_HARDWARE] (Pixel) only a
+ * matching BATTERY_HARDWARE reading confirms, and a hardware reading for a *different* policy is deliberately
+ * NOT treated as resolution — mid-transition the HAL legitimately still shows the old policy. For
+ * [VerificationStrategy.SYNC_READBACK] the settings readback is authoritative and synchronous, so ANY
+ * successful read resolves the transition: a Verified value (matching OR different — a different value is a
+ * native/competing change that has already taken effect) or a readable-but-unrecognized OEM value. Only a
+ * genuinely unreadable/generic-unknown sync state keeps the request pending until the window expires.
+ */
+internal fun computeRefreshPending(
+    reqPolicy: ChargePolicy?,
+    reqAt: Long,
+    now: Long,
+    observation: ChargeObservation,
+    hardware: ChargeObservation?,
+    verification: VerificationStrategy,
+): PendingRequest? {
+    if (reqPolicy == null || reqAt <= 0L) return null
+    if (now - reqAt !in 0 until SETTLING_WINDOW_MILLIS) return null
+    if (observation is ChargeObservation.Unsupported || observation is ChargeObservation.NeedsSetup) return null
+    val confirmed = when (verification) {
+        VerificationStrategy.SYNC_READBACK ->
+            observation is ChargeObservation.Verified ||
+                (observation is ChargeObservation.Unknown && observation.unrecognizedValue)
+        VerificationStrategy.ASYNC_HARDWARE ->
+            hardware is ChargeObservation.Verified &&
+                hardware.backend == BackendKind.BATTERY_HARDWARE &&
+                hardware.policy == reqPolicy
+    }
+    if (confirmed) return null
+    return PendingRequest(reqPolicy, reqAt)
 }

--- a/app/src/main/java/eu/darken/amply/charging/core/access/ShizukuSettingsBackend.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/access/ShizukuSettingsBackend.kt
@@ -34,12 +34,18 @@ class ShizukuSettingsBackend @Inject constructor(
         )
     }
 
-    override suspend fun read(namespace: SettingNamespace, key: String): SettingRead = runCatching {
+    override suspend fun read(namespace: SettingNamespace, key: String): SettingRead = try {
         SettingRead(
             readable = true,
             value = controller.service().readSetting(namespace.commandName, key),
         )
-    }.getOrElse { SettingRead(false, error = (it.message ?: it.javaClass.simpleName).toCaString()) }
+    } catch (e: CancellationException) {
+        // Binding the user service (controller.service()) can suspend up to ~15s; a cancelled read must
+        // propagate rather than be reported as an unreadable setting — matching snapshot() below.
+        throw e
+    } catch (e: Exception) {
+        SettingRead(false, error = (e.message ?: e.javaClass.simpleName).toCaString())
+    }
 
     override suspend fun write(mutation: SettingMutation): Boolean = runCatching {
         controller.service().writeSetting(

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingSyncReadTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingSyncReadTest.kt
@@ -1,0 +1,219 @@
+package eu.darken.amply.charging.core
+
+import android.content.Context
+import android.content.Intent
+import eu.darken.amply.charging.core.access.AccessBackend
+import eu.darken.amply.charging.core.access.BackendStatus
+import eu.darken.amply.charging.core.access.SettingMutation
+import eu.darken.amply.charging.core.access.SettingNamespace
+import eu.darken.amply.charging.core.access.SettingRead
+import eu.darken.amply.charging.core.adapter.ChargingAdapter
+import eu.darken.amply.charging.core.adapter.VerificationStrategy
+import eu.darken.amply.common.ca.toCaString
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class ChargingSyncReadTest {
+
+    private val target = ChargePolicy.FixedLimit(80)
+    private val other = ChargePolicy.Unrestricted
+    private val t0 = 1_000_000L
+
+    private fun verified(policy: ChargePolicy, backend: BackendKind) = ChargeObservation.Verified(policy, backend)
+    private fun unrecognized() = ChargeObservation.Unknown("weird".toCaString(), unrecognizedValue = true)
+    private fun generic() = ChargeObservation.Unknown("unreadable".toCaString())
+
+    // --- chooseSyncObservation precedence: Verified > unrecognized > generic; primary (direct) wins ties ---
+
+    @Test
+    fun `primary verified always wins`() {
+        val p = verified(target, BackendKind.DIRECT_WSS)
+        chooseSyncObservation(p, verified(other, BackendKind.SHIZUKU)) shouldBeSameInstanceAs p
+    }
+
+    @Test
+    fun `fallback verified wins over any non-verified primary`() {
+        val f = verified(target, BackendKind.SHIZUKU)
+        chooseSyncObservation(generic(), f) shouldBeSameInstanceAs f
+        chooseSyncObservation(unrecognized(), f) shouldBeSameInstanceAs f
+    }
+
+    @Test
+    fun `unrecognized primary survives over a generic fallback`() {
+        val p = unrecognized()
+        chooseSyncObservation(p, generic()) shouldBeSameInstanceAs p
+    }
+
+    @Test
+    fun `unrecognized fallback used when primary is generic`() {
+        val f = unrecognized()
+        chooseSyncObservation(generic(), f) shouldBeSameInstanceAs f
+    }
+
+    @Test
+    fun `both null is null`() {
+        chooseSyncObservation(null, null) shouldBe null
+    }
+
+    // --- readSyncDirectFirst: direct-first, Shizuku only as fallback (the latency fix) ---
+
+    @Test
+    fun `direct verified short-circuits without ever touching shizuku`() = runTest {
+        val direct = FakeBackend(BackendKind.DIRECT_WSS)
+        val shizuku = FakeBackend(BackendKind.SHIZUKU)
+        val adapter = FakeSyncAdapter(mapOf(direct to { verified(target, BackendKind.DIRECT_WSS) }))
+
+        readSyncDirectFirst(adapter, direct, shizuku) shouldBe verified(target, BackendKind.DIRECT_WSS)
+        // The whole point of the fix: a cold/stalled Shizuku bind is never on the read path.
+        adapter.readBackends shouldBe listOf(direct)
+    }
+
+    @Test
+    fun `falls back to shizuku only after a non-verified direct read`() = runTest {
+        val direct = FakeBackend(BackendKind.DIRECT_WSS)
+        val shizuku = FakeBackend(BackendKind.SHIZUKU)
+        val adapter = FakeSyncAdapter(
+            mapOf(
+                direct to { generic() },
+                shizuku to { verified(target, BackendKind.SHIZUKU) },
+            ),
+        )
+
+        readSyncDirectFirst(adapter, direct, shizuku) shouldBe verified(target, BackendKind.SHIZUKU)
+        adapter.readBackends shouldBe listOf(direct, shizuku)
+    }
+
+    @Test
+    fun `direct unrecognized value short-circuits without touching shizuku`() = runTest {
+        val direct = FakeBackend(BackendKind.DIRECT_WSS)
+        val shizuku = FakeBackend(BackendKind.SHIZUKU)
+        val adapter = FakeSyncAdapter(mapOf(direct to { unrecognized() }))
+
+        val result = readSyncDirectFirst(adapter, direct, shizuku)
+        (result as ChargeObservation.Unknown).unrecognizedValue shouldBe true
+        // A readable-but-unrecognized value is authoritative; Shizuku reads the same provider and can't do
+        // better, so it must not be bound (that is the ~15s stall we are avoiding).
+        adapter.readBackends shouldBe listOf(direct)
+    }
+
+    @Test
+    fun `null shizuku returns the direct read as-is`() = runTest {
+        val direct = FakeBackend(BackendKind.DIRECT_WSS)
+        val adapter = FakeSyncAdapter(mapOf(direct to { generic() }))
+
+        val result = readSyncDirectFirst(adapter, direct, null)
+        (result as ChargeObservation.Unknown).unrecognizedValue shouldBe false
+    }
+
+    @Test
+    fun `an ordinary direct read failure falls through to shizuku`() = runTest {
+        val direct = FakeBackend(BackendKind.DIRECT_WSS)
+        val shizuku = FakeBackend(BackendKind.SHIZUKU)
+        val adapter = FakeSyncAdapter(
+            mapOf(
+                direct to { throw IllegalStateException("boom") },
+                shizuku to { verified(target, BackendKind.SHIZUKU) },
+            ),
+        )
+
+        readSyncDirectFirst(adapter, direct, shizuku) shouldBe verified(target, BackendKind.SHIZUKU)
+    }
+
+    @Test
+    fun `cancellation from a read propagates and is never swallowed`() = runTest {
+        val direct = FakeBackend(BackendKind.DIRECT_WSS)
+        val adapter = FakeSyncAdapter(mapOf(direct to { throw CancellationException() }))
+
+        shouldThrow<CancellationException> { readSyncDirectFirst(adapter, direct, null) }
+    }
+
+    // --- computeRefreshPending: SYNC_READBACK clears on any authoritative read ---
+
+    private fun sync(observation: ChargeObservation, now: Long = t0 + 5_000) = computeRefreshPending(
+        reqPolicy = target,
+        reqAt = t0,
+        now = now,
+        observation = observation,
+        hardware = null,
+        verification = VerificationStrategy.SYNC_READBACK,
+    )
+
+    @Test
+    fun `sync verified matching clears pending`() {
+        sync(verified(target, BackendKind.DIRECT_WSS)) shouldBe null
+    }
+
+    @Test
+    fun `sync verified for a different policy also clears pending`() {
+        // A different verified value is a native/competing change that already took effect — not a
+        // mid-transition artifact — so the stale request must clear immediately, not linger 15s.
+        sync(verified(other, BackendKind.DIRECT_WSS)) shouldBe null
+    }
+
+    @Test
+    fun `sync readable-but-unrecognized value clears pending`() {
+        sync(unrecognized()) shouldBe null
+    }
+
+    @Test
+    fun `sync generic-unknown keeps pending until the window expires`() {
+        sync(generic()) shouldBe PendingRequest(target, t0)
+        sync(generic(), now = t0 + SETTLING_WINDOW_MILLIS) shouldBe null
+    }
+
+    // --- computeRefreshPending: ASYNC_HARDWARE behavior is unchanged ---
+
+    private fun async(observation: ChargeObservation, hardware: ChargeObservation?) = computeRefreshPending(
+        reqPolicy = target,
+        reqAt = t0,
+        now = t0 + 5_000,
+        observation = observation,
+        hardware = hardware,
+        verification = VerificationStrategy.ASYNC_HARDWARE,
+    )
+
+    @Test
+    fun `async clears only on matching hardware verification`() {
+        async(verified(target, BackendKind.SHIZUKU), verified(target, BackendKind.BATTERY_HARDWARE)) shouldBe null
+    }
+
+    @Test
+    fun `async keeps pending when hardware still shows a different policy mid-transition`() {
+        async(verified(target, BackendKind.SHIZUKU), verified(other, BackendKind.BATTERY_HARDWARE)) shouldBe
+            PendingRequest(target, t0)
+    }
+
+    @Test
+    fun `async ignores settings-only verification without a hardware signal`() {
+        async(verified(target, BackendKind.SHIZUKU), null) shouldBe PendingRequest(target, t0)
+    }
+
+    private class FakeBackend(override val kind: BackendKind) : AccessBackend {
+        override suspend fun status() = BackendStatus(true, true, "test".toCaString())
+        override suspend fun read(namespace: SettingNamespace, key: String) = SettingRead(readable = false)
+        override suspend fun write(mutation: SettingMutation) = false
+    }
+
+    private class FakeSyncAdapter(
+        private val reads: Map<AccessBackend, suspend () -> ChargeObservation>,
+    ) : ChargingAdapter {
+        val readBackends = mutableListOf<AccessBackend>()
+        override val id = "fake-sync"
+        override val displayName = "Fake".toCaString()
+        override val supportedPolicies = emptyList<ChargePolicy>()
+        override val verification = VerificationStrategy.SYNC_READBACK
+
+        override suspend fun read(backend: AccessBackend): ChargeObservation {
+            readBackends += backend
+            return (reads[backend] ?: error("unexpected backend $backend")).invoke()
+        }
+
+        override fun probe(device: DeviceInfo) = error("unused")
+        override suspend fun apply(policy: ChargePolicy, backend: AccessBackend) = false
+        override fun nativeSettingsIntent(context: Context): Intent = error("unused")
+    }
+}


### PR DESCRIPTION
## What changed

On Samsung, Xiaomi and OnePlus/ColorOS devices, the home-screen widget, Quick Settings tile and dashboard could show a **"waiting for system…" state for up to ~15 seconds** after you changed the charge policy — even though the write had already applied. That transient state no longer appears on these devices: the surfaces reflect the new policy promptly, and a policy changed from outside Amply is picked up immediately instead of lingering for a full settling window.

No behavior change for Pixel (which genuinely does apply asynchronously and still shows an honest settling state).

## Technical Context

**Root cause.** `ChargingRepository.refreshLocked()` read charge state through `AccessResolver.readBackend()`, which prefers Shizuku when it's ready. Binding the Shizuku user service (`ShizukuController.service()`) can block up to ~15 s on a cold process — and One UI evicts background processes aggressively, so a widget tap frequently cold-starts the app. That non-`Verified` read then fell through to `LastRequested`, and `computeRefreshPending()` fabricated a 15 s `PendingRequest` for a `SYNC_READBACK` adapter whose write was actually synchronous and already done. The dashboard was unaffected because it runs in the warm app process with a healthy binder.

**Fix.**
- Sync-readback adapters use world-readable / unprivileged keys, so the **direct** ContentResolver read is authoritative and never stalls. `refreshLocked` now reads direct-first for `SYNC_READBACK` (Pixel/`ASYNC_HARDWARE` keeps the preferred-backend + hardware path). An authoritative direct read — `Verified` **or** a readable-but-unrecognized OEM value — short-circuits without ever binding Shizuku (both backends read the same provider, so Shizuku can't report anything stronger).
- `computeRefreshPending` now clears pending on **any** authoritative sync read, including a `Verified` *different* policy (a native/competing change that already took effect, not a mid-transition artifact). `ASYNC_HARDWARE` is unchanged — it still clears only on a matching `BATTERY_HARDWARE` reading, preserving the Pixel mid-transition rationale.
- `ShizukuSettingsBackend.read()` now propagates `CancellationException` instead of reporting a cancelled read as an unreadable setting (matching the existing `snapshot()`).
- Read line now logs `pending=` for diagnosis.

**Scope / non-goals.** This does not change the Pixel async path, and it does not fix broken-Shizuku *writes* — Oplus writes still require Shizuku (`system` namespace). The fix targets faulty/stale sync *readback* after a successful write, and removing the Shizuku bind from the read critical path.

**Review guidance.** The precedence (`chooseSyncObservation`), read orchestration (`readSyncDirectFirst`) and `computeRefreshPending` are extracted as pure/top-level `internal` functions and unit-tested (`ChargingSyncReadTest`, 18 cases incl. direct-first with Shizuku untouched, unrecognized short-circuit, cancellation propagation, and clearing on a different verified policy). Reviewed by Codex.

## Verification

- `./gradlew testFossDebugUnitTest testGplayDebugUnitTest` — green (both flavors).
- On a Galaxy Tab A9+ (SM-X210, One UI 8.0): 5 policy changes, no "waiting" stall on the dashboard, `pending=null` in every refresh log line.

## Known separate issue (NOT addressed here)

Device testing surfaced a **distinct, pre-existing widget-refresh delivery bug** unrelated to this change (this PR never touches the widget update push): on some transitions the Glance widget's `updateAll()` recomposition doesn't reach the host, so a `Verified` backend change occasionally doesn't repaint the widget's RemoteViews until the next change forces a rebuild. Also observed: a first-tap-after-placement click drop, and a corrupted `AppWidgetManager` provider cache on that test device. These are tracked separately — they need a clean device to reproduce reliably.