### PR TITLE
Widget: Make the Glance widget reactive so taps reliably repaint

### DIFF
--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -51,6 +51,12 @@ data class ChargingState(
     val adapterName: CaString = R.string.adapter_name_detecting.toCaString(),
     val adapterId: String? = null,
     val supportedPolicies: List<ChargePolicy> = emptyList(),
+    /**
+     * The selected adapter's protective default (e.g. FixedLimit(80) on Pixel, Adaptive on Xiaomi), or
+     * null before an adapter is selected. Carried on the state so observing surfaces (the widget) can
+     * label the "∞ protect" action without a separate suspend adapter lookup at composition time.
+     */
+    val defaultProtectivePolicy: ChargePolicy? = null,
     val reconnectSupported: Boolean = false,
     /** True when the adapter's configured state is directly readable — Shizuku adds nothing for verification. */
     val syncVerification: Boolean = false,
@@ -310,7 +316,18 @@ class ChargingRepository @Inject constructor(
                 pending = pending,
                 message = message,
             )
-            if (pending != null) settleScheduler.schedule(now)
+            // Always schedule an eventual surface re-push, even for a settled write (pending == null).
+            // SYNC_READBACK adapters (Samsung/Xiaomi/Oplus) verify synchronously and leave pending null,
+            // so without this a static widget/tile on a killed process would never be pushed the new
+            // state after a tap. Scheduling with `now` fires the worker AFTER the settling window, so its
+            // refresh() computes pending == null (no phantom settling is reintroduced) and only re-pushes.
+            // Isolate the call locally: a scheduler failure must not fall into the metadata-failure catch
+            // below, which would overwrite this just-published settled state with a phantom PendingRequest.
+            try {
+                settleScheduler.schedule(now)
+            } catch (e: Exception) {
+                log(TAG, Logging.Priority.WARN) { "Surface re-push scheduling failed: ${e.message}" }
+            }
             ApplyResult(true, observation, message.get(context))
                 .also { log(TAG, Logging.Priority.INFO) { "Applied ${policy.stableId}: $observation" } }
         } catch (e: CancellationException) {
@@ -384,6 +401,7 @@ class ChargingRepository @Inject constructor(
             adapterName = adapter?.displayName ?: R.string.adapter_name_unsupported.toCaString(),
             adapterId = adapter?.id,
             supportedPolicies = adapter?.supportedPolicies.orEmpty(),
+            defaultProtectivePolicy = adapter?.defaultProtectivePolicy,
             reconnectSupported = adapter?.reconnectGestureSupported == true,
             syncVerification = adapter?.verification == VerificationStrategy.SYNC_READBACK,
             writeRequiresShizuku = adapter?.preferShizukuForWrites == true,

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -96,7 +96,8 @@ class ChargeSessionService : Service() {
                     // Respect a native Settings change instead of restoring over the user's choice.
                     manager.cancelWithoutRestore()
                     unregisterSettingObserver()
-                    SurfaceUpdater.update(this@ChargeSessionService)
+                    // continueGestureOrStop() awaits a surface update on every terminal branch, so no path
+                    // here leaves the widget/tile un-pushed (some paths push more than once — updateAll is idempotent).
                     continueGestureOrStop()
                 }
             }
@@ -197,7 +198,21 @@ class ChargeSessionService : Service() {
         val gestureActive = fullChargeStore.isQuickFullChargeEnabled() && reconnectGestureAvailable()
         if (!gestureActive && !anyWatcherEnabled()) {
             log(TAG) { "Reconnect gesture disabled/unsupported and no watcher enabled; stopping monitor" }
-            stopMonitoring()
+            // The stop branch used to be the one terminal path through continueGestureOrStop that pushed no
+            // surface update — a session/native change ending here (e.g. via the setting observer) left the
+            // widget and tile stale until some later refresh. Push here, before stopping, so no branch leaves
+            // the surfaces un-pushed (nested/recursive paths may legitimately push more than once — updateAll
+            // is idempotent). A surface failure must not skip stopMonitoring()'s required cleanup
+            // (stopForeground/stopSelf), and cancellation must still propagate.
+            try {
+                SurfaceUpdater.updateNow(this)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, Logging.Priority.WARN) { "Surface update before stop failed: ${e.message}" }
+            } finally {
+                stopMonitoring()
+            }
             return
         }
         unregisterSettingObserver()
@@ -453,7 +468,8 @@ class ChargeSessionService : Service() {
             val outcome = BootRecoveryFlow(recoveryHooks).run()
             log(TAG) { "Boot recovery outcome: $outcome" }
             commandMutex.withLock {
-                SurfaceUpdater.update(this@ChargeSessionService)
+                // continueGestureOrStop() awaits a surface update on every terminal branch, so no path here
+                // leaves the widget/tile un-pushed (some paths push more than once — updateAll is idempotent).
                 continueGestureOrStop()
             }
         }

--- a/app/src/main/java/eu/darken/amply/main/core/SettleRefreshWorker.kt
+++ b/app/src/main/java/eu/darken/amply/main/core/SettleRefreshWorker.kt
@@ -27,7 +27,10 @@ class SettleRefreshWorker(
         )
         return try {
             entryPoint.chargingRepository().refresh()
-            // Await the surface push in the worker's own scope so the process can't die before it lands.
+            // updateNow awaits Glance *enqueuing* its durable update work, not the eventual composition +
+            // AppWidgetManager delivery (Glance does that later in its own worker). Process-death safety for
+            // the actual push therefore rests on Glance's durable work, not on awaiting here; this call still
+            // ensures the enqueue happens (and a failure at that step yields Result.retry below).
             SurfaceUpdater.updateNow(applicationContext)
             Result.success()
         } catch (e: CancellationException) {

--- a/app/src/main/java/eu/darken/amply/main/core/SurfaceUpdater.kt
+++ b/app/src/main/java/eu/darken/amply/main/core/SurfaceUpdater.kt
@@ -6,22 +6,41 @@ import android.service.quicksettings.TileService
 import eu.darken.amply.main.ui.tile.ChargeTileService
 import eu.darken.amply.main.ui.widget.AmplyWidget
 import androidx.glance.appwidget.updateAll
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.CancellationException
 
 object SurfaceUpdater {
-    fun update(context: Context) {
-        TileService.requestListeningState(context, ComponentName(context, ChargeTileService::class.java))
-        CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
-            runCatching { AmplyWidget().updateAll(context) }
-        }
-    }
+    /**
+     * Awaits [updateAll] in the caller's scope. Note [updateAll] only awaits Glance *enqueuing* its durable
+     * update work (or handing an event to an active session), NOT the eventual composition +
+     * AppWidgetManager push, which Glance performs later in its own worker. So awaiting here guards the
+     * enqueue/repo step (a failure there propagates so a worker can retry, and [CancellationException] is
+     * rethrown), not delivery — process-death safety comes from Glance's durable work, not from this await.
+     * Only the tile update is isolated so its failure can never prevent the widget [updateAll].
+     */
+    suspend fun updateNow(context: Context) = runSurfaceUpdate(
+        tile = { requestTileUpdate(context) },
+        widget = { AmplyWidget().updateAll(context) },
+    )
 
-    /** Awaits the widget update in the caller's scope — use from a worker so it can't die before the push lands. */
-    suspend fun updateNow(context: Context) {
+    private fun requestTileUpdate(context: Context) {
         TileService.requestListeningState(context, ComponentName(context, ChargeTileService::class.java))
-        AmplyWidget().updateAll(context)
     }
+}
+
+/**
+ * Run the two surface updates with the required error policy: the [tile] update is best-effort and its
+ * ordinary failures are swallowed so they can never prevent the [widget] update, while the [widget] update's
+ * failures propagate to the caller. A [CancellationException] from either is always rethrown, never swallowed.
+ * Caveat: for the Glance widget, "[widget] failure" means an enqueue/repo failure — the eventual composition +
+ * AppWidgetManager delivery happens later in Glance's own worker and is not awaited here.
+ */
+internal suspend fun runSurfaceUpdate(tile: () -> Unit, widget: suspend () -> Unit) {
+    try {
+        tile()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        // Tile is best-effort; a failure here must not block the widget push.
+    }
+    widget()
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/widget/AmplyWidget.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/widget/AmplyWidget.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -55,6 +57,7 @@ import eu.darken.amply.fullcharge.core.FullChargeStore
 import eu.darken.amply.fullcharge.core.ChargeSessionService
 import eu.darken.amply.fullcharge.core.policyOrNull
 import eu.darken.amply.main.ui.MainActivity
+import kotlinx.coroutines.CancellationException
 
 /** Below this width the brand mark + name is dropped so the status line stays readable. */
 private val BRAND_MIN_WIDTH = 200.dp
@@ -71,20 +74,39 @@ class AmplyWidget : GlanceAppWidget() {
             context.applicationContext,
             AmplyWidgetEntryPoint::class.java,
         )
-        // Refresh on every render (with a last-good fallback): the widget process can be cold and the
-        // in-memory state stale, and native Settings changes are only observed while the app/service runs.
         val repo = entryPoint.chargingRepository()
-        val state = runCatching { repo.refresh() }.getOrElse { repo.state.value }
-        val sessionActive = entryPoint.sessionStore().currentSession() != null
-        val now = System.currentTimeMillis()
-        val requestedTarget = runCatching { entryPoint.chargingPreferences().lastRequestedNow() }.getOrNull()
-        val settling = state.isSettling(now)
-        // "Constant" state = a plain resting policy, nothing in flight — the only time the brand is shown.
-        val steady = !sessionActive && !settling
-        val status = statusLine(context, sessionActive, settling, state, requestedTarget)
+        val sessionStore = entryPoint.sessionStore()
+        val preferences = entryPoint.chargingPreferences()
+
+        // Seed once, before provideContent: the widget process can be cold and the in-memory state stale, and
+        // native Settings changes are only observed while the app/service runs. Doing this here (not in a
+        // per-composition LaunchedEffect) avoids re-refreshing once per size under SizeMode.Exact and avoids
+        // briefly flashing the empty initial ChargingState() before the refresh lands. Cancellation propagates.
+        try {
+            // Populate repo.state (collected below) so the first composition renders real values, not the
+            // empty initial ChargingState().
+            repo.refresh()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Cold read failed; the composition falls back to the last-known repo.state.value.
+        }
+        val initialSession = runCatching { sessionStore.currentSession() }.getOrNull()
+        val initialRequested = runCatching { preferences.lastRequestedNow() }.getOrNull()
 
         provideContent {
-            val showBrand = steady && LocalSize.current.width >= BRAND_MIN_WIDTH
+            // Reactive composition: Glance never re-runs an already-active provideGlance, so a one-shot
+            // pre-provideContent read alone would miss later backend changes and freeze the widget after a tap.
+            // Observing the same reactive sources the rest of the app uses makes Glance recompose this content
+            // in place whenever the backend emits. The StateFlow already reflects the seeded refresh above; the
+            // two plain flows are seeded with the pre-read values so the first frame is never empty.
+            val state by repo.state.collectAsState()
+            val session by sessionStore.session.collectAsState(initial = initialSession)
+            val requestedTarget by preferences.lastRequested.collectAsState(initial = initialRequested)
+
+            val display = widgetDisplay(state, sessionActive = session != null, now = System.currentTimeMillis())
+            val status = statusLine(context, display.sessionActive, display.settling, state, requestedTarget)
+            val showBrand = display.steady && LocalSize.current.width >= BRAND_MIN_WIDTH
             val titleStyle = TextStyle(color = TITLE_COLOR, fontWeight = FontWeight.Bold)
             Column(
                 modifier = GlanceModifier
@@ -120,7 +142,7 @@ class AmplyWidget : GlanceAppWidget() {
                 val buttonText = TextStyle(fontSize = 12.sp)
                 Row(modifier = GlanceModifier.fillMaxWidth().padding(top = 10.dp)) {
                     Button(
-                        text = protectButtonLabel(context, repo.currentAdapter()?.defaultProtectivePolicy),
+                        text = protectButtonLabel(context, state.defaultProtectivePolicy),
                         onClick = actionRunCallback<ProtectAction>(),
                         modifier = GlanceModifier.defaultWeight(),
                         style = buttonText,
@@ -146,6 +168,26 @@ class AmplyWidget : GlanceAppWidget() {
             }
         }
     }
+}
+
+/**
+ * Structural (context-free) widget display derivation, kept pure so the branches are JVM-unit-testable.
+ * `sessionActive` wins over everything; `settling` is the pending-request window; `steady` (a plain resting
+ * policy, nothing in flight) is the only state that shows the brand mark.
+ */
+internal data class WidgetDisplay(
+    val sessionActive: Boolean,
+    val settling: Boolean,
+    val steady: Boolean,
+)
+
+internal fun widgetDisplay(state: ChargingState, sessionActive: Boolean, now: Long): WidgetDisplay {
+    val settling = state.isSettling(now)
+    return WidgetDisplay(
+        sessionActive = sessionActive,
+        settling = settling,
+        steady = !sessionActive && !settling,
+    )
 }
 
 /**

--- a/app/src/test/java/eu/darken/amply/main/core/SurfaceUpdaterTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/core/SurfaceUpdaterTest.kt
@@ -1,0 +1,41 @@
+package eu.darken.amply.main.core
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class SurfaceUpdaterTest {
+
+    @Test
+    fun `a tile failure is isolated so the widget still updates`() = runTest {
+        var widgetRan = false
+        runSurfaceUpdate(
+            tile = { throw IllegalStateException("tile boom") },
+            widget = { widgetRan = true },
+        )
+        widgetRan shouldBe true
+    }
+
+    @Test
+    fun `an ordinary widget failure propagates so a worker can retry`() = runTest {
+        shouldThrow<IllegalStateException> {
+            runSurfaceUpdate(tile = {}, widget = { throw IllegalStateException("widget boom") })
+        }
+    }
+
+    @Test
+    fun `cancellation from the widget update propagates and is never swallowed`() = runTest {
+        shouldThrow<CancellationException> {
+            runSurfaceUpdate(tile = {}, widget = { throw CancellationException() })
+        }
+    }
+
+    @Test
+    fun `cancellation from the tile update propagates and is never swallowed`() = runTest {
+        shouldThrow<CancellationException> {
+            runSurfaceUpdate(tile = { throw CancellationException() }, widget = {})
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/amply/main/ui/widget/WidgetDisplayTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/widget/WidgetDisplayTest.kt
@@ -1,0 +1,46 @@
+package eu.darken.amply.main.ui.widget
+
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.ChargingState
+import eu.darken.amply.charging.core.PendingRequest
+import eu.darken.amply.charging.core.SETTLING_WINDOW_MILLIS
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class WidgetDisplayTest {
+
+    private val now = 1_000_000L
+    private val target = ChargePolicy.FixedLimit(80)
+
+    @Test
+    fun `a resting policy with no session is steady`() {
+        val display = widgetDisplay(ChargingState(), sessionActive = false, now = now)
+        display.sessionActive shouldBe false
+        display.settling shouldBe false
+        display.steady shouldBe true
+    }
+
+    @Test
+    fun `a pending request inside the settling window is settling, not steady`() {
+        val state = ChargingState(pending = PendingRequest(target, now))
+        val display = widgetDisplay(state, sessionActive = false, now = now + 1_000)
+        display.settling shouldBe true
+        display.steady shouldBe false
+    }
+
+    @Test
+    fun `an active session is never steady, even while a request is settling`() {
+        val state = ChargingState(pending = PendingRequest(target, now))
+        val display = widgetDisplay(state, sessionActive = true, now = now + 1_000)
+        display.sessionActive shouldBe true
+        display.steady shouldBe false
+    }
+
+    @Test
+    fun `an expired pending is no longer settling and the widget is steady again`() {
+        val state = ChargingState(pending = PendingRequest(target, now))
+        val display = widgetDisplay(state, sessionActive = false, now = now + SETTLING_WINDOW_MILLIS)
+        display.settling shouldBe false
+        display.steady shouldBe true
+    }
+}


### PR DESCRIPTION
## What changed

Home-screen widget button taps (∞ protect / ∞100% / charge-once) now update the widget's own text **reliably** on Samsung / Xiaomi / OnePlus devices. Previously the widget frequently **froze** at its old text after a tap even though the charge policy had actually changed — you'd only see the new state after some later, unrelated change. It now repaints within ~1–2 s of every tap.

This is the delivery-side follow-up to the earlier phantom-settling fix (#4): that fix correctly removed a spurious 15 s "waiting" state on Samsung, which had also been *accidentally masking* this pre-existing widget-refresh bug — so it surfaced clearly once #4 landed.

## Technical Context

**Root cause.** `AmplyWidget.provideGlance` read charge state **once** at composition time (`repo.refresh()`, session, prefs) rather than observing it. Per Glance's documented contract, an update does **not** rerun an already-active `provideGlance`, so a non-observing composition silently misses backend changes. On `SYNC_READBACK` adapters a synchronous verified write leaves `pending == null`, so `SettleScheduler` was never scheduled — meaning there was no safety-net re-push at all (unlike Pixel's async path, which self-heals ~16 s later and thus hid the bug there).

**Fix.**
- `provideContent` now collects `repo.state`, `FullChargeStore.session`, and `ChargingPreferences.lastRequested` via `collectAsState`, so Glance recomposes in place when the backend emits. A single pre-composition `repo.refresh()` seeds a cold widget process (no per-size `LaunchedEffect` under `SizeMode.Exact`, no empty-state flash; cancellation propagates).
- `ChargingState` carries the adapter's `defaultProtectivePolicy` so the "∞ protect" label is observable without a suspend adapter lookup at composition time.
- **Safety net:** the settle-worker surface re-push is now scheduled after *every* successful write (incl. `SYNC_READBACK`), isolated so a scheduler failure can't fall into the metadata-failure path and manufacture phantom settling (it fires after the settling window, so the worker recomputes `pending == null`).
- `SurfaceUpdater.updateNow` propagates the widget enqueue failure (so `SettleRefreshWorker` can `retry()`) and rethrows `CancellationException`; the tile update is isolated so it can't block the widget push. The dead fire-and-forget `update()` is removed.
- `ChargeSessionService` no longer fire-and-forgets a surface update before stopping; `continueGestureOrStop` pushes an awaited update on its stop branch, so no terminal branch leaves the surfaces un-pushed.

**Scope note.** `updateNow` awaits Glance *enqueuing* its durable update work, not the eventual `AppWidgetManager` delivery (which Glance performs later in its own worker); process-death safety rests on Glance's durable enqueue. Comments were corrected to reflect this.

**Review guidance.** The pure display derivation (`WidgetDisplay`) and the surface-update error policy (`runSurfaceUpdate`) are extracted and unit-tested. Two rounds of Codex review (architecture + implementation). The Pixel async path and the dashboard (separate `StateFlow` collector) are unchanged.

## Verification

- `./gradlew testFossDebugUnitTest testGplayDebugUnitTest lintVital{Foss,Gplay}{Beta,Release} assemble{Foss,Gplay}Debug` — all green (694 test runs, no lint findings).
- On a Galaxy Tab A9+ (SM-X210, One UI 8.0): **5/5 reliable widget repaints** across rapid alternating ∞100% / ∞80% taps, each backed by a `Verified(DIRECT_WSS)` write; delivery chain confirmed via logcat (tap → service → settings write → `AppWidgetHost.updateAppWidgetView` → `SettleRefreshWorker` SUCCESS).

## Known minor residual (inherent, not addressed)

A tap landing in the brief window right after widget placement — before Glance's first composition installs the wired `PendingIntent`s — can be dropped (the static `initialLayout` can't carry runtime pending intents). The seed-before-composition change shrinks this window; fully closing it would require hand-installing custom `RemoteViews`, which isn't worth the complexity. A retry works immediately.