### PR TITLE
Stats: Add opt-in battery charge statistics (P1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -139,6 +139,13 @@ android {
     }
 }
 
+// Export Room schemas to a committed directory so future schema changes (P2/P3) have a baseline to
+// diff and write tested migrations against. Room v1 has nothing to migrate yet, but the baseline must
+// exist from the first shipped version.
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+}
+
 androidComponents {
     onVariants { variant ->
         val buildType = variant.buildType ?: return@onVariants
@@ -201,6 +208,7 @@ dependencies {
     addCompose()
     addNavigation3()
     addDataStore()
+    addRoom()
     addGlance()
 
     addShizuku()

--- a/app/schemas/eu.darken.amply.stats.core.db.StatsDatabase/1.json
+++ b/app/schemas/eu.darken.amply.stats.core.db.StatsDatabase/1.json
@@ -1,0 +1,298 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "d39f220aefbc6937a7d9e2dde83995f1",
+    "entities": [
+      {
+        "tableName": "charge_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `startedAtWallMillis` INTEGER NOT NULL, `startedElapsedRealtimeMillis` INTEGER NOT NULL, `bootId` INTEGER NOT NULL, `endedAtWallMillis` INTEGER, `endedElapsedRealtimeMillis` INTEGER, `endReason` TEXT, `startPercent` INTEGER, `endPercent` INTEGER, `pluggedRaw` INTEGER, `fullReachedAtWallMillis` INTEGER, `partial` INTEGER NOT NULL, `avgPowerMilliwatts` INTEGER, `avgTemperatureTenthsC` INTEGER, `runningSampleCount` INTEGER NOT NULL, `runningPowerWeightedSum` REAL NOT NULL, `runningPowerWeightedDurationMillis` INTEGER NOT NULL, `runningTemperatureWeightedSum` REAL NOT NULL, `runningTemperatureWeightedDurationMillis` INTEGER NOT NULL, `runningPeakPowerMilliwatts` INTEGER, `runningMinTemperatureTenthsC` INTEGER, `runningMaxTemperatureTenthsC` INTEGER, `runningLastPowerMilliwatts` INTEGER, `runningLastTemperatureTenthsC` INTEGER, `runningLastPercent` INTEGER, `runningLastElapsedRealtimeMillis` INTEGER, `runningLastWallMillis` INTEGER, `limitHitEvidence` INTEGER NOT NULL, `overrideSeen` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAtWallMillis",
+            "columnName": "startedAtWallMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedElapsedRealtimeMillis",
+            "columnName": "startedElapsedRealtimeMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bootId",
+            "columnName": "bootId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endedAtWallMillis",
+            "columnName": "endedAtWallMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "endedElapsedRealtimeMillis",
+            "columnName": "endedElapsedRealtimeMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "endReason",
+            "columnName": "endReason",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "startPercent",
+            "columnName": "startPercent",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "endPercent",
+            "columnName": "endPercent",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pluggedRaw",
+            "columnName": "pluggedRaw",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fullReachedAtWallMillis",
+            "columnName": "fullReachedAtWallMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "partial",
+            "columnName": "partial",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avgPowerMilliwatts",
+            "columnName": "avgPowerMilliwatts",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "avgTemperatureTenthsC",
+            "columnName": "avgTemperatureTenthsC",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningSampleCount",
+            "columnName": "runningSampleCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningPowerWeightedSum",
+            "columnName": "runningPowerWeightedSum",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningPowerWeightedDurationMillis",
+            "columnName": "runningPowerWeightedDurationMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningTemperatureWeightedSum",
+            "columnName": "runningTemperatureWeightedSum",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningTemperatureWeightedDurationMillis",
+            "columnName": "runningTemperatureWeightedDurationMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runningPeakPowerMilliwatts",
+            "columnName": "runningPeakPowerMilliwatts",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningMinTemperatureTenthsC",
+            "columnName": "runningMinTemperatureTenthsC",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningMaxTemperatureTenthsC",
+            "columnName": "runningMaxTemperatureTenthsC",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningLastPowerMilliwatts",
+            "columnName": "runningLastPowerMilliwatts",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningLastTemperatureTenthsC",
+            "columnName": "runningLastTemperatureTenthsC",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningLastPercent",
+            "columnName": "runningLastPercent",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningLastElapsedRealtimeMillis",
+            "columnName": "runningLastElapsedRealtimeMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "runningLastWallMillis",
+            "columnName": "runningLastWallMillis",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "limitHitEvidence",
+            "columnName": "limitHitEvidence",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "overrideSeen",
+            "columnName": "overrideSeen",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "battery_samples",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `wallMillis` INTEGER NOT NULL, `elapsedRealtimeMillis` INTEGER NOT NULL, `bootId` INTEGER NOT NULL, `percent` INTEGER, `batteryStatus` INTEGER, `chargingStatus` INTEGER, `pluggedRaw` INTEGER, `temperatureTenthsC` INTEGER, `voltageMillivolts` INTEGER, `currentNowMicroamps` INTEGER, `powerMilliwatts` INTEGER, FOREIGN KEY(`sessionId`) REFERENCES `charge_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "wallMillis",
+            "columnName": "wallMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedRealtimeMillis",
+            "columnName": "elapsedRealtimeMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bootId",
+            "columnName": "bootId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percent",
+            "columnName": "percent",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "batteryStatus",
+            "columnName": "batteryStatus",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "chargingStatus",
+            "columnName": "chargingStatus",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pluggedRaw",
+            "columnName": "pluggedRaw",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "temperatureTenthsC",
+            "columnName": "temperatureTenthsC",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "voltageMillivolts",
+            "columnName": "voltageMillivolts",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "currentNowMicroamps",
+            "columnName": "currentNowMicroamps",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "powerMilliwatts",
+            "columnName": "powerMilliwatts",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_battery_samples_sessionId_elapsedRealtimeMillis",
+            "unique": false,
+            "columnNames": [
+              "sessionId",
+              "elapsedRealtimeMillis"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_battery_samples_sessionId_elapsedRealtimeMillis` ON `${TABLE_NAME}` (`sessionId`, `elapsedRealtimeMillis`)"
+          },
+          {
+            "name": "index_battery_samples_wallMillis",
+            "unique": false,
+            "columnNames": [
+              "wallMillis"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_battery_samples_wallMillis` ON `${TABLE_NAME}` (`wallMillis`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "charge_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd39f220aefbc6937a7d9e2dde83995f1')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,7 +69,7 @@
             android:foregroundServiceType="specialUse">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-                android:value="User-enabled charging monitor that restores temporary policy overrides, detects a deliberate unplug/replug gesture while a charge-protection policy is active, and alerts the user to unplug when the battery reaches a user-set charge level" />
+                android:value="User-enabled charging monitor that restores temporary policy overrides, detects a deliberate unplug/replug gesture while a charge-protection policy is active, alerts the user to unplug when the battery reaches a user-set charge level, and, when the user turns on battery statistics, records local charge-session measurements while running" />
         </service>
 
         <service

--- a/app/src/main/java/eu/darken/amply/battery/core/BatteryReader.kt
+++ b/app/src/main/java/eu/darken/amply/battery/core/BatteryReader.kt
@@ -20,17 +20,29 @@ import javax.inject.Inject
 class BatteryReader @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
+    /** Reads its own sticky [Intent.ACTION_BATTERY_CHANGED] broadcast (for callers without one). */
     fun read(): BatteryReadout {
         val battery = runCatching {
             context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
         }.getOrNull() ?: return BatteryReadout.UNKNOWN
+        return read(battery)
+    }
 
+    /**
+     * Build a readout from an already-resolved [Intent.ACTION_BATTERY_CHANGED] intent (the one the
+     * charge-session service just evaluated), so plug state / percent / voltage / temperature all
+     * come from a single observation and can't be joined across two different sticky reads during a
+     * rapid unplug/replug. Non-null and never falls back to a second sticky read — a caller with no
+     * intent must use [BatteryReadout.UNKNOWN] rather than passing null.
+     */
+    fun read(battery: Intent): BatteryReadout {
         val manager = context.getSystemService(BatteryManager::class.java)
 
         return BatteryReadoutFactory.build(
             level = battery.getIntExtra(BatteryManager.EXTRA_LEVEL, ABSENT),
             scale = battery.getIntExtra(BatteryManager.EXTRA_SCALE, ABSENT),
             status = battery.getIntExtra(BatteryManager.EXTRA_STATUS, ABSENT),
+            chargingStatus = battery.getIntExtra(BatteryManager.EXTRA_CHARGING_STATUS, ABSENT),
             plugged = battery.getIntExtra(BatteryManager.EXTRA_PLUGGED, ABSENT),
             health = battery.getIntExtra(BatteryManager.EXTRA_HEALTH, ABSENT),
             technology = battery.getStringExtra(BatteryManager.EXTRA_TECHNOLOGY),

--- a/app/src/main/java/eu/darken/amply/battery/core/BatteryReadout.kt
+++ b/app/src/main/java/eu/darken/amply/battery/core/BatteryReadout.kt
@@ -13,6 +13,8 @@ package eu.darken.amply.battery.core
 data class BatteryReadout(
     val levelPercent: Int? = null,
     val status: Int? = null,
+    /** Raw [android.os.BatteryManager.EXTRA_CHARGING_STATUS] (hidden Pixel charge-policy state). */
+    val chargingStatus: Int? = null,
     val plugged: Int? = null,
     val health: Int? = null,
     val technology: String? = null,

--- a/app/src/main/java/eu/darken/amply/battery/core/BatteryReadoutFactory.kt
+++ b/app/src/main/java/eu/darken/amply/battery/core/BatteryReadoutFactory.kt
@@ -20,6 +20,7 @@ object BatteryReadoutFactory {
         level: Int = ABSENT,
         scale: Int = ABSENT,
         status: Int = ABSENT,
+        chargingStatus: Int = ABSENT,
         plugged: Int = ABSENT,
         health: Int = ABSENT,
         technology: String? = null,
@@ -31,6 +32,7 @@ object BatteryReadoutFactory {
     ): BatteryReadout = BatteryReadout(
         levelPercent = percentOf(level, scale),
         status = status.orNull(),
+        chargingStatus = chargingStatus.orNull(),
         plugged = plugged.orNull(),
         health = health.orNull(),
         technology = technology?.trim()?.ifEmpty { null },

--- a/app/src/main/java/eu/darken/amply/common/compose/chart/LineChart.kt
+++ b/app/src/main/java/eu/darken/amply/common/compose/chart/LineChart.kt
@@ -1,0 +1,156 @@
+package eu.darken.amply.common.compose.chart
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.background
+
+/** One point of a [ChartSeries]. A null [y] marks a gap so the line is broken rather than interpolated. */
+data class ChartPoint(val x: Float, val y: Float?)
+
+/** A single labelled line, auto-scaled to its own value range (series use different units). */
+data class ChartSeries(
+    val label: String,
+    val color: Color,
+    val points: List<ChartPoint>,
+)
+
+/**
+ * Minimal, dependency-free line chart drawn on a Compose [Canvas]. Each series is normalized to its
+ * own min/max (percent, power, and temperature share no unit), so the chart shows curve *shape*, not
+ * absolute comparison — the numeric summary alongside it carries the real values. Handles the awkward
+ * cases explicitly: empty input renders a placeholder, a single point renders a dot, a zero-range
+ * series renders a centered flat line, and null points break the stroke.
+ */
+@Composable
+fun LineChart(
+    series: List<ChartSeries>,
+    modifier: Modifier = Modifier,
+    emptyLabel: String,
+) {
+    val drawable = series.filter { s -> s.points.any { it.y != null } }
+    if (drawable.isEmpty()) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(180.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                emptyLabel,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        return
+    }
+
+    val globalXRange = xRange(drawable)
+    val gridColor = MaterialTheme.colorScheme.outlineVariant
+
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(180.dp)
+            .padding(vertical = 8.dp),
+    ) {
+        drawBaseline(gridColor)
+        drawable.forEach { s -> drawSeries(s, globalXRange) }
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        drawable.forEach { s ->
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    Modifier
+                        .size(10.dp)
+                        .clip(CircleShape)
+                        .background(s.color),
+                )
+                Text(
+                    s.label,
+                    modifier = Modifier.padding(start = 6.dp),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+private fun xRange(series: List<ChartSeries>): ClosedFloatingPointRange<Float> {
+    val xs = series.flatMap { s -> s.points.filter { it.y != null }.map { it.x } }
+    val min = xs.min()
+    val max = xs.max()
+    return if (min == max) min..(min + 1f) else min..max
+}
+
+private fun DrawScope.drawBaseline(color: Color) {
+    drawLine(
+        color = color,
+        start = Offset(0f, size.height),
+        end = Offset(size.width, size.height),
+        strokeWidth = 1f,
+    )
+}
+
+private fun DrawScope.drawSeries(series: ChartSeries, xRange: ClosedFloatingPointRange<Float>) {
+    val ys = series.points.mapNotNull { it.y }
+    if (ys.isEmpty()) return
+    val yMin = ys.min()
+    val yMax = ys.max()
+    val ySpan = (yMax - yMin).takeIf { it > 0f }
+    val xSpan = (xRange.endInclusive - xRange.start).takeIf { it > 0f } ?: 1f
+
+    fun px(x: Float) = ((x - xRange.start) / xSpan) * size.width
+    // Higher value → higher on screen; a zero-range series sits centered.
+    fun py(y: Float) = if (ySpan == null) size.height / 2f else size.height * (1f - (y - yMin) / ySpan)
+
+    val drawn = series.points.filter { it.y != null }
+    if (drawn.size == 1) {
+        val p = drawn.first()
+        drawCircle(series.color, radius = 4f, center = Offset(px(p.x), py(p.y!!)))
+        return
+    }
+
+    // Break the path across null gaps rather than interpolating over missing data.
+    var path: Path? = null
+    for (point in series.points) {
+        val y = point.y
+        if (y == null) {
+            path?.let { drawPath(it, series.color, style = Stroke(width = 4f)) }
+            path = null
+            continue
+        }
+        val offset = Offset(px(point.x), py(y))
+        if (path == null) {
+            path = Path().apply { moveTo(offset.x, offset.y) }
+        } else {
+            path.lineTo(offset.x, offset.y)
+        }
+    }
+    path?.let { drawPath(it, series.color, style = Stroke(width = 4f)) }
+}

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -228,13 +228,26 @@ class ChargeSessionService : Service() {
      * by [WATCHER_TICK_BUDGET_MILLIS] and fully isolated: a hung or throwing watcher can neither
      * strand this evaluation nor, since restore already ran before this point, delay policy recovery.
      */
-    private suspend fun dispatchWatchers(plugged: Boolean, percent: Int, status: Int, sessionOwned: Boolean) {
+    private suspend fun dispatchWatchers(
+        plugged: Boolean,
+        percent: Int,
+        status: Int,
+        sessionOwned: Boolean,
+        battery: Intent?,
+        observedAtElapsed: Long,
+    ) {
         if (watchers.isEmpty()) return
+        // Pass the exact evaluated intent through; watchers parse it and read live properties off the
+        // evaluation thread. Building the readout here would put Binder calls under commandMutex and
+        // could delay a queued restore.
         val tick = ChargeMonitorTick(
             plugged = plugged,
             percent = percent,
             batteryStatus = status,
             sessionActive = sessionOwned,
+            batteryIntent = battery,
+            observedElapsedRealtimeMillis = observedAtElapsed,
+            wallClockMillis = System.currentTimeMillis(),
         )
         watchers.forEach { watcher ->
             try {
@@ -311,12 +324,12 @@ class ChargeSessionService : Service() {
                 )
             }
             // Non-restore session tick: let watchers observe it (the alarm claims the cycle here).
-            dispatchWatchers(plugged, percent, status, sessionOwned = true)
+            dispatchWatchers(plugged, percent, status, sessionOwned = true, battery, observedAtElapsed)
             return
         }
 
         if (!fullChargeStore.isQuickFullChargeEnabled() || !reconnectGestureAvailable()) {
-            dispatchWatchers(plugged, percent, status, sessionOwned = false)
+            dispatchWatchers(plugged, percent, status, sessionOwned = false, battery, observedAtElapsed)
             // Gesture inactive: keep running only if a watcher still wants the service, showing the
             // quiet monitoring notification instead of the gesture cue.
             if (anyWatcherEnabled()) {
@@ -355,7 +368,14 @@ class ChargeSessionService : Service() {
         }
         // A triggering tick is a deliberate full charge about to begin, so the alarm must treat it
         // as session-owned and NOT fire "unplug now" on the very reconnect that started the charge.
-        dispatchWatchers(plugged, percent, status, sessionOwned = decision == QuickFullChargeDecision.TRIGGER)
+        dispatchWatchers(
+            plugged,
+            percent,
+            status,
+            sessionOwned = decision == QuickFullChargeDecision.TRIGGER,
+            battery,
+            observedAtElapsed,
+        )
         if (decision == QuickFullChargeDecision.TRIGGER) {
             gestureExpiryJob?.cancel()
             log(TAG) { "Reconnect gesture triggered one-time full charging" }

--- a/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
@@ -60,12 +60,16 @@ import eu.darken.amply.main.ui.settings.SettingsDestination
 import eu.darken.amply.main.ui.settings.SettingsScreen
 import eu.darken.amply.main.ui.settings.SettingsViewModel
 import eu.darken.amply.main.ui.settings.SupportScreen
+import eu.darken.amply.stats.ui.StatsScreen
+import eu.darken.amply.stats.ui.StatsSessionDetailScreen
+import eu.darken.amply.stats.ui.StatsViewModel
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val viewModel: DashboardViewModel by viewModels()
     private val settingsViewModel: SettingsViewModel by viewModels()
     private val contributionViewModel: ContributionWizardViewModel by viewModels()
+    private val statsViewModel: StatsViewModel by viewModels()
 
     // Compose-observable so a widget launch that reuses an already-running activity (SINGLE_TOP →
     // onNewIntent, which does not re-run LaunchedEffect(Unit)) still triggers the permission flow.
@@ -99,6 +103,8 @@ class MainActivity : ComponentActivity() {
                     val state by viewModel.state.collectAsState()
                     val debugState by settingsViewModel.debugState.collectAsState()
                     val contributionState by contributionViewModel.state.collectAsState()
+                    val statsState by statsViewModel.state.collectAsState()
+                    val statsDetail by statsViewModel.detailState.collectAsState()
                     var destination by rememberSaveable { mutableStateOf(SettingsDestination.DASHBOARD) }
                     // Where a back-out of the contribution wizard returns to (set on each entry).
                     var wizardOrigin by rememberSaveable { mutableStateOf(SettingsDestination.DASHBOARD) }
@@ -119,6 +125,7 @@ class MainActivity : ComponentActivity() {
                             NotificationAction.START_FULL_CHARGE -> viewModel.startFullCharge()
                             NotificationAction.ENABLE_QUICK_GESTURE -> viewModel.setQuickFullChargeEnabled(true)
                             NotificationAction.ENABLE_CHARGE_ALARM -> viewModel.setChargeAlarmEnabled(true)
+                            NotificationAction.ENABLE_STATS -> statsViewModel.setCaptureEnabled(true)
                             null -> Unit
                         }
                     }
@@ -141,6 +148,7 @@ class MainActivity : ComponentActivity() {
                             NotificationAction.START_FULL_CHARGE -> viewModel.startFullCharge()
                             NotificationAction.ENABLE_QUICK_GESTURE -> viewModel.setQuickFullChargeEnabled(true)
                             NotificationAction.ENABLE_CHARGE_ALARM -> viewModel.setChargeAlarmEnabled(true)
+                            NotificationAction.ENABLE_STATS -> statsViewModel.setCaptureEnabled(true)
                         }
                     }
                 }
@@ -199,6 +207,11 @@ class MainActivity : ComponentActivity() {
                             SettingsDestination.SETTINGS,
                             SettingsDestination.RECONNECT_GESTURE,
                             SettingsDestination.BATTERY_DETAIL -> destination = SettingsDestination.DASHBOARD
+                            // The session detail returns to the stats list; the list returns to settings.
+                            SettingsDestination.STATS_SESSION_DETAIL -> {
+                                statsViewModel.closeSession()
+                                destination = SettingsDestination.STATS
+                            }
                             else -> destination = SettingsDestination.SETTINGS
                         }
                     }
@@ -256,6 +269,7 @@ class MainActivity : ComponentActivity() {
                         SettingsDestination.SETTINGS -> SettingsScreen(
                             onBack = { destination = SettingsDestination.DASHBOARD },
                             onGeneral = { destination = SettingsDestination.GENERAL },
+                            onStats = { destination = SettingsDestination.STATS },
                             // Offered whenever this device is one we want contribution data for (unsupported/lab),
                             // regardless of whether Shizuku is installed yet — the wizard nudges the install.
                             showDiagnostics = state.charging.contributionWanted,
@@ -323,6 +337,29 @@ class MainActivity : ComponentActivity() {
                             readout = state.batteryReadout,
                             onBack = { destination = SettingsDestination.DASHBOARD },
                         )
+                        SettingsDestination.STATS -> StatsScreen(
+                            state = statsState,
+                            onBack = { destination = SettingsDestination.SETTINGS },
+                            onCaptureEnabledChange = { enabled ->
+                                if (enabled) {
+                                    runWithNotifications(NotificationAction.ENABLE_STATS)
+                                } else {
+                                    statsViewModel.setCaptureEnabled(false)
+                                }
+                            },
+                            onOpenSession = { id ->
+                                statsViewModel.openSession(id)
+                                destination = SettingsDestination.STATS_SESSION_DETAIL
+                            },
+                            onClearData = statsViewModel::clearData,
+                        )
+                        SettingsDestination.STATS_SESSION_DETAIL -> StatsSessionDetailScreen(
+                            state = statsDetail,
+                            onBack = {
+                                statsViewModel.closeSession()
+                                destination = SettingsDestination.STATS
+                            },
+                        )
                     }
                 }
                 }
@@ -383,6 +420,7 @@ class MainActivity : ComponentActivity() {
         START_FULL_CHARGE,
         ENABLE_QUICK_GESTURE,
         ENABLE_CHARGE_ALARM,
+        ENABLE_STATS,
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsDestination.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsDestination.kt
@@ -9,4 +9,6 @@ enum class SettingsDestination {
     ACKNOWLEDGEMENTS,
     RECONNECT_GESTURE,
     BATTERY_DETAIL,
+    STATS,
+    STATS_SESSION_DETAIL,
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.twotone.Book
 import androidx.compose.material.icons.twotone.BugReport
 import androidx.compose.material.icons.twotone.Favorite
 import androidx.compose.material.icons.twotone.History
+import androidx.compose.material.icons.automirrored.twotone.ShowChart
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material.icons.twotone.SupportAgent
 import androidx.compose.material3.Icon
@@ -33,6 +34,7 @@ import eu.darken.amply.common.settings.SettingsNavigationItem
 fun SettingsScreen(
     onBack: () -> Unit,
     onGeneral: () -> Unit,
+    onStats: () -> Unit,
     showDiagnostics: Boolean,
     diagnosticsReady: Boolean,
     onDiagnostics: () -> Unit,
@@ -72,6 +74,15 @@ fun SettingsScreen(
                     subtitle = stringResource(R.string.settings_general_subtitle),
                     icon = Icons.TwoTone.Settings,
                     onClick = onGeneral,
+                )
+            }
+            item { SettingsDivider() }
+            item {
+                SettingsNavigationItem(
+                    title = stringResource(R.string.settings_stats_title),
+                    subtitle = stringResource(R.string.settings_stats_subtitle),
+                    icon = Icons.AutoMirrored.TwoTone.ShowChart,
+                    onClick = onStats,
                 )
             }
             item { SettingsDivider() }
@@ -148,6 +159,7 @@ private fun SettingsScreenPreview() = PreviewWrapper {
     SettingsScreen(
         onBack = {},
         onGeneral = {},
+        onStats = {},
         showDiagnostics = true,
         diagnosticsReady = true,
         onDiagnostics = {},

--- a/app/src/main/java/eu/darken/amply/monitor/core/ChargeMonitorWatcher.kt
+++ b/app/src/main/java/eu/darken/amply/monitor/core/ChargeMonitorWatcher.kt
@@ -1,9 +1,19 @@
 package eu.darken.amply.monitor.core
 
+import android.content.Intent
+
 /**
  * A single sample of public battery state, handed to every [ChargeMonitorWatcher] on each
- * evaluation tick of the charge-session foreground service. All fields come from the sticky
- * [android.content.Intent.ACTION_BATTERY_CHANGED] broadcast and need no permission.
+ * evaluation tick of the charge-session foreground service. All fields derive from the sticky
+ * [Intent.ACTION_BATTERY_CHANGED] broadcast and need no permission.
+ *
+ * [plugged]/[percent]/[batteryStatus] are the minimal fields simple watchers use. Richer consumers
+ * (statistics) get the exact [batteryIntent] this evaluation used — so they can read voltage /
+ * current / temperature / charging-status off the *same* observation rather than a second sticky
+ * read — plus [observedElapsedRealtimeMillis] (boot-scoped, for durations/ordering) and
+ * [wallClockMillis] (display). To keep the safety-critical evaluation cheap, watchers must not do
+ * blocking work here: parse [batteryIntent] and read live properties off the evaluation thread. The
+ * rich fields default to empty so a watcher or test needing only the basics can omit them.
  */
 data class ChargeMonitorTick(
     val plugged: Boolean,
@@ -13,6 +23,12 @@ data class ChargeMonitorTick(
     val batteryStatus: Int,
     /** Whether a temporary full-charge session is currently active. */
     val sessionActive: Boolean,
+    /** The exact battery intent this evaluation used, or null when none was available. */
+    val batteryIntent: Intent? = null,
+    /** [android.os.SystemClock.elapsedRealtime] when this state was observed. */
+    val observedElapsedRealtimeMillis: Long = 0,
+    /** Wall-clock time of observation, for display/persistence only. */
+    val wallClockMillis: Long = 0,
 )
 
 /**

--- a/app/src/main/java/eu/darken/amply/stats/core/BootIdSource.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/BootIdSource.kt
@@ -1,0 +1,31 @@
+package eu.darken.amply.stats.core
+
+import android.content.Context
+import android.provider.Settings
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Reads the device boot count, used to tell a same-boot process restart (resume the open session)
+ * from a reboot (seal it — elapsed-time continuity can't survive a power-off). The value can only
+ * change across a reboot, which restarts this process, so it is read once and cached. A device that
+ * doesn't report [Settings.Global.BOOT_COUNT] yields a constant sentinel; reboots then look like
+ * same-boot restarts, which degrades to a partial/interrupted seal rather than anything unsafe.
+ */
+@Singleton
+class BootIdSource @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val cached: Long by lazy { read() }
+
+    fun current(): Long = cached
+
+    private fun read(): Long = runCatching {
+        Settings.Global.getInt(context.contentResolver, Settings.Global.BOOT_COUNT, UNAVAILABLE).toLong()
+    }.getOrDefault(UNAVAILABLE.toLong())
+
+    private companion object {
+        const val UNAVAILABLE = -1
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRecorder.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRecorder.kt
@@ -1,0 +1,295 @@
+package eu.darken.amply.stats.core
+
+import android.os.BatteryManager
+import androidx.room.withTransaction
+import dagger.Lazy
+import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.battery.core.BatteryReader
+import eu.darken.amply.common.debug.logging.Logging
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import eu.darken.amply.stats.core.db.BatterySampleEntity
+import eu.darken.amply.stats.core.db.ChargeSessionEntity
+import eu.darken.amply.stats.core.db.StatsDatabase
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Serialized, off-service-thread writer for battery statistics. The watcher hands raw ticks in via
+ * [offer], which only enqueues (never blocks, never touches Room/Binder/DataStore), so all
+ * enrichment (parsing the intent, reading live battery properties, boot id) and all database work
+ * happen on this recorder's own IO coroutine — entirely off the charge-session service's
+ * `commandMutex`. That is what guarantees a slow read/write here can never delay the safety-critical
+ * charge-policy restore. The command channel is FIFO and unbounded, so plug transitions are never
+ * dropped and enable/disable/clear are strictly ordered against samples.
+ *
+ * Capture on/off is an in-memory [capturing] flag driven by ordered [Command.SetEnabled] commands
+ * (not a per-sample DataStore read), so an unplug sample enqueued just before a disable is sealed
+ * with the correct endpoint before capture stops. The [StatsDatabase] is injected lazily so a
+ * corrupt/locked stats DB can't fail construction of the safety-service graph.
+ */
+@Singleton
+class ChargeStatsRecorder @Inject constructor(
+    private val database: Lazy<StatsDatabase>,
+    private val preferences: StatsPreferences,
+    private val bootIdSource: BootIdSource,
+    private val batteryReader: BatteryReader,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val commands = Channel<Command>(Channel.UNLIMITED)
+
+    // Mutated only by the single consumer coroutine below — no locking needed.
+    private var capturing = false
+    private var openSession: ChargeSessionEntity? = null
+    private var previousPlugged: Boolean? = null
+    private var lastRecordedElapsed: Long? = null
+    private var lastRecordedPercent: Int? = null
+
+    init {
+        scope.launch {
+            // Runs before any command: seals sessions left open by an unclean shutdown, and seeds the
+            // capturing flag from the durable preference.
+            startupRepair()
+            for (command in commands) {
+                try {
+                    when (command) {
+                        is Command.Record -> onSample(command.tick)
+                        is Command.SetEnabled -> onSetEnabled(command.enabled)
+                        Command.Clear -> onClear()
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, Logging.Priority.WARN) { "Stats command ${command::class.simpleName} failed: ${e.message}" }
+                }
+            }
+        }
+    }
+
+    /** Enqueue a raw tick. Returns immediately; the caller (a monitor watcher) never awaits I/O. */
+    fun offer(tick: RawStatsTick) {
+        commands.trySend(Command.Record(tick))
+    }
+
+    /** Ordered enable/disable. Disabling seals any open session before capture stops. */
+    fun setEnabled(enabled: Boolean) {
+        commands.trySend(Command.SetEnabled(enabled))
+    }
+
+    /** Wipe all statistics. If capture is still enabled, the next sample opens a fresh session. */
+    fun clear() {
+        commands.trySend(Command.Clear)
+    }
+
+    private suspend fun startupRepair() {
+        try {
+            capturing = preferences.isCaptureEnabledNow()
+            // Only touch the DB when we might have data — avoids creating an empty stats.db for users
+            // who never enabled statistics. A dangling open row can only exist after prior recording,
+            // which always stamps lastCapture.
+            if (preferences.lastCaptureWallMillis.first() == null) return
+            sealDanglingSessions()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, Logging.Priority.WARN) { "Stats startup repair failed: ${e.message}" }
+        }
+    }
+
+    private suspend fun onSample(tick: RawStatsTick) {
+        if (!capturing) return
+        val sample = buildSample(tick)
+        val recordDue = StatsCadence.shouldRecord(
+            lastRecordedElapsedMillis = lastRecordedElapsed,
+            nowElapsedMillis = sample.elapsedRealtimeMillis,
+            lastRecordedPercent = lastRecordedPercent,
+            currentPercent = sample.percent,
+        )
+        when (val transition = StatsSessionEngine.decide(openSession != null, previousPlugged, sample.plugged, recordDue)) {
+            is StatsTransition.Open -> openNewSession(sample, transition.partial)
+            is StatsTransition.Append -> if (transition.record) appendSample(sample)
+            is StatsTransition.Seal -> sealCurrent(
+                reason = transition.reason,
+                endWallMillis = sample.wallMillis,
+                endElapsedMillis = sample.elapsedRealtimeMillis,
+                endPercent = sample.percent,
+            )
+            StatsTransition.Ignore -> Unit
+        }
+        previousPlugged = sample.plugged
+    }
+
+    private fun buildSample(tick: RawStatsTick): StatsSample {
+        val readout = tick.batteryIntent?.let { batteryReader.read(it) } ?: BatteryReadout.UNKNOWN
+        val percent = tick.percent.takeIf { it >= 0 } ?: readout.levelPercent
+        val full = tick.batteryStatus == BatteryManager.BATTERY_STATUS_FULL ||
+            (percent != null && percent >= 100)
+        return StatsSample(
+            elapsedRealtimeMillis = tick.observedElapsedRealtimeMillis,
+            wallMillis = tick.wallMillis,
+            bootId = bootIdSource.current(),
+            plugged = tick.plugged,
+            pluggedRaw = readout.plugged,
+            percent = percent,
+            batteryStatus = tick.batteryStatus,
+            chargingStatus = readout.chargingStatus,
+            temperatureTenthsC = readout.temperatureTenthsC,
+            voltageMillivolts = readout.voltageMillivolts,
+            currentNowMicroamps = readout.currentNowMicroamps,
+            powerMilliwatts = StatsPowerCalculator.milliwatts(readout.voltageMillivolts, readout.currentNowMicroamps),
+            full = full,
+            overrideActive = tick.sessionActive,
+            limitHeldNow = StatsLimitHitDetector.heldNow(
+                plugged = tick.plugged,
+                chargingStatus = readout.chargingStatus,
+                batteryStatus = tick.batteryStatus,
+                percent = percent,
+            ),
+        )
+    }
+
+    private suspend fun openNewSession(sample: StatsSample, partial: Boolean) {
+        val entity = StatsSessionEngine.open(sample, partial)
+        val db = database.get()
+        val id = db.withTransaction {
+            val newId = db.statsDao().insertSession(entity)
+            db.statsDao().insertSample(sample.toEntity(newId))
+            newId
+        }
+        openSession = entity.copy(id = id)
+        markRecorded(sample)
+    }
+
+    private suspend fun appendSample(sample: StatsSample) {
+        val current = openSession ?: return
+        val folded = StatsSessionEngine.fold(current, sample)
+        val db = database.get()
+        db.withTransaction {
+            db.statsDao().updateSession(folded)
+            db.statsDao().insertSample(sample.toEntity(folded.id))
+        }
+        openSession = folded
+        markRecorded(sample)
+    }
+
+    private suspend fun sealCurrent(
+        reason: StatsSealReason,
+        endWallMillis: Long,
+        endElapsedMillis: Long,
+        endPercent: Int?,
+    ) {
+        val current = openSession ?: return
+        val sealed = StatsSessionEngine.seal(current, reason, endWallMillis, endElapsedMillis, endPercent)
+        database.get().statsDao().updateSession(sealed)
+        openSession = null
+        lastRecordedElapsed = null
+        lastRecordedPercent = null
+        purgeOldSamples(endWallMillis)
+    }
+
+    private suspend fun onSetEnabled(enabled: Boolean) {
+        capturing = enabled
+        if (!enabled) {
+            openSession?.let { current ->
+                sealCurrent(
+                    reason = StatsSealReason.DISABLED,
+                    endWallMillis = current.runningLastWallMillis ?: current.startedAtWallMillis,
+                    endElapsedMillis = current.runningLastElapsedRealtimeMillis ?: current.startedElapsedRealtimeMillis,
+                    endPercent = current.runningLastPercent,
+                )
+            }
+            resetInMemory()
+        }
+    }
+
+    private suspend fun onClear() {
+        val db = database.get()
+        db.withTransaction {
+            db.statsDao().deleteAllSamples()
+            db.statsDao().deleteAllSessions()
+        }
+        // Reset in-memory state immediately after the durable delete, before the cosmetic pref write,
+        // so a failing pref edit can't strand a reference to a now-deleted parent row.
+        resetInMemory()
+        runCatching { preferences.clearLastCapture() }
+    }
+
+    /**
+     * Seal every session left open by an unclean shutdown (process kill / reboot). Never resumes:
+     * losing the monitor mid-charge breaks curve/elapsed continuity, so the session is closed
+     * honestly and the next plug opens a fresh one. This also sidesteps having to trust the boot
+     * count — a resumed session would risk a negative post-reboot duration.
+     */
+    private suspend fun sealDanglingSessions() {
+        val dao = database.get().statsDao()
+        val open = dao.openSessions()
+        if (open.isEmpty()) return
+        val currentBoot = bootIdSource.current()
+        open.forEach { dao.updateSession(sealFromLastKnown(it, currentBoot)) }
+        open.maxOfOrNull { it.runningLastWallMillis ?: it.startedAtWallMillis }?.let { purgeOldSamples(it) }
+    }
+
+    private fun sealFromLastKnown(row: ChargeSessionEntity, currentBoot: Long): ChargeSessionEntity {
+        val reason = if (row.bootId != currentBoot) StatsSealReason.REBOOT else StatsSealReason.INTERRUPTED
+        return StatsSessionEngine.seal(
+            session = row,
+            reason = reason,
+            endWallMillis = row.runningLastWallMillis ?: row.startedAtWallMillis,
+            endElapsedMillis = row.runningLastElapsedRealtimeMillis ?: row.startedElapsedRealtimeMillis,
+            endPercent = row.runningLastPercent,
+        )
+    }
+
+    /** Bound the raw-sample table: drop closed-session samples older than the retention window. */
+    private suspend fun purgeOldSamples(nowWallMillis: Long) {
+        val cutoff = nowWallMillis - RAW_SAMPLE_RETENTION_MILLIS
+        runCatching { database.get().statsDao().deleteSamplesOlderThan(cutoff) }
+            .onFailure { log(TAG, Logging.Priority.WARN) { "Stats retention purge failed: ${it.message}" } }
+    }
+
+    private suspend fun markRecorded(sample: StatsSample) {
+        lastRecordedElapsed = sample.elapsedRealtimeMillis
+        lastRecordedPercent = sample.percent
+        preferences.setLastCaptureWallMillis(sample.wallMillis)
+    }
+
+    private fun resetInMemory() {
+        openSession = null
+        previousPlugged = null
+        lastRecordedElapsed = null
+        lastRecordedPercent = null
+    }
+
+    private fun StatsSample.toEntity(sessionId: Long) = BatterySampleEntity(
+        sessionId = sessionId,
+        wallMillis = wallMillis,
+        elapsedRealtimeMillis = elapsedRealtimeMillis,
+        bootId = bootId,
+        percent = percent,
+        batteryStatus = batteryStatus,
+        chargingStatus = chargingStatus,
+        pluggedRaw = pluggedRaw,
+        temperatureTenthsC = temperatureTenthsC,
+        voltageMillivolts = voltageMillivolts,
+        currentNowMicroamps = currentNowMicroamps,
+        powerMilliwatts = powerMilliwatts,
+    )
+
+    private sealed interface Command {
+        data class Record(val tick: RawStatsTick) : Command
+        data class SetEnabled(val enabled: Boolean) : Command
+        data object Clear : Command
+    }
+
+    private companion object {
+        val TAG = logTag("Stats", "Recorder")
+        const val RAW_SAMPLE_RETENTION_MILLIS = 30L * 24 * 60 * 60 * 1000 // 30 days
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
@@ -1,0 +1,68 @@
+package eu.darken.amply.stats.core
+
+import dagger.Lazy
+import eu.darken.amply.stats.core.db.ChargeSessionEntity
+import eu.darken.amply.stats.core.db.StatsDatabase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Read-side facade over the stats Room store. Exposes domain models only ([ChargeSessionSummary],
+ * [ChargeCurvePoint]) so the UI never imports Room types, and injects the database lazily like the
+ * recorder does. Write ownership stays entirely with [ChargeStatsRecorder]; the only writes here are
+ * the explicit user "clear data" action, which is routed through the recorder to stay serialized.
+ */
+@Singleton
+class ChargeStatsRepository @Inject constructor(
+    private val database: Lazy<StatsDatabase>,
+    private val recorder: ChargeStatsRecorder,
+) {
+    fun recentSessions(limit: Int = DEFAULT_SESSION_LIMIT): Flow<List<ChargeSessionSummary>> =
+        database.get().statsDao().finishedSessions(limit).map { rows -> rows.map(::toSummary) }
+
+    fun session(id: Long): Flow<ChargeSessionSummary?> =
+        database.get().statsDao().sessionFlow(id).map { it?.let(::toSummary) }
+
+    suspend fun curve(id: Long, maxPoints: Int = DEFAULT_CURVE_POINTS): List<ChargeCurvePoint> {
+        val samples = database.get().statsDao().samplesForSessionNow(id)
+        val start = samples.firstOrNull()?.elapsedRealtimeMillis ?: 0L
+        val points = samples.map { sample ->
+            ChargeCurvePoint(
+                elapsedFromStartMillis = sample.elapsedRealtimeMillis - start,
+                percent = sample.percent,
+                powerMilliwatts = sample.powerMilliwatts,
+                temperatureTenthsC = sample.temperatureTenthsC,
+            )
+        }
+        return StatsDownsampler.decimate(points, maxPoints)
+    }
+
+    /** Wipe all statistics (serialized through the recorder so it can't race an in-flight sample). */
+    fun clearAll() = recorder.clear()
+
+    private fun toSummary(row: ChargeSessionEntity) = ChargeSessionSummary(
+        id = row.id,
+        startedAtWallMillis = row.startedAtWallMillis,
+        endedAtWallMillis = row.endedAtWallMillis,
+        durationMillis = row.endedElapsedRealtimeMillis?.let { it - row.startedElapsedRealtimeMillis }?.takeIf { it >= 0 },
+        startPercent = row.startPercent,
+        endPercent = row.endPercent,
+        chargingType = ChargingTypes.fromPluggedRaw(row.pluggedRaw),
+        avgPowerMilliwatts = row.avgPowerMilliwatts,
+        peakPowerMilliwatts = row.runningPeakPowerMilliwatts,
+        minTemperatureTenthsC = row.runningMinTemperatureTenthsC,
+        avgTemperatureTenthsC = row.avgTemperatureTenthsC,
+        maxTemperatureTenthsC = row.runningMaxTemperatureTenthsC,
+        limitHit = row.limitHitEvidence && !row.overrideSeen,
+        partial = row.partial,
+        fullReachedAtWallMillis = row.fullReachedAtWallMillis,
+        sealReason = row.endReason?.let { runCatching { StatsSealReason.valueOf(it) }.getOrNull() },
+    )
+
+    private companion object {
+        const val DEFAULT_SESSION_LIMIT = 100
+        const val DEFAULT_CURVE_POINTS = 200
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsWatcher.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsWatcher.kt
@@ -1,0 +1,42 @@
+package eu.darken.amply.stats.core
+
+import eu.darken.amply.monitor.core.ChargeMonitorTick
+import eu.darken.amply.monitor.core.ChargeMonitorWatcher
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Contributes battery-statistics capture to the charge-session monitor. [isEnabled] reflects the
+ * opt-in preference, so when capture is on the service's existing keep-alive logic holds the
+ * foreground service (and its persistent notification) up continuously — that is the always-on
+ * behavior.
+ *
+ * [onBatteryTick] does no blocking work: it copies the tick into a [RawStatsTick] and hands it to
+ * [ChargeStatsRecorder], which does every DataStore/Binder/Room read on its own IO thread. This runs
+ * under the service's `commandMutex`, so it must never touch the disk or a Binder — a slow read here
+ * could delay the safety-critical charge-policy restore.
+ */
+@Singleton
+class ChargeStatsWatcher @Inject constructor(
+    private val preferences: StatsPreferences,
+    private val recorder: ChargeStatsRecorder,
+) : ChargeMonitorWatcher {
+
+    override val id = "battery_stats"
+
+    override suspend fun isEnabled(): Boolean = preferences.isCaptureEnabledNow()
+
+    override suspend fun onBatteryTick(tick: ChargeMonitorTick) {
+        recorder.offer(
+            RawStatsTick(
+                plugged = tick.plugged,
+                percent = tick.percent,
+                batteryStatus = tick.batteryStatus,
+                sessionActive = tick.sessionActive,
+                batteryIntent = tick.batteryIntent,
+                observedElapsedRealtimeMillis = tick.observedElapsedRealtimeMillis,
+                wallMillis = tick.wallClockMillis,
+            ),
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/RawStatsTick.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/RawStatsTick.kt
@@ -1,0 +1,20 @@
+package eu.darken.amply.stats.core
+
+import android.content.Intent
+
+/**
+ * The unenriched hand-off from [ChargeStatsWatcher] to [ChargeStatsRecorder]. Constructed on the
+ * charge-session service's evaluation thread with only cheap in-memory copies plus a reference to
+ * the already-evaluated battery intent — no Binder or DataStore reads. The recorder parses the
+ * intent and reads live battery properties on its own IO thread, keeping all such work off the
+ * service's `commandMutex`.
+ */
+data class RawStatsTick(
+    val plugged: Boolean,
+    val percent: Int,
+    val batteryStatus: Int,
+    val sessionActive: Boolean,
+    val batteryIntent: Intent?,
+    val observedElapsedRealtimeMillis: Long,
+    val wallMillis: Long,
+)

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsCadence.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsCadence.kt
@@ -1,0 +1,37 @@
+package eu.darken.amply.stats.core
+
+import kotlin.math.abs
+
+/**
+ * Pure throttle deciding whether a plugged tick should be *recorded* (folded into the session's
+ * online aggregates and written as a curve point). The host service already ticks roughly every 30 s
+ * plus on battery broadcasts; without throttling a fast charge's frequent percent/temperature
+ * broadcasts would write many near-duplicate rows.
+ *
+ * A tick is recorded when it is the first of a session, when the minimum interval has elapsed, or
+ * when the battery level changed since the last recorded point (so charge steps are never missed).
+ * Aggregates are time-weighted downstream, so the ~30 s spacing this produces stays accurate.
+ */
+object StatsCadence {
+
+    const val CHARGING_MIN_INTERVAL_MILLIS = 20_000L
+
+    fun shouldRecord(
+        lastRecordedElapsedMillis: Long?,
+        nowElapsedMillis: Long,
+        lastRecordedPercent: Int?,
+        currentPercent: Int?,
+    ): Boolean {
+        if (lastRecordedElapsedMillis == null) return true
+        // A backwards elapsed jump (should not happen within a boot) forces a record rather than
+        // silently starving the curve.
+        val since = nowElapsedMillis - lastRecordedElapsedMillis
+        if (since >= CHARGING_MIN_INTERVAL_MILLIS || since < 0) return true
+        if (currentPercent != null && lastRecordedPercent != null &&
+            abs(currentPercent - lastRecordedPercent) >= 1
+        ) {
+            return true
+        }
+        return false
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsDownsampler.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsDownsampler.kt
@@ -1,0 +1,27 @@
+package eu.darken.amply.stats.core
+
+/**
+ * Pure, API-26-safe curve decimation. Deliberately avoids SQL window functions (not uniformly
+ * available on older device SQLite) — the projection query returns all of a session's points and
+ * this thins them in memory to at most [maxPoints], always keeping the first and last so the curve's
+ * endpoints are exact.
+ */
+object StatsDownsampler {
+
+    fun <T> decimate(points: List<T>, maxPoints: Int): List<T> {
+        if (maxPoints < 2 || points.size <= maxPoints) return points
+        val lastIndex = points.size - 1
+        // Uniform stride across the interior; first and last are pinned.
+        val result = ArrayList<T>(maxPoints)
+        val step = lastIndex.toDouble() / (maxPoints - 1)
+        var previousIndex = -1
+        for (i in 0 until maxPoints) {
+            val index = if (i == maxPoints - 1) lastIndex else Math.round(i * step).toInt()
+            if (index != previousIndex) {
+                result.add(points[index])
+                previousIndex = index
+            }
+        }
+        return result
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsLimitHitDetector.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsLimitHitDetector.kt
@@ -1,0 +1,33 @@
+package eu.darken.amply.stats.core
+
+import android.os.BatteryManager
+
+/**
+ * Pure heuristic for whether an OEM charge limit appears to be holding the battery *right now*. The
+ * recorder latches any positive result for the session; the UI phrases it as "limit likely reached"
+ * rather than asserting it, because — unlike the privileged adapters — this is inferred from public
+ * battery state without Shizuku.
+ *
+ * Two signals, strongest first:
+ *  - the hidden Pixel charge-policy state ([android.os.BatteryManager.EXTRA_CHARGING_STATUS] == 4,
+ *    "long life"/limit hold — the same value [eu.darken.amply.fullcharge.core.QuickFullChargeGesture]
+ *    keys its arming on), and
+ *  - a generic fallback: plugged, reported NOT_CHARGING, and below full.
+ */
+object StatsLimitHitDetector {
+
+    /** EXTRA_CHARGING_STATUS value meaning the charge policy is holding the battery below 100%. */
+    const val HARDWARE_HOLD_STATE = 4
+
+    fun heldNow(
+        plugged: Boolean,
+        chargingStatus: Int?,
+        batteryStatus: Int?,
+        percent: Int?,
+    ): Boolean {
+        if (!plugged) return false
+        if (chargingStatus == HARDWARE_HOLD_STATE) return true
+        val belowFull = percent == null || percent < 100
+        return batteryStatus == BatteryManager.BATTERY_STATUS_NOT_CHARGING && belowFull
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsModels.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsModels.kt
@@ -1,0 +1,58 @@
+package eu.darken.amply.stats.core
+
+/** How the device was connected during a session, derived from the raw plugged bitmask. */
+enum class ChargingType { AC, USB, WIRELESS, DOCK, MIXED, UNKNOWN }
+
+/** A finished (or resumed-open) charge session, mapped from Room for the UI. */
+data class ChargeSessionSummary(
+    val id: Long,
+    val startedAtWallMillis: Long,
+    val endedAtWallMillis: Long?,
+    /** Boot-scoped elapsed duration; null while open. Clock-change-proof. */
+    val durationMillis: Long?,
+    val startPercent: Int?,
+    val endPercent: Int?,
+    val chargingType: ChargingType,
+    val avgPowerMilliwatts: Int?,
+    val peakPowerMilliwatts: Int?,
+    val minTemperatureTenthsC: Int?,
+    val avgTemperatureTenthsC: Int?,
+    val maxTemperatureTenthsC: Int?,
+    /** Heuristic — presented as "limit likely reached", never asserted. */
+    val limitHit: Boolean,
+    val partial: Boolean,
+    val fullReachedAtWallMillis: Long?,
+    val sealReason: StatsSealReason?,
+)
+
+/** One point on a session's charge curve, timed from the session start. */
+data class ChargeCurvePoint(
+    val elapsedFromStartMillis: Long,
+    val percent: Int?,
+    val powerMilliwatts: Int?,
+    val temperatureTenthsC: Int?,
+)
+
+/** Maps a raw [android.os.BatteryManager.EXTRA_PLUGGED] bitmask to a [ChargingType]. */
+object ChargingTypes {
+    // Literal for DOCK avoids a hard API-33 symbol reference (BATTERY_PLUGGED_DOCK).
+    private const val AC = 1
+    private const val USB = 2
+    private const val WIRELESS = 4
+    private const val DOCK = 8
+
+    fun fromPluggedRaw(pluggedRaw: Int?): ChargingType {
+        if (pluggedRaw == null || pluggedRaw == 0) return ChargingType.UNKNOWN
+        val matched = buildList {
+            if (pluggedRaw and AC != 0) add(ChargingType.AC)
+            if (pluggedRaw and USB != 0) add(ChargingType.USB)
+            if (pluggedRaw and WIRELESS != 0) add(ChargingType.WIRELESS)
+            if (pluggedRaw and DOCK != 0) add(ChargingType.DOCK)
+        }
+        return when {
+            matched.isEmpty() -> ChargingType.UNKNOWN
+            matched.size > 1 -> ChargingType.MIXED
+            else -> matched.first()
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsModule.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsModule.kt
@@ -1,0 +1,21 @@
+package eu.darken.amply.stats.core
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.amply.monitor.core.ChargeMonitorWatcher
+
+/**
+ * Contributes [ChargeStatsWatcher] into the shared [Set] of [ChargeMonitorWatcher]s the
+ * charge-session service fans battery ticks out to — the entire integration point with the service,
+ * matching how the charge alarm binds itself.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class StatsModule {
+    @Binds
+    @IntoSet
+    abstract fun bindStatsWatcher(impl: ChargeStatsWatcher): ChargeMonitorWatcher
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsPowerCalculator.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsPowerCalculator.kt
@@ -1,0 +1,27 @@
+package eu.darken.amply.stats.core
+
+import kotlin.math.abs
+
+/**
+ * Pure conversion of battery voltage × current into a battery-terminal power magnitude, in
+ * milliwatts. This is power at the battery, not charger/input power, and the magnitude alone does
+ * not encode direction (charge vs discharge) — the caller derives direction from plug/charging state.
+ *
+ * `mV × µA = 10⁻⁹ W = 10⁻⁶ mW`, so `mW = mV × |µA| / 1_000_000`, computed in [Long] to avoid the
+ * `Int` overflow that `4300 mV × 3_000_000 µA` would hit. Values outside a plausible phone/tablet
+ * range are rejected as `null` because some OEM firmwares report current in the wrong unit (mA, or
+ * deci-units) and would otherwise poison the session average.
+ */
+object StatsPowerCalculator {
+
+    /** 250 W — generously above any phone/tablet charger; anything larger is a bad OEM reading. */
+    const val MAX_PLAUSIBLE_MILLIWATTS = 250_000
+
+    fun milliwatts(voltageMillivolts: Int?, currentNowMicroamps: Int?): Int? {
+        if (voltageMillivolts == null || currentNowMicroamps == null) return null
+        if (voltageMillivolts <= 0) return null
+        val mw = voltageMillivolts.toLong() * abs(currentNowMicroamps.toLong()) / 1_000_000L
+        if (mw < 0 || mw > MAX_PLAUSIBLE_MILLIWATTS) return null
+        return mw.toInt()
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsPreferences.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsPreferences.kt
@@ -1,0 +1,45 @@
+package eu.darken.amply.stats.core
+
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import eu.darken.amply.common.AppDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * DataStore facade for battery-statistics capture, sharing the single [AppDataStore]. Holds only
+ * small pointers — the opt-in flag and the wall time of the last successfully recorded sample (so
+ * the UI can honestly show "enabled but not currently capturing" when a gap opens). All time-series
+ * data lives in Room, never here.
+ */
+@Singleton
+class StatsPreferences @Inject constructor(
+    private val dataStore: AppDataStore,
+) {
+    val captureEnabled: Flow<Boolean> = dataStore.store.data.map { it[ENABLED] ?: false }
+
+    val lastCaptureWallMillis: Flow<Long?> = dataStore.store.data.map { it[LAST_CAPTURE] }
+
+    suspend fun isCaptureEnabledNow(): Boolean = captureEnabled.first()
+
+    suspend fun setCaptureEnabled(enabled: Boolean) {
+        dataStore.store.edit { it[ENABLED] = enabled }
+    }
+
+    suspend fun setLastCaptureWallMillis(millis: Long) {
+        dataStore.store.edit { it[LAST_CAPTURE] = millis }
+    }
+
+    suspend fun clearLastCapture() {
+        dataStore.store.edit { it.remove(LAST_CAPTURE) }
+    }
+
+    private companion object {
+        val ENABLED = booleanPreferencesKey("stats.capture_enabled")
+        val LAST_CAPTURE = longPreferencesKey("stats.last_capture_wall")
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsSample.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsSample.kt
@@ -1,0 +1,32 @@
+package eu.darken.amply.stats.core
+
+/**
+ * An immutable, fully-resolved battery observation handed to the recorder. Built once, on the
+ * service's evaluation thread, from the *same* battery intent the service evaluated (never a second
+ * sticky-broadcast read), so plug state, percent, and the electrical fields are always internally
+ * consistent even across a rapid unplug/replug.
+ *
+ * [elapsedRealtimeMillis] + [bootId] drive durations and ordering (clock-change proof);
+ * [wallMillis] is for display only.
+ */
+data class StatsSample(
+    val elapsedRealtimeMillis: Long,
+    val wallMillis: Long,
+    val bootId: Long,
+    val plugged: Boolean,
+    val pluggedRaw: Int?,
+    val percent: Int?,
+    val batteryStatus: Int?,
+    val chargingStatus: Int?,
+    val temperatureTenthsC: Int?,
+    val voltageMillivolts: Int?,
+    val currentNowMicroamps: Int?,
+    /** Battery-terminal power magnitude (mW), precomputed by [StatsPowerCalculator]; null if absent. */
+    val powerMilliwatts: Int?,
+    /** [android.os.BatteryManager.BATTERY_STATUS_FULL] or level ≥ 100. */
+    val full: Boolean,
+    /** An Amply full-charge override owns this plug cycle right now. */
+    val overrideActive: Boolean,
+    /** An OEM charge limit appears to be holding right now (see [StatsLimitHitDetector]). */
+    val limitHeldNow: Boolean,
+)

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsSealReason.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsSealReason.kt
@@ -1,0 +1,20 @@
+package eu.darken.amply.stats.core
+
+/**
+ * Why a charge session was closed. Note there is no `FULL` reason: a session represents a whole
+ * plug→unplug cycle and stays open after reaching 100% (the moment is recorded as `fullReachedAt`),
+ * so being held at full by an OEM limiter never fragments it into repeated degenerate sessions.
+ */
+enum class StatsSealReason {
+    /** Charger removed — the normal, complete end of a session. */
+    UNPLUGGED,
+
+    /** Reopened an open session after a process restart within the same boot; curve has a gap. */
+    INTERRUPTED,
+
+    /** Open session found after a reboot; elapsed-time continuity across power-off can't be trusted. */
+    REBOOT,
+
+    /** Capture was turned off while a session was open. */
+    DISABLED,
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsSessionEngine.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsSessionEngine.kt
@@ -1,0 +1,170 @@
+package eu.darken.amply.stats.core
+
+import eu.darken.amply.stats.core.db.ChargeSessionEntity
+import kotlin.math.roundToInt
+
+/** What the recorder should do with a [StatsSample] given the current open-session state. */
+sealed interface StatsTransition {
+    /** Start a new charge session. [partial] when the charge was already underway when observed. */
+    data class Open(val partial: Boolean) : StatsTransition
+
+    /** Continue the open session; [record] gates folding + writing a curve point (see [StatsCadence]). */
+    data class Append(val record: Boolean) : StatsTransition
+
+    /** Close the open session. */
+    data class Seal(val reason: StatsSealReason) : StatsTransition
+
+    /** Unplugged with no open session — nothing to do in P1 (discharge tracking is a later phase). */
+    data object Ignore : StatsTransition
+}
+
+/**
+ * Pure charge-session segmentation and online aggregation. Holds no state itself: the open session
+ * is a [ChargeSessionEntity] the recorder loads from (and persists to) Room, so every decision
+ * survives process death and is JVM-unit-testable without Android or a database.
+ *
+ * Aggregates are folded online with a left-Riemann, time-weighted scheme: each inter-sample interval
+ * is attributed to the value observed at its start, so irregular sample spacing (30 s polls mixed
+ * with battery broadcasts) does not bias the averages. Intervals are clamped to [MAX_WEIGHT_GAP_MILLIS]
+ * so a Doze gap can't massively overweight one stale reading.
+ */
+object StatsSessionEngine {
+
+    /** Longest inter-sample interval credited to a single reading (10 min). */
+    const val MAX_WEIGHT_GAP_MILLIS = 600_000L
+
+    fun decide(
+        hasOpenSession: Boolean,
+        previousPlugged: Boolean?,
+        plugged: Boolean,
+        recordDue: Boolean,
+    ): StatsTransition = when {
+        !hasOpenSession && !plugged -> StatsTransition.Ignore
+        // Clean start only when we just saw an unplugged tick; otherwise capture began mid-charge.
+        !hasOpenSession && plugged -> StatsTransition.Open(partial = previousPlugged != false)
+        hasOpenSession && plugged -> StatsTransition.Append(record = recordDue)
+        else -> StatsTransition.Seal(StatsSealReason.UNPLUGGED)
+    }
+
+    fun open(sample: StatsSample, partial: Boolean): ChargeSessionEntity = ChargeSessionEntity(
+        startedAtWallMillis = sample.wallMillis,
+        startedElapsedRealtimeMillis = sample.elapsedRealtimeMillis,
+        bootId = sample.bootId,
+        startPercent = sample.percent,
+        pluggedRaw = sample.pluggedRaw,
+        // Starting already full means we missed the charge — present it as partial.
+        partial = partial || sample.full,
+        fullReachedAtWallMillis = if (sample.full) sample.wallMillis else null,
+        runningSampleCount = 1,
+        runningPeakPowerMilliwatts = sample.powerMilliwatts,
+        runningMinTemperatureTenthsC = sample.temperatureTenthsC,
+        runningMaxTemperatureTenthsC = sample.temperatureTenthsC,
+        runningLastPowerMilliwatts = sample.powerMilliwatts,
+        runningLastTemperatureTenthsC = sample.temperatureTenthsC,
+        runningLastPercent = sample.percent,
+        runningLastElapsedRealtimeMillis = sample.elapsedRealtimeMillis,
+        runningLastWallMillis = sample.wallMillis,
+        limitHitEvidence = sample.limitHeldNow,
+        overrideSeen = sample.overrideActive,
+    )
+
+    fun fold(session: ChargeSessionEntity, sample: StatsSample): ChargeSessionEntity {
+        val credited = creditInterval(session, sample.elapsedRealtimeMillis)
+        return session.copy(
+            runningSampleCount = session.runningSampleCount + 1,
+            runningPowerWeightedSum = credited.powerSum,
+            runningPowerWeightedDurationMillis = credited.powerDuration,
+            runningTemperatureWeightedSum = credited.tempSum,
+            runningTemperatureWeightedDurationMillis = credited.tempDuration,
+            runningPeakPowerMilliwatts = maxNullable(session.runningPeakPowerMilliwatts, sample.powerMilliwatts),
+            runningMinTemperatureTenthsC = minNullable(session.runningMinTemperatureTenthsC, sample.temperatureTenthsC),
+            runningMaxTemperatureTenthsC = maxNullable(session.runningMaxTemperatureTenthsC, sample.temperatureTenthsC),
+            // Do NOT carry a stale value forward: an absent reading leaves the next interval uncredited.
+            runningLastPowerMilliwatts = sample.powerMilliwatts,
+            runningLastTemperatureTenthsC = sample.temperatureTenthsC,
+            runningLastPercent = sample.percent ?: session.runningLastPercent,
+            runningLastElapsedRealtimeMillis = sample.elapsedRealtimeMillis,
+            runningLastWallMillis = sample.wallMillis,
+            fullReachedAtWallMillis = session.fullReachedAtWallMillis
+                ?: sample.wallMillis.takeIf { sample.full },
+            limitHitEvidence = session.limitHitEvidence || sample.limitHeldNow,
+            overrideSeen = session.overrideSeen || sample.overrideActive,
+        )
+    }
+
+    /**
+     * Close [session]. [endWallMillis]/[endElapsedMillis]/[endPercent] come from the unplug tick when
+     * available, else the session's last recorded values (recovery/disable seals). The final open
+     * interval is credited before averaging so the tail isn't lost.
+     */
+    fun seal(
+        session: ChargeSessionEntity,
+        reason: StatsSealReason,
+        endWallMillis: Long,
+        endElapsedMillis: Long,
+        endPercent: Int?,
+    ): ChargeSessionEntity {
+        val credited = creditInterval(session, endElapsedMillis)
+        val avgPower = if (credited.powerDuration > 0) {
+            (credited.powerSum / credited.powerDuration).roundToInt()
+        } else {
+            session.runningLastPowerMilliwatts
+        }
+        val avgTemp = if (credited.tempDuration > 0) {
+            (credited.tempSum / credited.tempDuration).roundToInt()
+        } else {
+            session.runningLastTemperatureTenthsC
+        }
+        return session.copy(
+            endedAtWallMillis = endWallMillis,
+            endedElapsedRealtimeMillis = endElapsedMillis,
+            endReason = reason.name,
+            endPercent = endPercent ?: session.runningLastPercent,
+            avgPowerMilliwatts = avgPower,
+            avgTemperatureTenthsC = avgTemp,
+            runningPowerWeightedSum = credited.powerSum,
+            runningPowerWeightedDurationMillis = credited.powerDuration,
+            runningTemperatureWeightedSum = credited.tempSum,
+            runningTemperatureWeightedDurationMillis = credited.tempDuration,
+            partial = session.partial || reason == StatsSealReason.INTERRUPTED || reason == StatsSealReason.REBOOT,
+        )
+    }
+
+    private class Credited(
+        val powerSum: Double,
+        val powerDuration: Long,
+        val tempSum: Double,
+        val tempDuration: Long,
+    )
+
+    /** Credit the interval from the last recorded sample up to [untilElapsedMillis] to the last values. */
+    private fun creditInterval(session: ChargeSessionEntity, untilElapsedMillis: Long): Credited {
+        val last = session.runningLastElapsedRealtimeMillis ?: untilElapsedMillis
+        val dt = (untilElapsedMillis - last).coerceIn(0, MAX_WEIGHT_GAP_MILLIS)
+        val prevPower = session.runningLastPowerMilliwatts
+        val prevTemp = session.runningLastTemperatureTenthsC
+        // Inline null checks so prevPower/prevTemp smart-cast to non-null inside each branch.
+        return Credited(
+            powerSum = session.runningPowerWeightedSum +
+                if (prevPower != null && dt > 0) prevPower.toDouble() * dt else 0.0,
+            powerDuration = session.runningPowerWeightedDurationMillis +
+                if (prevPower != null && dt > 0) dt else 0L,
+            tempSum = session.runningTemperatureWeightedSum +
+                if (prevTemp != null && dt > 0) prevTemp.toDouble() * dt else 0.0,
+            tempDuration = session.runningTemperatureWeightedDurationMillis +
+                if (prevTemp != null && dt > 0) dt else 0L,
+        )
+    }
+
+    private fun maxNullable(a: Int?, b: Int?): Int? = when {
+        a == null -> b
+        b == null -> a
+        else -> maxOf(a, b)
+    }
+
+    private fun minNullable(a: Int?, b: Int?): Int? = when {
+        a == null -> b
+        b == null -> a
+        else -> minOf(a, b)
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/db/BatterySampleEntity.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/db/BatterySampleEntity.kt
@@ -1,0 +1,54 @@
+package eu.darken.amply.stats.core.db
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * One raw battery observation persisted for a charge curve. Belongs to a [ChargeSessionEntity]
+ * ([sessionId], cascade-deleted with its session). Retention purges old rows by [wallMillis]; the
+ * owning session's summary is unaffected because it is accumulated online, not recomputed from these.
+ *
+ * [powerMilliwatts] is battery-terminal power (battery voltage × |current|), not charger/input
+ * power, and cannot distinguish charging from discharging by itself — the owning session's phase and
+ * the [chargingStatus]/[batteryStatus] provide direction.
+ */
+@Entity(
+    tableName = "battery_samples",
+    foreignKeys = [
+        ForeignKey(
+            entity = ChargeSessionEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["sessionId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        // Curve reads and cascade deletes go by session, ordered by time.
+        Index("sessionId", "elapsedRealtimeMillis"),
+        // Retention purges by wall time.
+        Index("wallMillis"),
+    ],
+)
+data class BatterySampleEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+
+    val sessionId: Long,
+
+    val wallMillis: Long,
+    val elapsedRealtimeMillis: Long,
+    val bootId: Long,
+
+    val percent: Int? = null,
+    val batteryStatus: Int? = null,
+    /** Raw [android.os.BatteryManager.EXTRA_CHARGING_STATUS] (hidden Pixel charge-policy state). */
+    val chargingStatus: Int? = null,
+    val pluggedRaw: Int? = null,
+
+    val temperatureTenthsC: Int? = null,
+    val voltageMillivolts: Int? = null,
+    val currentNowMicroamps: Int? = null,
+    /** Precomputed battery-terminal power magnitude in milliwatts; null if inputs were absent. */
+    val powerMilliwatts: Int? = null,
+)

--- a/app/src/main/java/eu/darken/amply/stats/core/db/ChargeSessionEntity.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/db/ChargeSessionEntity.kt
@@ -1,0 +1,76 @@
+package eu.darken.amply.stats.core.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * One physical charge session (plug → unplug). Row is created on plug-in and stays open
+ * (`endedAtWallMillis == null`) until the charger is removed, so a battery that reaches 100% and is
+ * held there by an OEM limiter remains a single session rather than fragmenting into many.
+ *
+ * Timing is stored twice on purpose: wall-clock for display, and boot-scoped
+ * [android.os.SystemClock.elapsedRealtime] plus [bootId] for durations and ordering that survive
+ * manual clock changes / NTP / DST. A duration is only trustworthy when start and end share the same
+ * [bootId]; a session sealed after a reboot is marked [partial].
+ *
+ * Summary statistics are accumulated online while the session is open (see the running-* columns),
+ * never by re-scanning raw samples at close — so retention can purge old [BatterySampleEntity] rows
+ * without corrupting a finished summary, and a very long session never triggers an unbounded scan.
+ */
+@Entity(tableName = "charge_sessions")
+data class ChargeSessionEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+
+    val startedAtWallMillis: Long,
+    val startedElapsedRealtimeMillis: Long,
+    val bootId: Long,
+
+    val endedAtWallMillis: Long? = null,
+    val endedElapsedRealtimeMillis: Long? = null,
+    /** One of [eu.darken.amply.stats.core.StatsSealReason] names; null while open. */
+    val endReason: String? = null,
+
+    val startPercent: Int? = null,
+    val endPercent: Int? = null,
+    /** Raw [android.os.BatteryManager.EXTRA_PLUGGED] bitmask at start (AC/USB/WIRELESS/DOCK). */
+    val pluggedRaw: Int? = null,
+
+    /** When [android.os.BatteryManager.BATTERY_STATUS_FULL] was first seen this cycle, if ever. */
+    val fullReachedAtWallMillis: Long? = null,
+
+    /**
+     * True when the session does not represent a clean plug→unplug: capture was enabled mid-charge,
+     * started already at 100%, or the session was sealed by process recovery / reboot. The UI labels
+     * these as partial rather than presenting them as complete histories.
+     */
+    val partial: Boolean = false,
+
+    /** Set at close from the running weighted sums; null while open. */
+    val avgPowerMilliwatts: Int? = null,
+    val avgTemperatureTenthsC: Int? = null,
+
+    // --- Online accumulators (mutated on every recorded sample while the session is open) ---
+    val runningSampleCount: Int = 0,
+    /**
+     * Per-metric time-weighted sums and their denominators (kept separate because power and
+     * temperature can be absent on different ticks). Average = sum / duration.
+     */
+    val runningPowerWeightedSum: Double = 0.0,
+    val runningPowerWeightedDurationMillis: Long = 0,
+    val runningTemperatureWeightedSum: Double = 0.0,
+    val runningTemperatureWeightedDurationMillis: Long = 0,
+    val runningPeakPowerMilliwatts: Int? = null,
+    val runningMinTemperatureTenthsC: Int? = null,
+    val runningMaxTemperatureTenthsC: Int? = null,
+    /** Last observed values, used to weight the next interval and to seal on recovery. */
+    val runningLastPowerMilliwatts: Int? = null,
+    val runningLastTemperatureTenthsC: Int? = null,
+    val runningLastPercent: Int? = null,
+    val runningLastElapsedRealtimeMillis: Long? = null,
+    /** Wall time of the last recorded sample; the seal endpoint when no fresh tick is available. */
+    val runningLastWallMillis: Long? = null,
+    /** Sticky: an OEM charge limit was observed holding at least once this cycle. */
+    val limitHitEvidence: Boolean = false,
+    /** Sticky: an Amply full-charge override owned this plug cycle (forces limitHit false). */
+    val overrideSeen: Boolean = false,
+)

--- a/app/src/main/java/eu/darken/amply/stats/core/db/StatsDao.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/db/StatsDao.kt
@@ -1,0 +1,65 @@
+package eu.darken.amply.stats.core.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface StatsDao {
+
+    // --- charge_sessions ---
+
+    @Insert
+    suspend fun insertSession(session: ChargeSessionEntity): Long
+
+    @Update
+    suspend fun updateSession(session: ChargeSessionEntity)
+
+    /**
+     * Open sessions, newest first. Normally at most one exists; the recorder reconciles extras
+     * (sealing all but the newest) rather than assuming a single row, so a crash that left two open
+     * can never wedge capture.
+     */
+    @Query("SELECT * FROM charge_sessions WHERE endedAtWallMillis IS NULL ORDER BY startedElapsedRealtimeMillis DESC")
+    suspend fun openSessions(): List<ChargeSessionEntity>
+
+    @Query("SELECT * FROM charge_sessions WHERE id = :id")
+    suspend fun sessionById(id: Long): ChargeSessionEntity?
+
+    /** Finished sessions for the history list, newest first. */
+    @Query("SELECT * FROM charge_sessions WHERE endedAtWallMillis IS NOT NULL ORDER BY startedAtWallMillis DESC LIMIT :limit")
+    fun finishedSessions(limit: Int): Flow<List<ChargeSessionEntity>>
+
+    @Query("SELECT * FROM charge_sessions WHERE id = :id")
+    fun sessionFlow(id: Long): Flow<ChargeSessionEntity?>
+
+    @Query("DELETE FROM charge_sessions")
+    suspend fun deleteAllSessions()
+
+    // --- battery_samples ---
+
+    @Insert
+    suspend fun insertSample(sample: BatterySampleEntity): Long
+
+    @Query("SELECT * FROM battery_samples WHERE sessionId = :sessionId ORDER BY elapsedRealtimeMillis ASC")
+    fun samplesForSession(sessionId: Long): Flow<List<BatterySampleEntity>>
+
+    /** Raw samples for a session as a plain list (curve rendering decimates in memory). */
+    @Query("SELECT * FROM battery_samples WHERE sessionId = :sessionId ORDER BY elapsedRealtimeMillis ASC")
+    suspend fun samplesForSessionNow(sessionId: Long): List<BatterySampleEntity>
+
+    /** Retention: drop raw samples older than a cutoff whose session is already closed. */
+    @Query(
+        """
+        DELETE FROM battery_samples
+        WHERE wallMillis < :cutoffWallMillis
+        AND sessionId IN (SELECT id FROM charge_sessions WHERE endedAtWallMillis IS NOT NULL)
+        """,
+    )
+    suspend fun deleteSamplesOlderThan(cutoffWallMillis: Long): Int
+
+    @Query("DELETE FROM battery_samples")
+    suspend fun deleteAllSamples()
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/db/StatsDatabase.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/db/StatsDatabase.kt
@@ -1,0 +1,26 @@
+package eu.darken.amply.stats.core.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+/**
+ * Room store for battery statistics. Version 1 is P1-only (charge sessions + their raw samples);
+ * discharge and battery-health tables land in later versions as additive, tested migrations.
+ * Schemas are exported to `app/schemas` (see the KSP `room.schemaLocation` arg) so those migrations
+ * have a committed baseline to diff against.
+ */
+@Database(
+    entities = [
+        ChargeSessionEntity::class,
+        BatterySampleEntity::class,
+    ],
+    version = 1,
+    exportSchema = true,
+)
+abstract class StatsDatabase : RoomDatabase() {
+    abstract fun statsDao(): StatsDao
+
+    companion object {
+        const val NAME = "stats.db"
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/db/StatsDatabaseModule.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/db/StatsDatabaseModule.kt
@@ -1,0 +1,29 @@
+package eu.darken.amply.stats.core.db
+
+import android.content.Context
+import androidx.room.Room
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Provides the statistics [StatsDatabase]. Consumers inject it via `dagger.Lazy` so `build()` (and
+ * therefore any on-disk open) is deferred until stats capture is actually used — a corrupt/locked
+ * stats DB must never prevent the safety-critical charge-session service or the boot receiver from
+ * being constructed. No destructive-migration fallback: history is long-lived and must migrate.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object StatsDatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideStatsDatabase(@ApplicationContext context: Context): StatsDatabase =
+        Room.databaseBuilder(context, StatsDatabase::class.java, StatsDatabase.NAME).build()
+
+    @Provides
+    fun provideStatsDao(database: StatsDatabase): StatsDao = database.statsDao()
+}

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsFormat.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsFormat.kt
@@ -1,0 +1,47 @@
+package eu.darken.amply.stats.ui
+
+import eu.darken.amply.stats.core.ChargingType
+import java.util.Locale
+
+/** Number/label formatting for the statistics UI. Units are formatted inline; labels use resources. */
+object StatsFormat {
+
+    fun duration(millis: Long?): String? {
+        if (millis == null || millis < 0) return null
+        val totalMinutes = millis / 60_000
+        val hours = totalMinutes / 60
+        val minutes = totalMinutes % 60
+        return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+    }
+
+    fun power(milliwatts: Int?): String? =
+        milliwatts?.let { String.format(Locale.getDefault(), "%.1f W", it / 1000.0) }
+
+    fun temperature(tenthsC: Int?): String? =
+        tenthsC?.let { String.format(Locale.getDefault(), "%.1f °C", it / 10.0) }
+
+    fun percentRange(start: Int?, end: Int?): String {
+        val from = start?.let { "$it%" } ?: "—"
+        val to = end?.let { "$it%" } ?: "—"
+        return "$from → $to"
+    }
+
+    fun temperatureRange(min: Int?, max: Int?): String? {
+        val minText = temperature(min)
+        val maxText = temperature(max)
+        return when {
+            minText != null && maxText != null -> "$minText – $maxText"
+            else -> minText ?: maxText
+        }
+    }
+}
+
+/** Maps a [ChargingType] to a user-facing string-resource id. */
+fun chargingTypeLabel(type: ChargingType): Int = when (type) {
+    ChargingType.AC -> eu.darken.amply.R.string.stats_charging_type_ac
+    ChargingType.USB -> eu.darken.amply.R.string.stats_charging_type_usb
+    ChargingType.WIRELESS -> eu.darken.amply.R.string.stats_charging_type_wireless
+    ChargingType.DOCK -> eu.darken.amply.R.string.stats_charging_type_dock
+    ChargingType.MIXED -> eu.darken.amply.R.string.stats_charging_type_mixed
+    ChargingType.UNKNOWN -> eu.darken.amply.R.string.stats_charging_type_unknown
+}

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsScreen.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsScreen.kt
@@ -1,0 +1,294 @@
+package eu.darken.amply.stats.ui
+
+import android.text.format.DateUtils
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.DeleteOutline
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import eu.darken.amply.R
+import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.PreviewWrapper
+import eu.darken.amply.stats.core.ChargeSessionSummary
+import eu.darken.amply.stats.core.ChargingType
+import eu.darken.amply.stats.core.StatsSealReason
+
+/**
+ * Battery-statistics home: the opt-in capture switch (with the always-on persistent-notification
+ * caveat spelled out), a clear-data action, and the list of recorded charge sessions. State-hoisted
+ * and previewable. Enabling is routed by the caller through the notification-permission flow.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StatsScreen(
+    state: StatsUiState,
+    onBack: () -> Unit,
+    onCaptureEnabledChange: (Boolean) -> Unit,
+    onOpenSession: (Long) -> Unit,
+    onClearData: () -> Unit,
+) {
+    var confirmClear by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.stats_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item {
+                CaptureCard(
+                    enabled = state.captureEnabled,
+                    lastCaptureWallMillis = state.lastCaptureWallMillis,
+                    onCaptureEnabledChange = onCaptureEnabledChange,
+                )
+            }
+            item {
+                Text(
+                    stringResource(R.string.stats_sessions_header),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(start = 4.dp, top = 4.dp),
+                )
+            }
+            if (state.sessions.isEmpty()) {
+                item {
+                    Text(
+                        stringResource(R.string.stats_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(4.dp),
+                    )
+                }
+            } else {
+                items(state.sessions, key = { it.id }) { session ->
+                    SessionRow(session = session, onClick = { onOpenSession(session.id) })
+                }
+                item {
+                    TextButton(
+                        onClick = { confirmClear = true },
+                        modifier = Modifier.padding(top = 4.dp),
+                    ) {
+                        Icon(Icons.Default.DeleteOutline, contentDescription = null)
+                        Text(
+                            stringResource(R.string.stats_clear_action),
+                            modifier = Modifier.padding(start = 8.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (confirmClear) {
+        AlertDialog(
+            onDismissRequest = { confirmClear = false },
+            title = { Text(stringResource(R.string.stats_clear_confirm_title)) },
+            text = { Text(stringResource(R.string.stats_clear_confirm_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    confirmClear = false
+                    onClearData()
+                }) {
+                    Text(stringResource(R.string.stats_clear_confirm_positive))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmClear = false }) {
+                    Text(stringResource(R.string.stats_action_cancel))
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun CaptureCard(
+    enabled: Boolean,
+    lastCaptureWallMillis: Long?,
+    onCaptureEnabledChange: (Boolean) -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    stringResource(R.string.stats_capture_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                Switch(checked = enabled, onCheckedChange = onCaptureEnabledChange)
+            }
+            Text(
+                stringResource(R.string.stats_capture_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (enabled) {
+                val lastText = lastCaptureWallMillis?.let {
+                    DateUtils.getRelativeTimeSpanString(it).toString()
+                } ?: stringResource(R.string.stats_capture_never)
+                Text(
+                    stringResource(R.string.stats_capture_last_recorded, lastText),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SessionRow(session: ChargeSessionSummary, onClick: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .clickable(onClick = onClick)
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    DateUtils.getRelativeTimeSpanString(session.startedAtWallMillis).toString(),
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    buildString {
+                        append(StatsFormat.percentRange(session.startPercent, session.endPercent))
+                        StatsFormat.duration(session.durationMillis)?.let { append("  ·  $it") }
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                val tags = buildList {
+                    if (session.limitHit) add(stringResource(R.string.stats_session_limit_likely))
+                    if (session.partial) add(stringResource(R.string.stats_session_partial))
+                }
+                if (tags.isNotEmpty()) {
+                    Text(
+                        tags.joinToString("  ·  "),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@AmplyPreview
+@Composable
+private fun StatsScreenPreview() = PreviewWrapper {
+    StatsScreen(
+        state = StatsUiState(
+            captureEnabled = true,
+            lastCaptureWallMillis = System.currentTimeMillis() - 120_000,
+            sessions = listOf(
+                ChargeSessionSummary(
+                    id = 1,
+                    startedAtWallMillis = System.currentTimeMillis() - 7_200_000,
+                    endedAtWallMillis = System.currentTimeMillis() - 3_600_000,
+                    durationMillis = 3_600_000,
+                    startPercent = 42,
+                    endPercent = 100,
+                    chargingType = ChargingType.AC,
+                    avgPowerMilliwatts = 12_000,
+                    peakPowerMilliwatts = 27_000,
+                    minTemperatureTenthsC = 280,
+                    avgTemperatureTenthsC = 305,
+                    maxTemperatureTenthsC = 330,
+                    limitHit = false,
+                    partial = false,
+                    fullReachedAtWallMillis = System.currentTimeMillis() - 3_650_000,
+                    sealReason = StatsSealReason.UNPLUGGED,
+                ),
+                ChargeSessionSummary(
+                    id = 2,
+                    startedAtWallMillis = System.currentTimeMillis() - 90_000_000,
+                    endedAtWallMillis = System.currentTimeMillis() - 88_000_000,
+                    durationMillis = 2_000_000,
+                    startPercent = 62,
+                    endPercent = 80,
+                    chargingType = ChargingType.WIRELESS,
+                    avgPowerMilliwatts = 6_500,
+                    peakPowerMilliwatts = 9_000,
+                    minTemperatureTenthsC = 300,
+                    avgTemperatureTenthsC = 320,
+                    maxTemperatureTenthsC = 350,
+                    limitHit = true,
+                    partial = true,
+                    fullReachedAtWallMillis = null,
+                    sealReason = StatsSealReason.UNPLUGGED,
+                ),
+            ),
+        ),
+        onBack = {},
+        onCaptureEnabledChange = {},
+        onOpenSession = {},
+        onClearData = {},
+    )
+}
+
+@AmplyPreview
+@Composable
+private fun StatsScreenEmptyPreview() = PreviewWrapper {
+    StatsScreen(
+        state = StatsUiState(captureEnabled = false),
+        onBack = {},
+        onCaptureEnabledChange = {},
+        onOpenSession = {},
+        onClearData = {},
+    )
+}

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsSessionDetailScreen.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsSessionDetailScreen.kt
@@ -1,0 +1,216 @@
+package eu.darken.amply.stats.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import eu.darken.amply.R
+import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.PreviewWrapper
+import eu.darken.amply.common.compose.chart.ChartPoint
+import eu.darken.amply.common.compose.chart.ChartSeries
+import eu.darken.amply.common.compose.chart.LineChart
+import eu.darken.amply.stats.core.ChargeCurvePoint
+import eu.darken.amply.stats.core.ChargeSessionSummary
+import eu.darken.amply.stats.core.ChargingType
+import eu.darken.amply.stats.core.StatsSealReason
+
+/**
+ * One session's charge curve (percent / power / temperature over time) plus its numeric summary.
+ * State-hoisted; a null [state] shows a spinner while the ViewModel resolves the selection.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StatsSessionDetailScreen(
+    state: StatsDetailState?,
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.stats_detail_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        val summary = state?.summary
+        if (state == null || summary == null) {
+            Box(
+                Modifier
+                    .padding(padding)
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+            return@Scaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { CurveCard(state.curve) }
+            item { SummaryCard(summary) }
+            if (summary.partial) {
+                item {
+                    Text(
+                        stringResource(R.string.stats_detail_partial_note),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CurveCard(curve: List<ChargeCurvePoint>) {
+    val percentColor = MaterialTheme.colorScheme.primary
+    val powerColor = MaterialTheme.colorScheme.tertiary
+    val tempColor = MaterialTheme.colorScheme.error
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                stringResource(R.string.stats_detail_curve_title),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+            LineChart(
+                series = listOf(
+                    ChartSeries(
+                        label = stringResource(R.string.stats_curve_series_percent),
+                        color = percentColor,
+                        points = curve.map { ChartPoint(it.elapsedFromStartMillis.toFloat(), it.percent?.toFloat()) },
+                    ),
+                    ChartSeries(
+                        label = stringResource(R.string.stats_curve_series_power),
+                        color = powerColor,
+                        points = curve.map { ChartPoint(it.elapsedFromStartMillis.toFloat(), it.powerMilliwatts?.toFloat()) },
+                    ),
+                    ChartSeries(
+                        label = stringResource(R.string.stats_curve_series_temperature),
+                        color = tempColor,
+                        points = curve.map { ChartPoint(it.elapsedFromStartMillis.toFloat(), it.temperatureTenthsC?.toFloat()) },
+                    ),
+                ),
+                emptyLabel = stringResource(R.string.stats_curve_empty),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SummaryCard(summary: ChargeSessionSummary) {
+    val notReported = stringResource(R.string.battery_value_not_reported)
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            DetailRow(stringResource(R.string.stats_detail_level), StatsFormat.percentRange(summary.startPercent, summary.endPercent))
+            DetailRow(stringResource(R.string.stats_detail_duration), StatsFormat.duration(summary.durationMillis) ?: notReported)
+            DetailRow(stringResource(R.string.stats_detail_charging_type), stringResource(chargingTypeLabel(summary.chargingType)))
+            DetailRow(stringResource(R.string.stats_detail_avg_power), StatsFormat.power(summary.avgPowerMilliwatts) ?: notReported)
+            DetailRow(stringResource(R.string.stats_detail_peak_power), StatsFormat.power(summary.peakPowerMilliwatts) ?: notReported)
+            DetailRow(
+                stringResource(R.string.stats_detail_temperature),
+                StatsFormat.temperatureRange(summary.minTemperatureTenthsC, summary.maxTemperatureTenthsC) ?: notReported,
+            )
+            DetailRow(
+                stringResource(R.string.stats_detail_limit_likely),
+                stringResource(if (summary.limitHit) R.string.stats_value_yes else R.string.stats_value_no),
+            )
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f),
+        )
+        Text(value, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium)
+    }
+}
+
+@AmplyPreview
+@Composable
+private fun StatsSessionDetailScreenPreview() = PreviewWrapper {
+    val start = 0L
+    val curve = (0..20).map { i ->
+        ChargeCurvePoint(
+            elapsedFromStartMillis = start + i * 180_000L,
+            percent = (42 + i * 3).coerceAtMost(100),
+            powerMilliwatts = (25_000 - i * 900).coerceAtLeast(1_500),
+            temperatureTenthsC = 300 + i * 2,
+        )
+    }
+    StatsSessionDetailScreen(
+        state = StatsDetailState(
+            summary = ChargeSessionSummary(
+                id = 1,
+                startedAtWallMillis = System.currentTimeMillis() - 3_600_000,
+                endedAtWallMillis = System.currentTimeMillis(),
+                durationMillis = 3_600_000,
+                startPercent = 42,
+                endPercent = 100,
+                chargingType = ChargingType.AC,
+                avgPowerMilliwatts = 12_000,
+                peakPowerMilliwatts = 25_000,
+                minTemperatureTenthsC = 300,
+                avgTemperatureTenthsC = 320,
+                maxTemperatureTenthsC = 340,
+                limitHit = false,
+                partial = false,
+                fullReachedAtWallMillis = System.currentTimeMillis() - 60_000,
+                sealReason = StatsSealReason.UNPLUGGED,
+            ),
+            curve = curve,
+        ),
+        onBack = {},
+    )
+}

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsViewModel.kt
@@ -1,0 +1,109 @@
+package eu.darken.amply.stats.ui
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.amply.fullcharge.core.ChargeSessionService
+import eu.darken.amply.stats.core.ChargeCurvePoint
+import eu.darken.amply.stats.core.ChargeSessionSummary
+import eu.darken.amply.stats.core.ChargeStatsRecorder
+import eu.darken.amply.stats.core.ChargeStatsRepository
+import eu.darken.amply.stats.core.StatsPreferences
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class StatsUiState(
+    val captureEnabled: Boolean = false,
+    val lastCaptureWallMillis: Long? = null,
+    val sessions: List<ChargeSessionSummary> = emptyList(),
+)
+
+data class StatsDetailState(
+    val summary: ChargeSessionSummary?,
+    val curve: List<ChargeCurvePoint>,
+)
+
+@HiltViewModel
+class StatsViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val preferences: StatsPreferences,
+    private val repository: ChargeStatsRepository,
+    private val recorder: ChargeStatsRecorder,
+) : ViewModel() {
+
+    val state: StateFlow<StatsUiState> = combine(
+        preferences.captureEnabled,
+        preferences.lastCaptureWallMillis,
+        repository.recentSessions(),
+    ) { enabled, lastCapture, sessions ->
+        StatsUiState(captureEnabled = enabled, lastCaptureWallMillis = lastCapture, sessions = sessions)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS), StatsUiState())
+
+    private val selectedSessionId = MutableStateFlow<Long?>(null)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val detailState: StateFlow<StatsDetailState?> = selectedSessionId
+        .flatMapLatest { id ->
+            if (id == null) {
+                flowOf<StatsDetailState?>(null)
+            } else {
+                flow<StatsDetailState?> {
+                    // A closed session's samples are immutable, so the curve is fetched once.
+                    val curve = runCatching { repository.curve(id) }.getOrDefault(emptyList())
+                    emitAll(repository.session(id).map { StatsDetailState(it, curve) })
+                }
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS), null)
+
+    fun openSession(id: Long) {
+        selectedSessionId.value = id
+    }
+
+    fun closeSession() {
+        selectedSessionId.value = null
+    }
+
+    /**
+     * Enable/disable capture. Enabling is routed through the activity's notification-permission flow
+     * first (the always-on service shows a persistent notification). Disabling seals any open session
+     * before the service is nudged to re-evaluate and stop.
+     */
+    fun setCaptureEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            // Durable state for keep-alive / isEnabled, plus an ordered recorder command that seals
+            // any open session on disable before the service is nudged to re-evaluate and stop.
+            preferences.setCaptureEnabled(enabled)
+            recorder.setEnabled(enabled)
+            nudgeService()
+        }
+    }
+
+    fun clearData() {
+        repository.clearAll()
+    }
+
+    private fun nudgeService() {
+        val intent = Intent(context, ChargeSessionService::class.java).setAction(ChargeSessionService.ACTION_MONITOR)
+        ContextCompat.startForegroundService(context, intent)
+    }
+
+    private companion object {
+        const val STOP_TIMEOUT_MILLIS = 5_000L
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -462,4 +462,44 @@
     <string name="widget_label_adaptive">Adaptive charging</string>
     <string name="widget_label_pause_at_full">Pause at full charge</string>
     <string name="widget_label_tap">Tap to set a limit</string>
+
+    <!-- Battery statistics -->
+    <string name="settings_stats_title">Battery statistics</string>
+    <string name="settings_stats_subtitle">Detailed charge history, speed, and temperature</string>
+    <string name="stats_title">Battery statistics</string>
+    <string name="stats_capture_title">Record statistics</string>
+    <string name="stats_capture_subtitle">Records each charge in detail — level, charging speed, and temperature over time. While on, Amply keeps a permanent notification and runs continuously; you can turn it off any time.</string>
+    <string name="stats_capture_last_recorded">Last recorded %1$s</string>
+    <string name="stats_capture_never">not yet — recording starts on your next charge</string>
+    <string name="stats_sessions_header">Charge sessions</string>
+    <string name="stats_empty">No charge sessions recorded yet. Plug in while recording is on to capture one.</string>
+    <string name="stats_clear_action">Clear statistics data</string>
+    <string name="stats_clear_confirm_title">Clear statistics?</string>
+    <string name="stats_clear_confirm_message">This permanently deletes all recorded charge sessions from this device. This can\'t be undone.</string>
+    <string name="stats_clear_confirm_positive">Clear</string>
+    <string name="stats_action_cancel">Cancel</string>
+    <string name="stats_session_partial">Partial</string>
+    <string name="stats_session_limit_likely">Limit likely reached</string>
+    <string name="stats_detail_title">Charge session</string>
+    <string name="stats_detail_curve_title">Charge curve</string>
+    <string name="stats_curve_empty">No curve data for this session</string>
+    <string name="stats_curve_series_percent">Level</string>
+    <string name="stats_curve_series_power">Power</string>
+    <string name="stats_curve_series_temperature">Temperature</string>
+    <string name="stats_detail_level">Level</string>
+    <string name="stats_detail_duration">Duration</string>
+    <string name="stats_detail_charging_type">Connection</string>
+    <string name="stats_detail_avg_power">Average power</string>
+    <string name="stats_detail_peak_power">Peak power</string>
+    <string name="stats_detail_temperature">Temperature range</string>
+    <string name="stats_detail_limit_likely">Limit likely reached</string>
+    <string name="stats_detail_partial_note">This session is partial: recording started mid-charge, or was interrupted by a restart or reboot, so its duration and curve may be incomplete.</string>
+    <string name="stats_value_yes">Yes</string>
+    <string name="stats_value_no">No</string>
+    <string name="stats_charging_type_ac">AC charger</string>
+    <string name="stats_charging_type_usb">USB</string>
+    <string name="stats_charging_type_wireless">Wireless</string>
+    <string name="stats_charging_type_dock">Dock</string>
+    <string name="stats_charging_type_mixed">Mixed</string>
+    <string name="stats_charging_type_unknown">Unknown</string>
 </resources>

--- a/app/src/test/java/eu/darken/amply/monitor/core/ChargeMonitorWatcherGraphTest.kt
+++ b/app/src/test/java/eu/darken/amply/monitor/core/ChargeMonitorWatcherGraphTest.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import dagger.hilt.components.SingletonComponent
 import eu.darken.amply.alarm.core.ChargeAlarmWatcher
+import eu.darken.amply.stats.core.ChargeStatsWatcher
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import org.junit.Rule
@@ -47,5 +48,17 @@ class ChargeMonitorWatcherGraphTest {
 
         watchers.map { it.id } shouldContain "charge_alarm"
         watchers.any { it is ChargeAlarmWatcher } shouldBe true
+    }
+
+    @Test
+    fun `the battery stats watcher is bound into the monitor watcher set`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val watchers = EntryPointAccessors.fromApplication(
+            context,
+            WatcherEntryPoint::class.java,
+        ).watchers()
+
+        watchers.map { it.id } shouldContain "battery_stats"
+        watchers.any { it is ChargeStatsWatcher } shouldBe true
     }
 }

--- a/app/src/test/java/eu/darken/amply/stats/core/StatsCadenceTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/StatsCadenceTest.kt
@@ -1,0 +1,57 @@
+package eu.darken.amply.stats.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class StatsCadenceTest {
+
+    @Test
+    fun `first sample of a session always records`() {
+        StatsCadence.shouldRecord(
+            lastRecordedElapsedMillis = null,
+            nowElapsedMillis = 10_000,
+            lastRecordedPercent = null,
+            currentPercent = 50,
+        ) shouldBe true
+    }
+
+    @Test
+    fun `within the interval and no percent change does not record`() {
+        StatsCadence.shouldRecord(
+            lastRecordedElapsedMillis = 100_000,
+            nowElapsedMillis = 105_000,
+            lastRecordedPercent = 50,
+            currentPercent = 50,
+        ) shouldBe false
+    }
+
+    @Test
+    fun `elapsed interval reached records`() {
+        StatsCadence.shouldRecord(
+            lastRecordedElapsedMillis = 100_000,
+            nowElapsedMillis = 100_000 + StatsCadence.CHARGING_MIN_INTERVAL_MILLIS,
+            lastRecordedPercent = 50,
+            currentPercent = 50,
+        ) shouldBe true
+    }
+
+    @Test
+    fun `percent change records even within the interval`() {
+        StatsCadence.shouldRecord(
+            lastRecordedElapsedMillis = 100_000,
+            nowElapsedMillis = 102_000,
+            lastRecordedPercent = 50,
+            currentPercent = 51,
+        ) shouldBe true
+    }
+
+    @Test
+    fun `backwards elapsed jump records rather than starving the curve`() {
+        StatsCadence.shouldRecord(
+            lastRecordedElapsedMillis = 100_000,
+            nowElapsedMillis = 90_000,
+            lastRecordedPercent = 50,
+            currentPercent = 50,
+        ) shouldBe true
+    }
+}

--- a/app/src/test/java/eu/darken/amply/stats/core/StatsDownsamplerTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/StatsDownsamplerTest.kt
@@ -1,0 +1,30 @@
+package eu.darken.amply.stats.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class StatsDownsamplerTest {
+
+    @Test
+    fun `lists at or below the cap are returned unchanged`() {
+        val points = (1..10).toList()
+        StatsDownsampler.decimate(points, 10) shouldBe points
+        StatsDownsampler.decimate(points, 20) shouldBe points
+    }
+
+    @Test
+    fun `decimation keeps first and last and respects the cap`() {
+        val points = (0..999).toList()
+        val result = StatsDownsampler.decimate(points, 100)
+        result.size shouldBe 100
+        result.first() shouldBe 0
+        result.last() shouldBe 999
+    }
+
+    @Test
+    fun `degenerate caps are handled`() {
+        val points = (0..50).toList()
+        StatsDownsampler.decimate(points, 1) shouldBe points
+        StatsDownsampler.decimate(points, 0) shouldBe points
+    }
+}

--- a/app/src/test/java/eu/darken/amply/stats/core/StatsLimitHitDetectorTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/StatsLimitHitDetectorTest.kt
@@ -1,0 +1,58 @@
+package eu.darken.amply.stats.core
+
+import android.os.BatteryManager
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class StatsLimitHitDetectorTest {
+
+    @Test
+    fun `unplugged is never a limit hold`() {
+        StatsLimitHitDetector.heldNow(
+            plugged = false,
+            chargingStatus = StatsLimitHitDetector.HARDWARE_HOLD_STATE,
+            batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+            percent = 80,
+        ) shouldBe false
+    }
+
+    @Test
+    fun `hardware hold state signals a limit`() {
+        StatsLimitHitDetector.heldNow(
+            plugged = true,
+            chargingStatus = StatsLimitHitDetector.HARDWARE_HOLD_STATE,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            percent = 80,
+        ) shouldBe true
+    }
+
+    @Test
+    fun `not-charging below full is a heuristic hold`() {
+        StatsLimitHitDetector.heldNow(
+            plugged = true,
+            chargingStatus = 0,
+            batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+            percent = 80,
+        ) shouldBe true
+    }
+
+    @Test
+    fun `not-charging at full is not a hold`() {
+        StatsLimitHitDetector.heldNow(
+            plugged = true,
+            chargingStatus = 0,
+            batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+            percent = 100,
+        ) shouldBe false
+    }
+
+    @Test
+    fun `plain charging is not a hold`() {
+        StatsLimitHitDetector.heldNow(
+            plugged = true,
+            chargingStatus = 0,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            percent = 50,
+        ) shouldBe false
+    }
+}

--- a/app/src/test/java/eu/darken/amply/stats/core/StatsPowerCalculatorTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/StatsPowerCalculatorTest.kt
@@ -1,0 +1,47 @@
+package eu.darken.amply.stats.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class StatsPowerCalculatorTest {
+
+    @Test
+    fun `computes battery power in milliwatts from mV and uA`() {
+        // 4000 mV * 2_000_000 uA = 8 W = 8000 mW
+        StatsPowerCalculator.milliwatts(4000, 2_000_000) shouldBe 8000
+    }
+
+    @Test
+    fun `current magnitude is used so discharge sign does not matter`() {
+        StatsPowerCalculator.milliwatts(4000, -2_000_000) shouldBe 8000
+    }
+
+    @Test
+    fun `null inputs yield null`() {
+        StatsPowerCalculator.milliwatts(null, 1_000_000) shouldBe null
+        StatsPowerCalculator.milliwatts(4000, null) shouldBe null
+    }
+
+    @Test
+    fun `non-positive voltage is rejected`() {
+        StatsPowerCalculator.milliwatts(0, 1_000_000) shouldBe null
+        StatsPowerCalculator.milliwatts(-10, 1_000_000) shouldBe null
+    }
+
+    @Test
+    fun `implausible OEM current is rejected rather than poisoning the average`() {
+        // A device reporting current in mA instead of uA would look like ~1000x too much power.
+        StatsPowerCalculator.milliwatts(4000, 2_000_000_0 /* 20 A in uA-ish scale */).let {
+            // 4000mV * 20_000_000uA = 80W = 80000mW, still under cap
+            it shouldBe 80000
+        }
+        // 4000 mV * 100_000_000 (bad units) = 400 W > cap → null
+        StatsPowerCalculator.milliwatts(4000, 100_000_000) shouldBe null
+    }
+
+    @Test
+    fun `long math avoids int overflow`() {
+        // 4300 * 3_000_000 = 12_900_000_000 which overflows Int; result 12_900 mW.
+        StatsPowerCalculator.milliwatts(4300, 3_000_000) shouldBe 12_900
+    }
+}

--- a/app/src/test/java/eu/darken/amply/stats/core/StatsSessionEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/StatsSessionEngineTest.kt
@@ -1,0 +1,153 @@
+package eu.darken.amply.stats.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class StatsSessionEngineTest {
+
+    private fun sample(
+        elapsed: Long,
+        wall: Long = elapsed,
+        plugged: Boolean = true,
+        percent: Int? = 50,
+        power: Int? = null,
+        temp: Int? = null,
+        full: Boolean = false,
+        override: Boolean = false,
+        limit: Boolean = false,
+    ) = StatsSample(
+        elapsedRealtimeMillis = elapsed,
+        wallMillis = wall,
+        bootId = 1,
+        plugged = plugged,
+        pluggedRaw = if (plugged) 1 else 0,
+        percent = percent,
+        batteryStatus = null,
+        chargingStatus = null,
+        temperatureTenthsC = temp,
+        voltageMillivolts = null,
+        currentNowMicroamps = null,
+        powerMilliwatts = power,
+        full = full,
+        overrideActive = override,
+        limitHeldNow = limit,
+    )
+
+    @Test
+    fun `unplugged with no open session is ignored`() {
+        StatsSessionEngine.decide(false, previousPlugged = false, plugged = false, recordDue = true) shouldBe
+            StatsTransition.Ignore
+    }
+
+    @Test
+    fun `clean start after an unplugged tick is not partial`() {
+        StatsSessionEngine.decide(false, previousPlugged = false, plugged = true, recordDue = true) shouldBe
+            StatsTransition.Open(partial = false)
+    }
+
+    @Test
+    fun `first-ever tick already plugged is a partial start`() {
+        StatsSessionEngine.decide(false, previousPlugged = null, plugged = true, recordDue = true) shouldBe
+            StatsTransition.Open(partial = true)
+    }
+
+    @Test
+    fun `plugged with an open session appends, gated by record`() {
+        StatsSessionEngine.decide(true, previousPlugged = true, plugged = true, recordDue = false) shouldBe
+            StatsTransition.Append(record = false)
+        StatsSessionEngine.decide(true, previousPlugged = true, plugged = true, recordDue = true) shouldBe
+            StatsTransition.Append(record = true)
+    }
+
+    @Test
+    fun `unplugging an open session seals it`() {
+        StatsSessionEngine.decide(true, previousPlugged = true, plugged = false, recordDue = true) shouldBe
+            StatsTransition.Seal(StatsSealReason.UNPLUGGED)
+    }
+
+    @Test
+    fun `starting already full marks the session partial`() {
+        val opened = StatsSessionEngine.open(sample(elapsed = 0, percent = 100, full = true), partial = false)
+        opened.partial shouldBe true
+        opened.fullReachedAtWallMillis shouldBe 0L
+    }
+
+    @Test
+    fun `time-weighted average reflects step durations, not sample count`() {
+        // 1000 mW for 10s, 2000 mW for 10s, 3000 mW for 10s → time-weighted mean = 2000 mW.
+        var s = StatsSessionEngine.open(sample(elapsed = 0, power = 1000), partial = false)
+        s = StatsSessionEngine.fold(s, sample(elapsed = 10_000, power = 2000))
+        s = StatsSessionEngine.fold(s, sample(elapsed = 20_000, power = 3000))
+        val sealed = StatsSessionEngine.seal(
+            s,
+            StatsSealReason.UNPLUGGED,
+            endWallMillis = 30_000,
+            endElapsedMillis = 30_000,
+            endPercent = 90,
+        )
+        sealed.avgPowerMilliwatts shouldBe 2000
+        sealed.runningPeakPowerMilliwatts shouldBe 3000
+        sealed.endPercent shouldBe 90
+        sealed.endReason shouldBe StatsSealReason.UNPLUGGED.name
+    }
+
+    @Test
+    fun `a single-sample session averages to that sample`() {
+        val s = StatsSessionEngine.open(sample(elapsed = 0, power = 1500, temp = 250), partial = false)
+        val sealed = StatsSessionEngine.seal(
+            s,
+            StatsSealReason.UNPLUGGED,
+            endWallMillis = 0,
+            endElapsedMillis = 0,
+            endPercent = 42,
+        )
+        sealed.avgPowerMilliwatts shouldBe 1500
+        sealed.avgTemperatureTenthsC shouldBe 250
+    }
+
+    @Test
+    fun `absent power leaves that interval uncredited`() {
+        // 2000 mW for 10s, then a gap with no power reading, then unplug.
+        var s = StatsSessionEngine.open(sample(elapsed = 0, power = 2000), partial = false)
+        s = StatsSessionEngine.fold(s, sample(elapsed = 10_000, power = null))
+        val sealed = StatsSessionEngine.seal(
+            s,
+            StatsSealReason.UNPLUGGED,
+            endWallMillis = 20_000,
+            endElapsedMillis = 20_000,
+            endPercent = 60,
+        )
+        // Only the first 10s (at 2000 mW) is credited; the null-power tail contributes nothing.
+        sealed.avgPowerMilliwatts shouldBe 2000
+    }
+
+    @Test
+    fun `recovery seal marks the session partial`() {
+        val s = StatsSessionEngine.open(sample(elapsed = 0, power = 1000), partial = false)
+        val sealed = StatsSessionEngine.seal(
+            s,
+            StatsSealReason.INTERRUPTED,
+            endWallMillis = 5_000,
+            endElapsedMillis = 5_000,
+            endPercent = 55,
+        )
+        sealed.partial shouldBe true
+    }
+
+    @Test
+    fun `override and limit evidence latch across folds`() {
+        var s = StatsSessionEngine.open(sample(elapsed = 0, limit = true), partial = false)
+        s = StatsSessionEngine.fold(s, sample(elapsed = 10_000, limit = false, override = true))
+        s = StatsSessionEngine.fold(s, sample(elapsed = 20_000))
+        s.limitHitEvidence shouldBe true
+        s.overrideSeen shouldBe true
+    }
+
+    @Test
+    fun `a doze gap is clamped so it cannot overweight one reading`() {
+        // 1000 mW then a 1-hour gap: only MAX_WEIGHT_GAP_MILLIS of it is credited.
+        var s = StatsSessionEngine.open(sample(elapsed = 0, power = 1000), partial = false)
+        s = StatsSessionEngine.fold(s, sample(elapsed = 3_600_000, power = 1000))
+        s.runningPowerWeightedDurationMillis shouldBe StatsSessionEngine.MAX_WEIGHT_GAP_MILLIS
+    }
+}

--- a/app/src/test/java/eu/darken/amply/stats/core/db/StatsDaoTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/db/StatsDaoTest.kt
@@ -1,0 +1,101 @@
+package eu.darken.amply.stats.core.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * DAO round-trip + FK/retention behavior on an in-memory Room instance. Robolectric (JUnit 4) per the
+ * project's convention for anything needing the Android framework.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class StatsDaoTest {
+
+    private lateinit var database: StatsDatabase
+    private lateinit var dao: StatsDao
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, StatsDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = database.statsDao()
+    }
+
+    @After
+    fun teardown() {
+        database.close()
+    }
+
+    private fun openSession(startWall: Long = 1_000L) = ChargeSessionEntity(
+        startedAtWallMillis = startWall,
+        startedElapsedRealtimeMillis = startWall,
+        bootId = 7,
+        startPercent = 40,
+    )
+
+    @Test
+    fun `open session is listed as open and excluded from finished`() = runTest {
+        val id = dao.insertSession(openSession())
+        dao.openSessions().map { it.id } shouldBe listOf(id)
+        dao.finishedSessions(10).first() shouldBe emptyList()
+    }
+
+    @Test
+    fun `sealed session appears in finished, not open`() = runTest {
+        val id = dao.insertSession(openSession())
+        val sealed = dao.sessionById(id)!!.copy(endedAtWallMillis = 5_000L, endedElapsedRealtimeMillis = 5_000L)
+        dao.updateSession(sealed)
+        dao.openSessions() shouldBe emptyList()
+        dao.finishedSessions(10).first().map { it.id } shouldBe listOf(id)
+    }
+
+    @Test
+    fun `deleting a session cascades to its samples`() = runTest {
+        val id = dao.insertSession(openSession())
+        dao.insertSample(sample(id, wall = 1_100L))
+        dao.insertSample(sample(id, wall = 1_200L))
+        dao.samplesForSessionNow(id).size shouldBe 2
+
+        dao.deleteAllSessions()
+        dao.samplesForSessionNow(id) shouldBe emptyList()
+    }
+
+    @Test
+    fun `retention only purges old samples of closed sessions`() = runTest {
+        val closedId = dao.insertSession(openSession(startWall = 1_000L))
+        dao.updateSession(dao.sessionById(closedId)!!.copy(endedAtWallMillis = 2_000L, endedElapsedRealtimeMillis = 2_000L))
+        dao.insertSample(sample(closedId, wall = 1_000L)) // old
+        dao.insertSample(sample(closedId, wall = 9_000L)) // recent
+
+        val openId = dao.insertSession(openSession(startWall = 1_000L))
+        dao.insertSample(sample(openId, wall = 1_000L)) // old but session still open
+
+        val deleted = dao.deleteSamplesOlderThan(cutoffWallMillis = 5_000L)
+        deleted shouldBe 1
+        dao.samplesForSessionNow(closedId).map { it.wallMillis } shouldBe listOf(9_000L)
+        // The open session's old sample is retained (its summary isn't finalized yet).
+        dao.samplesForSessionNow(openId).map { it.wallMillis } shouldBe listOf(1_000L)
+    }
+
+    private fun sample(sessionId: Long, wall: Long) = BatterySampleEntity(
+        sessionId = sessionId,
+        wallMillis = wall,
+        elapsedRealtimeMillis = wall,
+        bootId = 7,
+        percent = 50,
+        powerMilliwatts = 10_000,
+        temperatureTenthsC = 300,
+    )
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -73,6 +73,14 @@ fun DependencyHandlerScope.addDataStore() {
     implementation("androidx.datastore:datastore-preferences:1.2.0")
 }
 
+fun DependencyHandlerScope.addRoom() {
+    implementation("androidx.room:room-runtime:${Versions.Room.core}")
+    implementation("androidx.room:room-ktx:${Versions.Room.core}")
+    ksp("androidx.room:room-compiler:${Versions.Room.core}")
+    // In-memory Room for DAO/migration tests (Robolectric, JUnit 4 lane).
+    testImplementation("androidx.room:room-testing:${Versions.Room.core}")
+}
+
 fun DependencyHandlerScope.addGlance() {
     implementation("androidx.glance:glance-appwidget:${Versions.Glance.core}")
     implementation("androidx.glance:glance-material3:${Versions.Glance.core}")

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -15,6 +15,10 @@ object Versions {
         const val lifecycle = "2.10.0"
     }
 
+    object Room {
+        const val core = "2.7.1"
+    }
+
     object Navigation3 {
         const val core = "1.0.1"
     }


### PR DESCRIPTION
## What changed

Adds a new **opt-in Battery statistics** feature (Settings → Battery statistics, **off by default**). When enabled, Amply records each charge session in detail and shows a history list; tapping a session opens a curve of battery **level, charging power, and temperature over time**, plus average/peak power, temperature range, connection type (AC/USB/wireless/dock), and a *"limit likely reached"* indicator. Turning it on keeps Amply's existing monitor notification up continuously while it records — this is stated in the toggle copy and it can be turned off any time. All data is stored locally with a **Clear statistics data** action.

For non-user-facing reviewers: this is phase 1 (charge-session capture). Discharge tracking, battery-health trends, and a dashboard card are planned additive follow-ups (P2/P3) within this feature, not part of this PR.

## Technical Context

**Integration & safety boundary**
- Rides the existing `ChargeMonitorWatcher` `@IntoSet` seam. `ChargeSessionService` is unchanged except its watcher tick now carries the *evaluated* battery intent + observation timing. **No changes** to the privileged charge-control paths, AIDL, `SettingWritePolicy`, or capability gates — stats is a read-only observer of public battery state.
- The stats watcher's `onBatteryTick` does **no blocking work** — it only copies a `RawStatsTick` and enqueues it. All enrichment (intent parse, live `BatteryManager` property reads, boot id) and all Room I/O happen on a dedicated serialized IO recorder, entirely off the service's `commandMutex`, so a slow read/write can never delay the safety-critical policy restore.

**Data model**
- New Room DB `stats.db` (schema v1 = `charge_sessions` + `battery_samples`) — the app's first Room dependency; schema is exported and committed (`app/schemas/`) so P2/P3 land as tested additive migrations.
- Session summaries are accumulated **online** with a time-weighted (left-Riemann, max-gap-clamped) scheme, so retention can purge raw samples without corrupting a finished summary and a very long session never triggers an unbounded close-time scan. Raw samples older than 30 days are purged at seal time.
- A session is a whole plug→unplug cycle; reaching 100% is recorded (`fullReachedAt`), not a session end, so being held at full by an OEM limiter doesn't fragment it. Process death / reboot **seal** any dangling session (never resumed → no post-reboot negative durations) and mark it *partial*. Disable seals the open session via an ordered recorder command; a crash-before-disable is repaired on the next process startup.
- Power is battery-terminal `mV × |µA|` in `Long` with a plausibility cap; the limit-hit signal is the Pixel hardware-hold state with a generic `NOT_CHARGING`-below-full fallback, surfaced as "likely" rather than asserted.

**UI / wiring**
- State-hoisted, previewable screens; enabling routes through the existing notification-permission flow (`NotificationAction.ENABLE_STATS`) because always-on capture shows the persistent notification. Curve rendering decimates in-memory (API-26-safe, no SQL window functions). Charts are hand-drawn Compose `Canvas` (no new charting dependency).
- `specialUse` FGS subtype text updated to declare the continuous charge-session recording use case.

**Tests / review**
- Pure JVM engines (segmentation incl. aggregation math, cadence, power, limit-hit, downsampler), a Robolectric Room DAO round-trip/retention/cascade test, and a watcher-graph binding assertion. Full suite (750 tests) + both-flavor assemble + all four `lintVital` variants pass.
- Reviewed by Codex (xhigh); all 7 findings addressed — notably moving all I/O off the service mutex, ordered enable/disable with startup repair for the crash-before-disable case, and seal-time retention.

## Draft — outstanding before ready
Manual on-device pass (I don't have an assigned device in this session): enable/disable while charging, force-stop and reboot mid-charge, and a run alongside a live full-charge session on a gated Pixel. Record results before marking ready.