### PR TITLE
Charging: Add LineageOS charge-control adapter (diagnostics-only)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,16 +8,21 @@ Amply is an **experimental Android controller for OEM battery charge-protection 
 temporarily allows a full charge, then restores the user's protective policy at 100%, on unplug, or at a safety
 timeout.
 
-Three control adapters exist. **Pixel charging optimization** is capability-gated to Pixel 6a and newer phones on
+Several control adapters exist — four OEM adapters plus a custom-ROM (LineageOS) adapter. **Pixel charging optimization** is capability-gated to Pixel 6a and newer phones on
 Android 15+ when Google's charging-optimization controller is present. **Samsung battery protection** (global
 `protect_battery` keys) is gated to verified One UI generations — One UI 8 multi-mode, and the legacy One UI 4/5
 toggle — on the system user. **Xiaomi charging protection** (secure `security_pc_secure_protect_mode_key`,
 binary Adaptive/Unrestricted) is gated to the HyperOS 2.x ROM (`ro.mi.os.version.code == 2`) on Xiaomi devices.
 **OnePlus/ColorOS charging protection** (mutually-exclusive `system` keys `regular_/smart_charge_protection_switch_state`
 = FixedLimit(80)/Adaptive) is gated to ColorOS 15 (`ro.build.version.oplusrom == 15`) across the Oplus family
-(OnePlus/Oppo/Realme) — **writes require Shizuku** (system namespace). Other Pixels, Samsung on unverified One UI
-versions (6/7, 9+), non-HyperOS-2 Xiaomi devices, and non-ColorOS-15 Oplus devices remain diagnostics-only. See the
-qualification ledger in `.claude/rules/privileged-access.md` for the verified devices and mappings.
+(OnePlus/Oppo/Realme) — **writes require Shizuku** (system namespace). **LineageOS charging control** (the private
+`lineagesettings` provider, keys `charging_control_enabled`/`_mode`/`_charging_limit`) is manufacturer-agnostic —
+gated to a **physically-qualified device-codename allowlist** (HAL enforcement is per-device) plus the provider and
+system user; **reads are unprivileged (ContentResolver), writes require Shizuku** (the shell UID holds
+`lineageos.permission.WRITE_SETTINGS`, which `WRITE_SECURE_SETTINGS` does not cover). Other Pixels, Samsung on
+unverified One UI versions (6/7, 9+), non-HyperOS-2 Xiaomi devices, non-ColorOS-15 Oplus devices, and unqualified
+LineageOS builds remain diagnostics-only. See the qualification ledger in `.claude/rules/privileged-access.md` for
+the verified devices and mappings.
 
 Package: `eu.darken.amply`. License: GPL-3.0-or-later. Status: pre-launch (`0.1.0-beta1`).
 

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -14,7 +14,7 @@ project's convention. Code is grouped by **feature**, not framework layer.
 eu.darken.amply
 ├── charging/core            policies, capability gate, OEM adapters, WSS + Shizuku access
 │   ├── access/shizuku       Shizuku detection, user-service client, AIDL boundary
-│   └── adapter              AdapterRegistry + per-OEM adapters (Pixel, Samsung, Xiaomi, OnePlus/ColorOS live)
+│   └── adapter              AdapterRegistry + adapters (Pixel, Samsung, Xiaomi, OnePlus/ColorOS, LineageOS live)
 ├── fullcharge/core          temporary session, boot recovery, reconnect gesture, decision engines
 ├── diagnostics/core + ui    "Help add support" contribution wizard: read-only multi-mode setting discovery + on-device privacy review
 ├── main
@@ -102,6 +102,33 @@ override = Unrestricted; protective default = FixedLimit(80). **Writes require S
 namespace, which WRITE_SECURE_SETTINGS cannot write (reads are unprivileged); the adapter sets
 `preferShizukuForWrites`. Unqualified Oplus versions fall to `OnePlusLabAdapter`. Enforcement is directly
 observable (device holds at 80%). See the qualification ledger in `privileged-access.md`.
+
+## LineageOS Adapter
+
+One live adapter (`lineageos-chargingcontrol-v1`) plus a `LineageLabAdapter`, for LineageOS's native Charging
+Control. **Manufacturer-agnostic** — the ROM changes charging control regardless of the OEM hardware — so both are
+registered **first** in `AdapterRegistry`, ahead of every OEM adapter; a LineageOS build on Samsung/Xiaomi/OnePlus/
+Pixel hardware is handled by these, never the OEM lab adapters (stock devices have `lineageOsVersion == null` and
+skip both). Gate: `ro.lineage.build.version` present + `Build.DEVICE` in a **physically-qualified codename
+allowlist** (`QUALIFIED_CODENAMES`) + `lineagesettings` provider present + system user. Unqualified LineageOS builds
+fall to `LineageLabAdapter`.
+
+The three keys live in the private `content://lineagesettings/system` provider (`SettingNamespace.LINEAGE_SYSTEM`),
+NOT any AOSP `settings` namespace: `charging_control_enabled` (0/1), `charging_control_mode` (3=LIMIT), and
+`charging_control_charging_limit` (the discrete ticks 70/75/80/85/90/95). A hard cap is `enabled=1`+`mode=3`+`limit=N`;
+`enabled=0` is Unrestricted. Writes are ordered limit→mode→enabled (the observable "on" flip last). **Reads are
+unprivileged** (`LineageSettingsClient` via ContentResolver, shared by both backends); **writes require Shizuku**
+(`content insert`; the shell UID holds `lineageos.permission.WRITE_SETTINGS`, which `WRITE_SECURE_SETTINGS` cannot
+cover — `preferShizukuForWrites`, and the WSS auto-grant is skipped). `SYNC_READBACK` with read-back equality;
+session override = Unrestricted; protective default = FixedLimit(80); reconnect gesture unsupported.
+
+LineageOS's own `ChargingControlController` observes these keys and re-drives the `vendor.lineage.health.
+IChargingControl` HAL, so an external write is honored. But the HAL is **device-dependent** (the setting can flip
+while charging never actually stops — the `mIsLimitSet:false` bug), which is why the gate is a qualified-codename
+allowlist and control ships disabled until a codename is physically proven. `read()` returns `Verified` **only** for
+states v1 can restore exactly (a supported fixed limit, or Unrestricted); AUTO/CUSTOM schedules, off-tick limits, and
+an absent/malformed `enabled` decode to `Unknown(unrecognizedValue=true)` so a temporary session refuses rather than
+clobbering the user's native choice. Verified devices + coverage: see the qualification ledger in `privileged-access.md`.
 
 ## Pixel Adapter
 

--- a/.claude/rules/privileged-access.md
+++ b/.claude/rules/privileged-access.md
@@ -83,6 +83,31 @@ assumptions: the feature is treated as present on any HyperOS 2 device (a device
 absent → a harmless false claim of control), and daemon-level enforcement of external writes is pending
 long-term observation (see Known gaps below).
 
+### LineageOS
+
+LineageOS control requires **all** of: LineageOS (`ro.lineage.build.version` present), a **physically-qualified
+device codename** (`Build.DEVICE` ∈ `LineageChargingAdapter.QUALIFIED_CODENAMES`), the `lineagesettings` provider
+present, and the system user. It is **manufacturer-agnostic** (LineageOS runs on many OEMs), so the Lineage
+live/lab adapters are ordered **before all OEM adapters** in `AdapterRegistry` — a LineageOS build on Samsung/
+Xiaomi/OnePlus hardware must never be swallowed by a manufacturer-based lab adapter. Unqualified LineageOS builds
+fall to `LineageLabAdapter` (diagnostics/contribution).
+
+The three keys live in the private `content://lineagesettings/system` provider — **NOT** any AOSP `settings`
+namespace. Modeled as `SettingNamespace.LINEAGE_SYSTEM`: **reads are unprivileged** (`LineageSettingsClient`,
+ContentResolver — the provider declares no readPermission), **writes require Shizuku** (`content insert`, the shell
+UID holds `lineageos.permission.WRITE_SETTINGS`; `WRITE_SECURE_SETTINGS` cannot write it). The adapter sets
+`preferShizukuForWrites`, and `AutoWssGrantCoordinator` skips the WSS auto-grant for it (WSS is useless here).
+Writable keys/domains (`LineageSettingWritePolicy`, independent of the adapter): `charging_control_enabled` ∈
+{0,1}, `charging_control_mode` = 3 (LIMIT only; mode 0 is invalid, disabling is via enabled=0), and
+`charging_control_charging_limit` ∈ {70,75,80,85,90,95}. Verification is `SYNC_READBACK` (read-back equality).
+
+**Crucial gate rationale:** the setting can be written while the `vendor.lineage.health.IChargingControl` HAL never
+actually limits (the `mIsLimitSet:false` class of bug) — setting readback does **not** prove hardware enforcement.
+That is why the gate is a qualified-codename allowlist, not "any LineageOS device": a device must be physically
+proven (see the qualification protocol) before its codename is added. The adapter also **refuses** (reads
+`Unknown(unrecognizedValue=true)`) any native state it cannot restore exactly — AUTO/CUSTOM schedule modes, off-tick
+limits, or an absent/malformed `enabled` — so a temporary session never clobbers the user's own choice.
+
 ## Foreground Service Requirement
 
 The temporary override uses a `specialUse` foreground service because dormant apps cannot reliably receive
@@ -137,6 +162,29 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
 
 ## Known gaps
 
+- **LineageOS** — landed **diagnostics-only**: `QUALIFIED_CODENAMES` ships **empty**, so the live adapter never
+  matches and every LineageOS build falls to `LineageLabAdapter`. A codename is added only after that device passes
+  qualification (real charging cessation at the limit, wired + wireless, below/at/above threshold) and gets a
+  "Verified devices" row.
+  - **Pixel 6 (oriole) on LineageOS 20.0 / Android 13 — tested 2026-07-22, result NO-GO (no hardware enforcement).**
+    The *software chain is fully validated* — both raw (shell-UID `content query`/`content insert`) **and through the
+    app's real Shizuku backend end-to-end** (R8 debug build + Shizuku granted): tapping 80 % wrote the trio via
+    `writeLineageSetting` and read back `Verified(FixedLimit(80), SHIZUKU)`. LineageOS's `ChargingControlController`
+    **observes the external write** and updates its live config (`dumpsys lineagehealth` → `mConfigEnabled:true,
+    mConfigMode:3, mConfigLimit:80`); the `vendor.lineage.health.IChargingControl/default` HAL is registered and its
+    service runs. The refuse-don't-clobber decode was also confirmed live: a native `mode=2` (CUSTOM) state read as
+    `Unknown(unrecognized)` ("Policy not verified"), never overwritten. And the diagnostics-only path was smoke-tested
+    (empty allowlist → `lineageos-lab` → "Detected for diagnostics only", no crash). **But the hard percent
+    limit did not cut charging** — with `limit=80` set, the battery charged 92→95 %+ at ~1.2 A (`charge_stage=Inactive`,
+    `charge_limit` sysfs empty, `mChargingStopReason:0`). On Pixel the charge hardware is driven by Google's
+    adaptive/`charge_deadline` mechanism, and this Lineage build's HAL does not map the %-cap to a real cutoff — the
+    `mIsLimitSet:false` device-dependent class of gap. So oriole stays **out** of the allowlist. This is a clean
+    validation of the conservative gate: an "any LineageOS device" gate would have claimed 80 % protection while the
+    phone charged to 100 %. (Qualifying a device with a *working* charge-control HAL remains open; the adapter's
+    provider/observer mechanism is proven, only per-device HAL enforcement varies.)
+  - Also confirmed on oriole: `charging_control_*` keys are **absent in factory state** (validates the conservative
+    "absent → unrecognized" decode). Still open: the provider's change-notification URI form (per-key vs table)
+    against the registered `observedSettingUris`, to be checked on a HAL-enforcing device.
 - **Xiaomi** — adaptive hardware enforcement of external writes unconfirmed; treat the adapter as provisional until
   the 80% hold is physically observed.
 - **Pixel** — wireless at-threshold hold/charge-past and the widget under Shizuku-only remain unexercised (both share

--- a/.claude/rules/privileged-access.md
+++ b/.claude/rules/privileged-access.md
@@ -185,6 +185,19 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
   - Also confirmed on oriole: `charging_control_*` keys are **absent in factory state** (validates the conservative
     "absent → unrecognized" decode). Still open: the provider's change-notification URI form (per-key vs table)
     against the registered `observedSettingUris`, to be checked on a HAL-enforcing device.
+  - **Pixel 6 (oriole) on LineageOS 23.2 / Android 16 — retested 2026-07-22 after an anti-rollback firmware bump,
+    result NO-GO (HAL no longer offers LIMIT mode at all).** A *sharper* root cause than the LOS 20 run: the
+    `vendor.lineage.health.IChargingControl` HAL reports `getSupportedMode()` **without the LIMIT bit**, so
+    `ChargingControlController.isChargingModeSupported(LIMIT)` is false and LineageOS **coerces `charging_control_mode=3`
+    → `1` (AUTO)** — verified live: every raw shell-UID `content insert` of `mode=3` (even while `enabled=0`) read back
+    as `1`. Enabling then logs `LineageHealth: No alarm found, auto charging control has no effect` and `Setting charge
+    deadline: … 73353`; the active provider is `ccprovider.Deadline` (Google Adaptive Charging — time/alarm-based, **no
+    fixed-percent cap**). `charging_policy`/`charge_stage` sysfs never changed. So oriole is NO-GO on **both** builds for
+    different reasons: LOS 20 *accepted* LIMIT but the HAL silently didn't cut; LOS 23.2's HAL dropped LIMIT and falls
+    back to the Deadline mechanism. Consequence for the adapter (unchanged — correct by design): SYNC_READBACK
+    `apply(FixedLimit)` writes `mode=3`, reads back `mode=1 ≠ 3` → decodes `Unknown(unrecognizedValue=true)` → `apply`
+    returns false, so it **refuses without a false claim of control**. Reinforces the allowlist bar: a device must both
+    expose the LIMIT mode bit **and** actually cut charging. `charging_control_*` again **absent in factory state**.
 - **Xiaomi** — adaptive hardware enforcement of external writes unconfirmed; treat the adapter as provisional until
   the 80% hold is physically observed.
 - **Pixel** — wireless at-threshold hold/charge-past and the widget under Shizuku-only remain unexercised (both share

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ control can write Pixel's hidden values but Android blocks direct third-party re
 public charging-hardware state; Shizuku provides exact configured-setting readback while it is running. On tested
 Pixels, Google's policy worker takes roughly 10–15 seconds to propagate a setting change to the charging HAL.
 
+The required access path is adapter-dependent: some devices (OnePlus/Oppo/Realme on ColorOS, and LineageOS) keep their
+setting in a namespace that `WRITE_SECURE_SETTINGS` cannot write, so control there **requires Shizuku** — the ADB grant
+alone won't be enough, and the dashboard surfaces this. The relevant dashboard card guides you to the option your
+device needs.
+
 ## License
 
 Amply's code is available under a GPL v3 license, this excludes:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,9 @@
     <queries>
         <package android:name="moe.shizuku.privileged.api" />
         <package android:name="com.google.android.settings.intelligence" />
+        <!-- LineageOS private settings provider — needed so resolveContentProvider/query aren't
+             hidden by package visibility on API 30+ (the Lineage charge-control adapter reads it). -->
+        <provider android:authorities="lineagesettings" />
         <intent>
             <action android:name="android.settings.BATTERY_SAVER_SETTINGS" />
         </intent>

--- a/app/src/main/aidl/eu/darken/amply/charging/core/access/shizuku/IChargingControlService.aidl
+++ b/app/src/main/aidl/eu/darken/amply/charging/core/access/shizuku/IChargingControlService.aidl
@@ -5,5 +5,9 @@ interface IChargingControlService {
     boolean writeSetting(String namespace, String key, String value) = 2;
     boolean grantWriteSecureSettings(String packageName) = 3;
     String snapshotSettings(String namespace) = 4;
+    // LineageOS charging control lives in a separate provider (content://lineagesettings/system) that
+    // /system/bin/settings cannot write. Dedicated op: `content insert` (Shizuku shell UID holds the
+    // Lineage write permission). Reads are unprivileged (LineageSettingsClient), so there is no read op.
+    boolean writeLineageSetting(String key, String value) = 5;
     void destroy() = 16777114;
 }

--- a/app/src/main/java/eu/darken/amply/charging/core/DeviceInfo.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/DeviceInfo.kt
@@ -12,12 +12,15 @@ data class DeviceInfo(
     val model: String,
     val sdk: Int,
     val fingerprint: String,
+    val codename: String = "",
     val isPhone: Boolean = true,
     val hasChargingOptimization: Boolean = true,
     val oneUiVersion: Int? = null,
     val hyperOsVersion: Int? = null,
     val oplusRomVersion: Int? = null,
+    val lineageOsVersion: String? = null,
     val hasProtectBattery: Boolean = false,
+    val hasLineageSettingsProvider: Boolean = false,
     val isSystemUser: Boolean = true,
 ) {
     companion object {
@@ -26,6 +29,7 @@ data class DeviceInfo(
             model = Build.MODEL.orEmpty(),
             sdk = Build.VERSION.SDK_INT,
             fingerprint = Build.FINGERPRINT.orEmpty(),
+            codename = Build.DEVICE.orEmpty(),
             isPhone = context?.packageManager?.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)
                 ?: true,
             hasChargingOptimization = context?.let {
@@ -34,9 +38,18 @@ data class DeviceInfo(
             oneUiVersion = OneUiVersionDetector.detect(),
             hyperOsVersion = HyperOsVersionDetector.detect(),
             oplusRomVersion = OplusRomVersionDetector.detect(),
+            lineageOsVersion = LineageOsDetector.detect(),
             hasProtectBattery = context?.let {
                 runCatching {
                     Settings.Global.getString(it.contentResolver, KEY_PROTECT_BATTERY) != null
+                }.getOrDefault(false)
+            } ?: false,
+            // Whether LineageOS's private settings provider is installed (the charge-control settings
+            // surface). Fail closed; requires the <queries> provider entry so package visibility on
+            // API 30+ doesn't false-negative resolution. Provider presence is not HAL-enforcement proof.
+            hasLineageSettingsProvider = context?.let {
+                runCatching {
+                    it.packageManager.resolveContentProvider(LINEAGE_SETTINGS_AUTHORITY, 0) != null
                 }.getOrDefault(false)
             } ?: false,
             // Fail closed: this gates device-wide Samsung writes, so an unresolvable UserManager
@@ -52,5 +65,8 @@ data class DeviceInfo(
 
         // Shared with the Samsung adapters; duplicated here to keep DeviceInfo dependency-free.
         const val KEY_PROTECT_BATTERY = "protect_battery"
+
+        /** Authority of LineageOS's private settings provider (`content://lineagesettings/...`). */
+        const val LINEAGE_SETTINGS_AUTHORITY = "lineagesettings"
     }
 }

--- a/app/src/main/java/eu/darken/amply/charging/core/LineageOsDetector.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/LineageOsDetector.kt
@@ -1,0 +1,16 @@
+package eu.darken.amply.charging.core
+
+/**
+ * Detects LineageOS (and close derivatives that keep the property) from `ro.lineage.build.version`
+ * (e.g. "23.2"). The value is the ROM version string; presence alone is what gates the Lineage
+ * charging-control adapter — the feature has shipped since LineageOS 20 and is not version-scoped.
+ * Null on any failure or non-Lineage device; downstream gates treat null as "not LineageOS".
+ */
+object LineageOsDetector {
+
+    fun detect(): String? = parse(SystemPropertyReader.read(PROPERTY))
+
+    internal fun parse(raw: String?): String? = raw?.trim()?.takeIf { it.isNotEmpty() }
+
+    private const val PROPERTY = "ro.lineage.build.version"
+}

--- a/app/src/main/java/eu/darken/amply/charging/core/access/AccessBackend.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/access/AccessBackend.kt
@@ -7,7 +7,20 @@ enum class SettingNamespace(val commandName: String) {
     SECURE("secure"),
     GLOBAL("global"),
     SYSTEM("system"),
+
+    /**
+     * LineageOS's private settings provider (`content://lineagesettings/system`), which is NOT reachable
+     * via `/system/bin/settings`. [commandName] is a sentinel and is never passed to that CLI — the
+     * backends branch on this value: reads go through [LineageSettingsClient] (unprivileged ContentResolver)
+     * and writes through the dedicated `writeLineageSetting` AIDL op (`/system/bin/content`, Shizuku only).
+     * Deliberately excluded from the contribution wizard's capture set ([STANDARD_SETTINGS_NAMESPACES]).
+     */
+    LINEAGE_SYSTEM("lineage_system"),
 }
+
+/** The three real AOSP `settings` namespaces the contribution wizard snapshots — excludes [SettingNamespace.LINEAGE_SYSTEM]. */
+val STANDARD_SETTINGS_NAMESPACES: List<SettingNamespace> =
+    listOf(SettingNamespace.SECURE, SettingNamespace.GLOBAL, SettingNamespace.SYSTEM)
 
 data class SettingRead(
     val readable: Boolean,

--- a/app/src/main/java/eu/darken/amply/charging/core/access/AutoWssGrantCoordinator.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/access/AutoWssGrantCoordinator.kt
@@ -27,6 +27,7 @@ internal data class AutoWssGrantInputs(
     val controlEnabled: Boolean,
     val shizukuReady: Boolean,
     val wssReady: Boolean,
+    val writeRequiresShizuku: Boolean,
 )
 
 /**
@@ -81,6 +82,7 @@ internal fun autoWssGrantInputs(
         controlEnabled = state.controlEnabled,
         shizukuReady = state.access?.shizuku?.ready == true,
         wssReady = state.access?.direct?.ready == true,
+        writeRequiresShizuku = state.writeRequiresShizuku,
     )
 }.distinctUntilChanged()
     .retryWhen { cause, attempt ->
@@ -120,6 +122,7 @@ internal suspend fun observeAutoWssGrant(
             controlEnabled = input.controlEnabled,
             shizukuReady = input.shizukuReady,
             wssReady = input.wssReady,
+            writeRequiresShizuku = input.writeRequiresShizuku,
             attempted = attempted,
         )
         attempted = outcome.attempted

--- a/app/src/main/java/eu/darken/amply/charging/core/access/AutoWssGrantPolicy.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/access/AutoWssGrantPolicy.kt
@@ -22,14 +22,18 @@ object AutoWssGrantPolicy {
         controlEnabled: Boolean,
         shizukuReady: Boolean,
         wssReady: Boolean,
+        writeRequiresShizuku: Boolean,
         attempted: Boolean,
     ): Outcome = when {
         // Episode over (WSS obtained) or not active (Shizuku not ready): clear the latch so the next
         // Shizuku-ready episode gets a fresh automatic attempt.
         wssReady || !shizukuReady -> Outcome(grant = false, attempted = false)
         // Not eligible to auto-grant yet: before onboarding is accepted we must not grant a system
-        // permission, and a capability-gated device could never use it. Hold the latch unchanged.
-        !onboardingComplete || !controlEnabled -> Outcome(grant = false, attempted = attempted)
+        // permission, a capability-gated device could never use it, and a Shizuku-write adapter
+        // (system/lineagesettings namespace) can never write via WSS — so granting it would be
+        // wasted least-privilege surface. Hold the latch unchanged.
+        !onboardingComplete || !controlEnabled || writeRequiresShizuku ->
+            Outcome(grant = false, attempted = attempted)
         // Already tried this episode: leave it to the manual fallback button.
         attempted -> Outcome(grant = false, attempted = true)
         // First eligible observation of Shizuku-ready-without-WSS: grant once and latch.

--- a/app/src/main/java/eu/darken/amply/charging/core/access/DirectSettingsBackend.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/access/DirectSettingsBackend.kt
@@ -31,11 +31,21 @@ class DirectSettingsBackend @Inject constructor(
         )
     }
 
-    override suspend fun read(namespace: SettingNamespace, key: String): SettingRead = runCatching {
+    override suspend fun read(namespace: SettingNamespace, key: String): SettingRead {
+        // Lineage reads never go through a settings backend — the adapter reads a consistent snapshot via
+        // LineageChargeReader (unprivileged ContentResolver). Guard defensively.
+        if (namespace == SettingNamespace.LINEAGE_SYSTEM) {
+            return SettingRead(readable = false, error = R.string.charging_reason_settings_unreadable.toCaString())
+        }
+        return readAosp(namespace, key)
+    }
+
+    private fun readAosp(namespace: SettingNamespace, key: String): SettingRead = runCatching {
         val value = when (namespace) {
             SettingNamespace.SECURE -> Settings.Secure.getString(context.contentResolver, key)
             SettingNamespace.GLOBAL -> Settings.Global.getString(context.contentResolver, key)
             SettingNamespace.SYSTEM -> Settings.System.getString(context.contentResolver, key)
+            SettingNamespace.LINEAGE_SYSTEM -> error("Lineage reads are handled by LineageSettingsClient")
         }
         SettingRead(readable = true, value = value)
     }.getOrElse {
@@ -49,6 +59,9 @@ class DirectSettingsBackend @Inject constructor(
     }
 
     override suspend fun write(mutation: SettingMutation): Boolean {
+        // WRITE_SECURE_SETTINGS cannot write the Lineage provider (it needs lineageos.permission.WRITE_SETTINGS,
+        // held only by the shell UID) — fail honestly so the adapter falls back to Shizuku.
+        if (mutation.namespace == SettingNamespace.LINEAGE_SYSTEM) return false
         if (!status().ready) return false
         return runCatching {
             when (mutation.namespace) {
@@ -67,6 +80,7 @@ class DirectSettingsBackend @Inject constructor(
                     mutation.key,
                     mutation.value,
                 )
+                SettingNamespace.LINEAGE_SYSTEM -> false // unreachable: early-returned above
             }
         }.getOrDefault(false)
     }

--- a/app/src/main/java/eu/darken/amply/charging/core/access/LineageSettingsClient.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/access/LineageSettingsClient.kt
@@ -1,0 +1,91 @@
+package eu.darken.amply.charging.core.access
+
+import android.content.Context
+import android.net.Uri
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.amply.R
+import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.common.ca.CaString
+import eu.darken.amply.common.ca.toCaString
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** The three LineageOS charge-control values read as ONE consistent snapshot, or a typed failure. */
+sealed interface LineageChargeReadout {
+    /** A single consistent read of all three keys; a null field means that key was absent. */
+    data class Values(val enabled: String?, val mode: String?, val limit: String?) : LineageChargeReadout
+
+    /** Provider/security failure, missing columns, or an unexpected (duplicate) row — never guessed from. */
+    data class Unreadable(val reason: CaString) : LineageChargeReadout
+}
+
+/**
+ * Reads LineageOS's charge-control keys from `content://lineagesettings/system` in a single query, so the
+ * three values are a **consistent snapshot** — separate per-key reads could interleave with an external
+ * change and fabricate a state that never existed. An interface so the adapter is unit-testable without
+ * Android.
+ */
+interface LineageChargeReader {
+    suspend fun readChargeControl(): LineageChargeReadout
+}
+
+/**
+ * Unprivileged ContentResolver implementation of [LineageChargeReader]. Reads carry no permission (the
+ * provider declares no readPermission), so this works regardless of Shizuku/WSS — only *writes* are
+ * privileged (Shizuku, see `ChargingControlUserService.writeLineageSetting`). Requires the
+ * `<queries><provider authorities="lineagesettings"/>` manifest entry so package visibility on API 30+
+ * doesn't hide the provider.
+ */
+@Singleton
+class LineageSettingsClient @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : LineageChargeReader {
+    private val systemUri: Uri = Uri.parse("content://${DeviceInfo.LINEAGE_SETTINGS_AUTHORITY}/system")
+
+    override suspend fun readChargeControl(): LineageChargeReadout = withContext(Dispatchers.IO) {
+        runCatching {
+            context.contentResolver.query(
+                systemUri,
+                arrayOf(COL_NAME, COL_VALUE),
+                "$COL_NAME IN (?,?,?)",
+                arrayOf(KEY_ENABLED, KEY_MODE, KEY_LIMIT),
+                null,
+            )?.use { cursor ->
+                val nameIdx = cursor.getColumnIndex(COL_NAME)
+                val valueIdx = cursor.getColumnIndex(COL_VALUE)
+                // A missing expected column is a genuine failure — never fall back to a positional guess.
+                if (nameIdx < 0 || valueIdx < 0) return@use unreadable()
+                val values = HashMap<String, String>()
+                while (cursor.moveToNext()) {
+                    val name = cursor.getString(nameIdx) ?: continue
+                    // name is UNIQUE; a duplicate is an unexpected provider state we refuse rather than guess from.
+                    if (values.putIfAbsent(name, cursor.getString(valueIdx).orEmpty()) != null) return@use unreadable()
+                }
+                LineageChargeReadout.Values(
+                    enabled = values[KEY_ENABLED],
+                    mode = values[KEY_MODE],
+                    limit = values[KEY_LIMIT],
+                )
+            } ?: unreadable()
+        }.getOrElse {
+            LineageChargeReadout.Unreadable(
+                when (it) {
+                    is SecurityException -> R.string.access_read_blocked.toCaString()
+                    else -> (it.message ?: it.javaClass.simpleName).toCaString()
+                },
+            )
+        }
+    }
+
+    private fun unreadable() = LineageChargeReadout.Unreadable(R.string.charging_reason_settings_unreadable.toCaString())
+
+    companion object {
+        const val COL_NAME = "name"
+        const val COL_VALUE = "value"
+        const val KEY_ENABLED = "charging_control_enabled"
+        const val KEY_MODE = "charging_control_mode"
+        const val KEY_LIMIT = "charging_control_charging_limit"
+    }
+}

--- a/app/src/main/java/eu/darken/amply/charging/core/access/ShizukuSettingsBackend.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/access/ShizukuSettingsBackend.kt
@@ -34,20 +34,37 @@ class ShizukuSettingsBackend @Inject constructor(
         )
     }
 
-    override suspend fun read(namespace: SettingNamespace, key: String): SettingRead = runCatching {
-        SettingRead(
-            readable = true,
-            value = controller.service().readSetting(namespace.commandName, key),
-        )
-    }.getOrElse { SettingRead(false, error = (it.message ?: it.javaClass.simpleName).toCaString()) }
+    override suspend fun read(namespace: SettingNamespace, key: String): SettingRead {
+        // Lineage reads never go through a settings backend — the adapter reads a consistent snapshot via
+        // LineageChargeReader (unprivileged ContentResolver). Guard defensively.
+        if (namespace == SettingNamespace.LINEAGE_SYSTEM) {
+            return SettingRead(readable = false, error = R.string.charging_reason_settings_unreadable.toCaString())
+        }
+        // Blocking Binder transaction: keep off the caller's (often Main) thread to avoid an ANR.
+        return withContext(Dispatchers.IO) {
+            try {
+                SettingRead(readable = true, value = controller.service().readSetting(namespace.commandName, key))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                SettingRead(false, error = (e.message ?: e.javaClass.simpleName).toCaString())
+            }
+        }
+    }
 
-    override suspend fun write(mutation: SettingMutation): Boolean = runCatching {
-        controller.service().writeSetting(
-            mutation.namespace.commandName,
-            mutation.key,
-            mutation.value,
-        )
-    }.getOrDefault(false)
+    override suspend fun write(mutation: SettingMutation): Boolean = withContext(Dispatchers.IO) {
+        try {
+            if (mutation.namespace == SettingNamespace.LINEAGE_SYSTEM) {
+                controller.service().writeLineageSetting(mutation.key, mutation.value)
+            } else {
+                controller.service().writeSetting(mutation.namespace.commandName, mutation.key, mutation.value)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            false
+        }
+    }
 
     override suspend fun snapshot(namespace: SettingNamespace): NamespaceSnapshot = withContext(Dispatchers.IO) {
         // Blocking Binder transaction (a full `settings list` can take ~10s) — keep it off the caller's thread.

--- a/app/src/main/java/eu/darken/amply/charging/core/access/shizuku/ChargingControlUserService.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/access/shizuku/ChargingControlUserService.kt
@@ -44,6 +44,22 @@ class ChargingControlUserService(
         return result.stdout
     }
 
+    override fun writeLineageSetting(key: String, value: String): Boolean {
+        // Boundary owns validation: key allowlist + per-key value domain, independent of the adapter layer.
+        LineageSettingWritePolicy.validate(key, value)
+        // `content insert` upserts (name TEXT UNIQUE ON CONFLICT REPLACE). Constant binary + constant URI,
+        // argv-separated — no shell string. The allowlisted key/value contain no ':'/space so the
+        // `col:s:val` bind tokens stay single argv elements. Exit code is corroborated by the adapter's
+        // read-back verification, so a `content`-reported success that the provider validator rejected still fails.
+        val result = runCommand(
+            "/system/bin/content", "insert",
+            "--uri", LINEAGE_SYSTEM_URI,
+            "--bind", "name:s:$key",
+            "--bind", "value:s:$value",
+        )
+        return result.exitCode == 0
+    }
+
     override fun destroy() = exitProcess(0)
 
     private fun requireNamespace(namespace: String) {
@@ -61,6 +77,7 @@ class ChargingControlUserService(
         private val NAMESPACES = setOf("secure", "global", "system")
         private val KEY = Regex("[A-Za-z0-9_.:-]{1,160}")
         private val PACKAGE = Regex("[A-Za-z][A-Za-z0-9_.]{2,200}")
+        const val LINEAGE_SYSTEM_URI = "content://lineagesettings/system"
         private const val COMMAND_TIMEOUT_MS = 10_000L
         // `snapshotSettings` returns the whole dump as one AIDL String, whose Parcel is ~2 bytes/char plus overhead,
         // so this UTF-8 byte cap stays well under the ~1 MiB Binder transaction ceiling. Real `settings list`
@@ -183,5 +200,31 @@ internal object SettingWritePolicy {
         val domain = WRITABLE[namespace]?.get(key)
         require(domain != null) { "Setting is not allowlisted for writes" }
         require(value in domain) { "Invalid setting value: not in the key's allowed domain" }
+    }
+}
+
+/**
+ * Write boundary for the LineageOS `content://lineagesettings/system` charge-control keys. Exact-string
+ * domains, which also reject non-canonical forms (e.g. leading-zero "080") for free. Mirrors — and is kept
+ * in lockstep with — the supported set in `LineageChargingAdapter`; the boundary constrains independently
+ * of the adapter, so widen it only when the corresponding policy is supported AND qualified.
+ */
+internal object LineageSettingWritePolicy {
+    const val KEY_ENABLED = "charging_control_enabled"
+    const val KEY_MODE = "charging_control_mode"
+    const val KEY_LIMIT = "charging_control_charging_limit"
+
+    // v1 supports mode 3 (LIMIT) only; disabling control is via enabled=0, never mode=0 (invalid: provider
+    // validates mode 1..3). Limits are the discrete 70..95 ticks the adapter exposes.
+    private val WRITABLE: Map<String, Set<String>> = mapOf(
+        KEY_ENABLED to setOf("0", "1"),
+        KEY_MODE to setOf("3"),
+        KEY_LIMIT to setOf("70", "75", "80", "85", "90", "95"),
+    )
+
+    fun validate(key: String, value: String) {
+        val domain = WRITABLE[key]
+        require(domain != null) { "Lineage setting is not allowlisted for writes" }
+        require(value in domain) { "Invalid Lineage setting value: not in the key's allowed domain" }
     }
 }

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/AdapterRegistry.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/AdapterRegistry.kt
@@ -15,6 +15,8 @@ data class AdapterSelection(
 @Singleton
 class AdapterRegistry @Inject constructor(
     @ApplicationContext private val context: Context,
+    lineage: LineageChargingAdapter,
+    lineageLab: LineageLabAdapter,
     pixel: PixelChargingAdapter,
     samsungModern: SamsungModernChargingAdapter,
     samsungLegacy: SamsungLegacyChargingAdapter,
@@ -24,9 +26,14 @@ class AdapterRegistry @Inject constructor(
     onePlus: OnePlusChargingAdapter,
     onePlusLab: OnePlusLabAdapter,
 ) {
-    // Live adapters match only their verified device/version scopes; other devices of the same
-    // OEM fall through to the diagnostics-only lab adapters.
+    // LineageOS adapters come FIRST: a custom ROM changes charging control regardless of the OEM
+    // hardware underneath, so a LineageOS build on Samsung/Xiaomi/OnePlus/Pixel must be handled by the
+    // Lineage live/lab pair — never swallowed by a manufacturer-based OEM adapter. lineageLab (any
+    // LineageOS build) sits right after the live adapter (qualified codenames) and before all OEM
+    // adapters. Stock devices have lineageOsVersion == null, so both skip and OEM matching proceeds.
+    // Live adapters otherwise match only their verified scopes; same-OEM misses fall to the lab adapters.
     private val adapters = listOf(
+        lineage, lineageLab,
         pixel, samsungModern, samsungLegacy, samsungLab, xiaomi, xiaomiLab, onePlus, onePlusLab,
     )
 

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/LabChargingAdapters.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/LabChargingAdapters.kt
@@ -65,6 +65,24 @@ class XiaomiLabAdapter @Inject constructor() : DisabledLabAdapter() {
 }
 
 @Singleton
+class LineageLabAdapter @Inject constructor() : DisabledLabAdapter() {
+    override val id = "lineageos-lab"
+    override val displayName = R.string.adapter_name_lineageos.toCaString()
+
+    // Any LineageOS build whose device codename is not in the live adapter's qualified allowlist.
+    // Charging control is HAL-dependent and unverified here, so it stays diagnostics/contribution only.
+    override fun matches(device: DeviceInfo) = device.lineageOsVersion != null
+
+    companion object {
+        val CANDIDATE_KEYS = setOf(
+            "charging_control_enabled",
+            "charging_control_mode",
+            "charging_control_charging_limit",
+        )
+    }
+}
+
+@Singleton
 class OnePlusLabAdapter @Inject constructor() : DisabledLabAdapter() {
     override val id = "oneplus-lab"
     override val displayName = R.string.adapter_name_oneplus.toCaString()

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapter.kt
@@ -1,0 +1,173 @@
+package eu.darken.amply.charging.core.adapter
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import eu.darken.amply.R
+import eu.darken.amply.charging.core.BackendKind
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.access.AccessBackend
+import eu.darken.amply.charging.core.access.LineageChargeReadout
+import eu.darken.amply.charging.core.access.LineageChargeReader
+import eu.darken.amply.charging.core.access.SettingMutation
+import eu.darken.amply.charging.core.access.SettingNamespace
+import eu.darken.amply.common.ca.toCaString
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * LineageOS native Charging Control via its private `content://lineagesettings/system` provider
+ * (three keys: `charging_control_enabled`, `charging_control_mode`, `charging_control_charging_limit`).
+ * A hard percent cap is `enabled=1` + `mode=3` (LIMIT) + `limit=N`; `enabled=0` is unrestricted.
+ * LineageOS's own `ChargingControlController` observes these keys and re-drives the
+ * `vendor.lineage.health.IChargingControl` HAL, so an external write is honored.
+ *
+ * **Reads** are unprivileged and taken as one consistent snapshot ([LineageChargeReader]). **Writes
+ * require Shizuku** (the provider's write permission is held only by the shell UID, so
+ * `WRITE_SECURE_SETTINGS` cannot write it — [preferShizukuForWrites]). Verified with read-back equality
+ * ([VerificationStrategy.SYNC_READBACK]).
+ *
+ * The HAL is device-dependent (some devices flip the setting but never limit — the `mIsLimitSet:false`
+ * class of bug), so control is gated to a **physically-qualified codename allowlist**
+ * ([QUALIFIED_CODENAMES]) that ships **empty** until a device passes qualification; every LineageOS build
+ * otherwise falls through to [LineageLabAdapter]. See the qualification ledger in
+ * `.claude/rules/privileged-access.md`.
+ */
+@Singleton
+class LineageChargingAdapter @Inject constructor(
+    private val reader: LineageChargeReader,
+) : ChargingAdapter {
+
+    /** Test seam: exercises the gate logic while production ships the empty [QUALIFIED_CODENAMES]. */
+    internal constructor(reader: LineageChargeReader, qualifiedCodenames: Set<String>) : this(reader) {
+        this.qualifiedCodenames = qualifiedCodenames
+    }
+
+    private var qualifiedCodenames: Set<String> = QUALIFIED_CODENAMES
+
+    override val id = "lineageos-chargingcontrol-v1"
+    override val displayName = R.string.adapter_name_lineageos.toCaString()
+
+    override val supportedPolicies = SUPPORTED_LIMITS.map { ChargePolicy.FixedLimit(it) } + ChargePolicy.Unrestricted
+
+    override val defaultProtectivePolicy = ChargePolicy.FixedLimit(80)
+    override val sessionOverridePolicy = ChargePolicy.Unrestricted
+    override val verification = VerificationStrategy.SYNC_READBACK
+    override val preferShizukuForWrites = true
+
+    override fun probe(device: DeviceInfo): AdapterSupport {
+        val matched = device.lineageOsVersion != null && device.codename in qualifiedCodenames
+        return AdapterSupport(
+            matched = matched,
+            controlEnabled = matched && device.hasLineageSettingsProvider && device.isSystemUser,
+            detail = when {
+                !matched -> R.string.adapter_detail_requires_lineageos
+                !device.hasLineageSettingsProvider -> R.string.adapter_detail_lineageos_no_provider
+                !device.isSystemUser -> R.string.adapter_detail_secondary_user
+                else -> R.string.adapter_detail_lineageos_ready
+            },
+            // Unqualified LineageOS builds are handled by LineageLabAdapter, so this live adapter never
+            // solicits a contribution itself.
+            contributionWanted = false,
+        )
+    }
+
+    override suspend fun read(backend: AccessBackend): ChargeObservation = decode(reader.readChargeControl(), backend.kind)
+
+    /** Pure decode of a single consistent snapshot — Verified only for states v1 can restore exactly. */
+    private fun decode(readout: LineageChargeReadout, kind: BackendKind): ChargeObservation = when (readout) {
+        is LineageChargeReadout.Unreadable -> ChargeObservation.Unknown(readout.reason)
+        is LineageChargeReadout.Values -> when (readout.enabled) {
+            VALUE_OFF -> ChargeObservation.Verified(ChargePolicy.Unrestricted, kind)
+            VALUE_ON -> {
+                // Only a canonical tick string is restorable — reject "080"/"+80"/whitespace, which the
+                // write boundary and mutations could not reproduce.
+                val percent = readout.limit?.takeIf { it in CANONICAL_LIMIT_STRINGS }?.toInt()
+                if (readout.mode == MODE_LIMIT && percent != null) {
+                    ChargeObservation.Verified(ChargePolicy.FixedLimit(percent), kind)
+                } else {
+                    // Enabled, but an AUTO/CUSTOM schedule or an off-tick/non-canonical limit v1 cannot
+                    // restore exactly → refuse so a session never clobbers the user's native choice.
+                    unrecognized(KEY_MODE, "mode=${readout.mode},limit=${readout.limit}")
+                }
+            }
+            // Absent (null) or malformed enabled: refuse rather than guess. Absent-key meaning is
+            // characterized on-device (see the qualification ledger) before any relaxation here.
+            else -> unrecognized(KEY_ENABLED, readout.enabled)
+        }
+    }
+
+    override suspend fun apply(policy: ChargePolicy, backend: AccessBackend): Boolean {
+        val mutations = mutationsFor(policy) ?: return false
+        if (!mutations.all { backend.write(it) }) return false
+        // Writes upsert synchronously; require read-back equality (the multi-key transition isn't atomic).
+        val observed = read(backend)
+        return observed is ChargeObservation.Verified && observed.policy == policy
+    }
+
+    /** Ordered writes: limit → mode → enabled, so the observable "on" flip is last with a consistent mode/limit. */
+    internal fun mutationsFor(policy: ChargePolicy): List<SettingMutation>? = when (policy) {
+        is ChargePolicy.FixedLimit -> if (policy.percent in SUPPORTED_LIMITS) {
+            listOf(
+                SettingMutation(SettingNamespace.LINEAGE_SYSTEM, KEY_LIMIT, policy.percent.toString()),
+                SettingMutation(SettingNamespace.LINEAGE_SYSTEM, KEY_MODE, MODE_LIMIT),
+                SettingMutation(SettingNamespace.LINEAGE_SYSTEM, KEY_ENABLED, VALUE_ON),
+            )
+        } else {
+            null
+        }
+        ChargePolicy.Unrestricted -> listOf(
+            SettingMutation(SettingNamespace.LINEAGE_SYSTEM, KEY_ENABLED, VALUE_OFF),
+        )
+        ChargePolicy.Adaptive, ChargePolicy.PauseAtFull -> null
+    }
+
+    override val observedSettingUris
+        get() = listOf(
+            Uri.parse(SYSTEM_URI),
+            Uri.parse("$SYSTEM_URI/$KEY_ENABLED"),
+            Uri.parse("$SYSTEM_URI/$KEY_MODE"),
+            Uri.parse("$SYSTEM_URI/$KEY_LIMIT"),
+        )
+
+    override fun nativeSettingsIntent(context: Context): Intent {
+        // LineageOS keeps Charging Control under Settings › Battery; the generic AOSP power-usage screen
+        // is the closest resolvable, brittle-ComponentName-free entry point, with Battery Saver as fallback.
+        val powerUsage = Intent(Intent.ACTION_POWER_USAGE_SUMMARY).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        return if (powerUsage.resolveActivity(context.packageManager) != null) {
+            powerUsage
+        } else {
+            Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+
+    private fun unrecognized(key: String, value: String?) = ChargeObservation.Unknown(
+        R.string.charging_reason_value_unrecognized.toCaString(key, value.toString()),
+        unrecognizedValue = true,
+    )
+
+    companion object {
+        const val SYSTEM_URI = "content://lineagesettings/system"
+        const val KEY_ENABLED = "charging_control_enabled"
+        const val KEY_MODE = "charging_control_mode"
+        const val KEY_LIMIT = "charging_control_charging_limit"
+        const val VALUE_ON = "1"
+        const val VALUE_OFF = "0"
+        const val MODE_LIMIT = "3" // LineageOS ChargingControlMode.LIMIT
+
+        /** Discrete percent ticks Amply exposes/writes (LineageOS's native slider spans 70..100). */
+        val SUPPORTED_LIMITS = listOf(70, 75, 80, 85, 90, 95)
+        private val CANONICAL_LIMIT_STRINGS = SUPPORTED_LIMITS.map { it.toString() }.toSet()
+
+        /**
+         * Physically-qualified device codenames (`Build.DEVICE`) where the charge-control HAL is confirmed
+         * to enforce the limit. **Ships empty** — the adapter is diagnostics-only until a device passes the
+         * qualification protocol and gets a ledger row (see `.claude/rules/privileged-access.md`). Widen
+         * ONLY with a qualified device.
+         */
+        val QUALIFIED_CODENAMES = emptySet<String>()
+    }
+}

--- a/app/src/main/java/eu/darken/amply/diagnostics/core/ContributionRepository.kt
+++ b/app/src/main/java/eu/darken/amply/diagnostics/core/ContributionRepository.kt
@@ -5,7 +5,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.amply.charging.core.DeviceInfo
 import eu.darken.amply.charging.core.access.BackendStatus
 import eu.darken.amply.charging.core.access.NamespaceSnapshot
-import eu.darken.amply.charging.core.access.SettingNamespace
+import eu.darken.amply.charging.core.access.STANDARD_SETTINGS_NAMESPACES
 import eu.darken.amply.charging.core.access.SettingsSnapshotSource
 import eu.darken.amply.charging.core.adapter.AdapterRegistry
 import eu.darken.amply.common.ca.CaString
@@ -40,7 +40,9 @@ class DefaultContributionRepository @Inject constructor(
 
     override suspend fun captureSnapshot(): CaptureResult {
         val merged = LinkedHashMap<SettingId, String>()
-        for (namespace in SettingNamespace.entries) {
+        // Only the three AOSP namespaces — never the Lineage provider. It isn't a `settings` CLI
+        // namespace, and querying it on a non-Lineage device would fail the whole capture.
+        for (namespace in STANDARD_SETTINGS_NAMESPACES) {
             when (val result = source.snapshot(namespace)) {
                 is NamespaceSnapshot.Success -> result.values.forEach { (key, value) ->
                     merged[SettingId(namespace, key)] = value

--- a/app/src/main/java/eu/darken/amply/main/core/ChargingCoreModule.kt
+++ b/app/src/main/java/eu/darken/amply/main/core/ChargingCoreModule.kt
@@ -5,6 +5,8 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import eu.darken.amply.charging.core.SettleScheduler
+import eu.darken.amply.charging.core.access.LineageChargeReader
+import eu.darken.amply.charging.core.access.LineageSettingsClient
 import eu.darken.amply.charging.core.access.SettingsSnapshotSource
 import eu.darken.amply.charging.core.access.ShizukuSettingsBackend
 import eu.darken.amply.diagnostics.core.ContributionRepository
@@ -22,4 +24,8 @@ abstract class ChargingCoreModule {
 
     @Binds
     abstract fun bindContributionRepository(impl: DefaultContributionRepository): ContributionRepository
+
+    /** LineageOS charge-control reads: unprivileged ContentResolver snapshot, shared by the Lineage adapter. */
+    @Binds
+    abstract fun bindLineageChargeReader(impl: LineageSettingsClient): LineageChargeReader
 }

--- a/app/src/main/java/eu/darken/amply/main/core/DeviceSupportReporter.kt
+++ b/app/src/main/java/eu/darken/amply/main/core/DeviceSupportReporter.kt
@@ -35,7 +35,9 @@ data class DeviceSupportReport(
     val oneUiVersion: Int?,
     val hyperOsVersion: Int?,
     val oplusRomVersion: Int?,
+    val lineageOsVersion: String?,
     val hasProtectBattery: Boolean,
+    val hasLineageSettingsProvider: Boolean,
     val adapterId: String?,
     val adapterMatched: Boolean,
     val adapterControlEnabled: Boolean,
@@ -73,7 +75,9 @@ class DeviceSupportReporter @Inject constructor(
             oneUiVersion = device.oneUiVersion,
             hyperOsVersion = device.hyperOsVersion,
             oplusRomVersion = device.oplusRomVersion,
+            lineageOsVersion = device.lineageOsVersion,
             hasProtectBattery = device.hasProtectBattery,
+            hasLineageSettingsProvider = device.hasLineageSettingsProvider,
             adapterId = selection.adapter?.id,
             adapterMatched = selection.support.matched,
             adapterControlEnabled = selection.support.controlEnabled,
@@ -105,7 +109,7 @@ internal fun sanitizeReportValue(value: String?, max: Int = 120): String {
 /** Deterministic, single stable schema. Keep field order fixed so reports are diff-friendly. */
 internal fun formatReport(report: DeviceSupportReport): String = buildString {
     appendLine("Amply device-support request")
-    appendLine("report_schema=6")
+    appendLine("report_schema=7")
     appendLine("app_version=${report.appVersionName} (${report.appVersionCode})")
     appendLine("distribution=${report.flavor}/${report.buildType}")
     appendLine("manufacturer=${report.manufacturer}")
@@ -121,7 +125,9 @@ internal fun formatReport(report: DeviceSupportReport): String = buildString {
     appendLine("one_ui_version=${report.oneUiVersion ?: "none"}")
     appendLine("hyperos_version=${report.hyperOsVersion ?: "none"}")
     appendLine("oplus_rom_version=${report.oplusRomVersion ?: "none"}")
+    appendLine("lineageos_version=${report.lineageOsVersion ?: "none"}")
     appendLine("has_protect_battery=${report.hasProtectBattery}")
+    appendLine("has_lineage_settings_provider=${report.hasLineageSettingsProvider}")
     appendLine("adapter=${report.adapterId ?: "none"}")
     appendLine("adapter_matched=${report.adapterMatched}")
     appendLine("adapter_control_enabled=${report.adapterControlEnabled}")

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -182,6 +182,7 @@ fun DashboardScreen(
                             manufacturer = state.charging.device.manufacturer
                                 .ifBlank { stringResource(R.string.dashboard_manufacturer_fallback) },
                             onOpenSettings = onNativeSettings,
+                            isLineageOs = state.charging.device.lineageOsVersion != null,
                         )
                     }
                     item {

--- a/app/src/main/java/eu/darken/amply/main/ui/setup/OemGuideCard.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/setup/OemGuideCard.kt
@@ -3,6 +3,7 @@ package eu.darken.amply.main.ui.setup
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -15,6 +16,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -33,6 +35,7 @@ fun OemGuideCard(
     manufacturer: String,
     onOpenSettings: () -> Unit,
     modifier: Modifier = Modifier,
+    isLineageOs: Boolean = false,
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -44,22 +47,30 @@ fun OemGuideCard(
             modifier = Modifier.padding(20.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Icon(
-                Icons.TwoTone.BatteryChargingFull,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSecondaryContainer,
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    Icons.TwoTone.BatteryChargingFull,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+                Text(
+                    stringResource(R.string.setup_oem_guide_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
             Text(
-                stringResource(R.string.setup_oem_guide_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSecondaryContainer,
-            )
-            Text(
-                stringResource(oemInstructions(manufacturer)),
+                stringResource(oemInstructions(manufacturer, isLineageOs)),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSecondaryContainer,
             )
-            FilledTonalButton(onClick = onOpenSettings) {
+            FilledTonalButton(
+                onClick = onOpenSettings,
+                modifier = Modifier.align(Alignment.End),
+            ) {
                 Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null)
                 Text(
                     stringResource(R.string.setup_oem_guide_open_action),
@@ -70,12 +81,19 @@ fun OemGuideCard(
     }
 }
 
+/**
+ * Keyed by manufacturer, except LineageOS wins first: a custom ROM replaces the OEM's charge feature
+ * with its own "Charging control", so the OEM-specific wording (e.g. Pixel's "charging optimization")
+ * would point the user at a feature name that isn't there.
+ */
 @StringRes
-private fun oemInstructions(manufacturer: String): Int = when (manufacturer.lowercase()) {
-    "samsung" -> R.string.setup_oem_guide_samsung
-    "oneplus", "oppo" -> R.string.setup_oem_guide_oneplus
-    "xiaomi" -> R.string.setup_oem_guide_xiaomi
-    "google" -> R.string.setup_oem_guide_google
+private fun oemInstructions(manufacturer: String, isLineageOs: Boolean): Int = when {
+    isLineageOs -> R.string.setup_oem_guide_lineageos
+    manufacturer.equals("samsung", ignoreCase = true) -> R.string.setup_oem_guide_samsung
+    manufacturer.equals("oneplus", ignoreCase = true) ||
+        manufacturer.equals("oppo", ignoreCase = true) -> R.string.setup_oem_guide_oneplus
+    manufacturer.equals("xiaomi", ignoreCase = true) -> R.string.setup_oem_guide_xiaomi
+    manufacturer.equals("google", ignoreCase = true) -> R.string.setup_oem_guide_google
     else -> R.string.setup_oem_guide_generic
 }
 
@@ -84,6 +102,6 @@ private fun oemInstructions(manufacturer: String): Int = when (manufacturer.lowe
 private fun OemGuideCardPreview() = PreviewWrapper {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         OemGuideCard(manufacturer = "Samsung", onOpenSettings = {})
-        OemGuideCard(manufacturer = "SomeOtherBrand", onOpenSettings = {})
+        OemGuideCard(manufacturer = "Google", isLineageOs = true, onOpenSettings = {})
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,7 +53,7 @@
     <string name="onboarding_caveat_support_title">Support grows device by device</string>
     <string name="onboarding_caveat_support_body">Charge control is mapped one device at a time. Right now, direct control works on Pixel 6a and newer phones running Android 15 or later, on Samsung devices with verified One UI versions, on verified Xiaomi devices, and on OnePlus, Oppo, and Realme devices on ColorOS 15. On other devices, Amply explains why control is unavailable, and where a device report can help expand support, the dashboard lets you send one.</string>
     <string name="onboarding_caveat_setup_title">One-time setup on supported devices</string>
-    <string name="onboarding_caveat_setup_body">Changing the charge policy requires a permission that apps cannot grant themselves. You grant it once: either run a single command from a computer over ADB, or use the Shizuku app on this phone. If your device is supported, the dashboard walks you through both options.</string>
+    <string name="onboarding_caveat_setup_body">Changing the charge policy requires a permission that apps cannot grant themselves. You grant it once, using either a single command from a computer over ADB or the Shizuku app on this phone. Some devices require Shizuku specifically. If your device is supported, the dashboard walks you through the right option.</string>
     <string name="onboarding_caveat_restore_title">Protection returns on its own</string>
     <string name="onboarding_caveat_restore_body">When you allow a one-time full charge, Amply restores your protective limit as soon as the battery is full, when you unplug, or after a safety timeout. This relies on Amply staying alive in the background. If the app gets force-stopped during a session, opening Amply again resumes monitoring and restores the limit once it is due.</string>
     <string name="onboarding_page_progress">Page %1$d of %2$d</string>
@@ -100,6 +100,7 @@
     <string name="adapter_name_xiaomi_protection">Xiaomi charging protection</string>
     <string name="adapter_name_oneplus">OnePlus/Oppo/Realme (diagnostics)</string>
     <string name="adapter_name_oplus_protection">ColorOS charging protection</string>
+    <string name="adapter_name_lineageos">LineageOS charging control</string>
 
     <!-- Adapter support detail (why a device is or isn\'t controllable) -->
     <string name="adapter_detail_requires_pixel">Requires a supported Google Pixel phone</string>
@@ -118,6 +119,9 @@
     <string name="adapter_detail_xiaomi_ready">Xiaomi charging protection detected; changes apply immediately</string>
     <string name="adapter_detail_requires_oplus">Requires a OnePlus, Oppo, or Realme device on ColorOS 15</string>
     <string name="adapter_detail_oplus_ready">ColorOS charging protection detected; control requires Shizuku</string>
+    <string name="adapter_detail_requires_lineageos">Requires a qualified LineageOS device</string>
+    <string name="adapter_detail_lineageos_no_provider">LineageOS charging control is not available on this build</string>
+    <string name="adapter_detail_lineageos_ready">LineageOS charging control detected; control requires Shizuku</string>
     <string name="adapter_detail_none">No charging adapter is known for this device</string>
 
     <!-- Access backend detail + summary labels -->
@@ -445,6 +449,7 @@
     <string name="setup_oem_guide_oneplus">OnePlus and Oppo phones offer charge limiting under Settings → Battery → Battery health (or Smart charging). Amply can\'t control it directly on this device, but you can enable it there.</string>
     <string name="setup_oem_guide_xiaomi">Xiaomi, Redmi, and POCO phones may offer charge limiting or protection under Settings → Battery → Battery protection. Amply can\'t control it directly on this device, but you can look for it there.</string>
     <string name="setup_oem_guide_google">Look for charging optimization under Settings → Battery. Amply can\'t control it directly on this device.</string>
+    <string name="setup_oem_guide_lineageos">LineageOS includes Charging control under Settings → Battery. Amply can\'t control it directly on this device, but you can set a limit there.</string>
     <string name="setup_oem_guide_generic">Your phone may offer a built-in battery-protection or charge-limit option in its battery settings. Amply can\'t control it directly on this device, but it\'s worth a look.</string>
 
     <!-- Widget (in-widget text) -->

--- a/app/src/test/java/eu/darken/amply/charging/core/LineageOsDetectorTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/LineageOsDetectorTest.kt
@@ -1,0 +1,20 @@
+package eu.darken.amply.charging.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class LineageOsDetectorTest {
+
+    @Test
+    fun `a present version string means LineageOS`() {
+        LineageOsDetector.parse("23.2") shouldBe "23.2"
+        LineageOsDetector.parse(" 22.1 ") shouldBe "22.1" // trimmed
+    }
+
+    @Test
+    fun `null or blank means not LineageOS`() {
+        LineageOsDetector.parse(null) shouldBe null
+        LineageOsDetector.parse("") shouldBe null
+        LineageOsDetector.parse("   ") shouldBe null
+    }
+}

--- a/app/src/test/java/eu/darken/amply/charging/core/access/AutoWssGrantCoordinatorTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/access/AutoWssGrantCoordinatorTest.kt
@@ -23,6 +23,7 @@ class AutoWssGrantCoordinatorTest {
 
     private val ready = AutoWssGrantInputs(
         onboardingComplete = true, controlEnabled = true, shizukuReady = true, wssReady = false,
+        writeRequiresShizuku = false,
     )
     private val wssGranted = ready.copy(wssReady = true)
     private val shizukuGone = ready.copy(shizukuReady = false)

--- a/app/src/test/java/eu/darken/amply/charging/core/access/AutoWssGrantPolicyTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/access/AutoWssGrantPolicyTest.kt
@@ -10,12 +10,14 @@ class AutoWssGrantPolicyTest {
         controlEnabled: Boolean = true,
         shizukuReady: Boolean = true,
         wssReady: Boolean = false,
+        writeRequiresShizuku: Boolean = false,
         attempted: Boolean = false,
     ) = AutoWssGrantPolicy.evaluate(
         onboardingComplete = onboardingComplete,
         controlEnabled = controlEnabled,
         shizukuReady = shizukuReady,
         wssReady = wssReady,
+        writeRequiresShizuku = writeRequiresShizuku,
         attempted = attempted,
     )
 
@@ -56,6 +58,15 @@ class AutoWssGrantPolicyTest {
     fun `never grants on a capability-gated device and preserves the latch`() {
         eval(controlEnabled = false) shouldBe AutoWssGrantPolicy.Outcome(grant = false, attempted = false)
         eval(controlEnabled = false, attempted = true) shouldBe
+            AutoWssGrantPolicy.Outcome(grant = false, attempted = true)
+    }
+
+    @Test
+    fun `never grants for a shizuku-write adapter and preserves the latch`() {
+        // Lineage/Oplus write via the system/lineagesettings namespace, which WSS can't touch — auto-granting
+        // WSS there is wasted least-privilege surface.
+        eval(writeRequiresShizuku = true) shouldBe AutoWssGrantPolicy.Outcome(grant = false, attempted = false)
+        eval(writeRequiresShizuku = true, attempted = true) shouldBe
             AutoWssGrantPolicy.Outcome(grant = false, attempted = true)
     }
 

--- a/app/src/test/java/eu/darken/amply/charging/core/access/LineageSettingsClientTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/access/LineageSettingsClientTest.kt
@@ -1,0 +1,86 @@
+package eu.darken.amply.charging.core.access
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.pm.ProviderInfo
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LineageSettingsClientTest {
+
+    private lateinit var provider: FakeLineageProvider
+    private lateinit var client: LineageSettingsClient
+
+    @Before
+    fun setup() {
+        val info = ProviderInfo().apply { authority = "lineagesettings" }
+        provider = Robolectric.buildContentProvider(FakeLineageProvider::class.java).create(info).get()
+        client = LineageSettingsClient(ApplicationProvider.getApplicationContext())
+    }
+
+    @Test
+    fun `present and absent keys collapse into one consistent snapshot`() = runTest {
+        provider.rows = listOf(
+            LineageSettingsClient.KEY_ENABLED to "1",
+            LineageSettingsClient.KEY_LIMIT to "80",
+            // mode intentionally absent
+        )
+        client.readChargeControl() shouldBe LineageChargeReadout.Values(enabled = "1", mode = null, limit = "80")
+    }
+
+    @Test
+    fun `an empty table reads as all-absent, not a failure`() = runTest {
+        provider.rows = emptyList()
+        client.readChargeControl() shouldBe LineageChargeReadout.Values(enabled = null, mode = null, limit = null)
+    }
+
+    @Test
+    fun `a duplicate row for a key is unreadable, never guessed`() = runTest {
+        provider.rows = listOf(
+            LineageSettingsClient.KEY_ENABLED to "1",
+            LineageSettingsClient.KEY_ENABLED to "0",
+        )
+        client.readChargeControl().shouldBeInstanceOf<LineageChargeReadout.Unreadable>()
+    }
+
+    @Test
+    fun `a missing value column is unreadable, never a positional guess`() = runTest {
+        provider.columns = arrayOf(LineageSettingsClient.COL_NAME) // no "value" column
+        provider.rows = listOf(LineageSettingsClient.KEY_ENABLED to "1")
+        client.readChargeControl().shouldBeInstanceOf<LineageChargeReadout.Unreadable>()
+    }
+
+    class FakeLineageProvider : ContentProvider() {
+        var rows: List<Pair<String, String?>> = emptyList()
+        var columns: Array<String> = arrayOf(LineageSettingsClient.COL_NAME, LineageSettingsClient.COL_VALUE)
+
+        override fun onCreate() = true
+        override fun query(
+            uri: Uri,
+            projection: Array<String>?,
+            selection: String?,
+            selectionArgs: Array<String>?,
+            sortOrder: String?,
+        ): Cursor = MatrixCursor(columns).apply {
+            rows.forEach { (name, value) ->
+                addRow(if (columns.size == 1) arrayOf<Any?>(name) else arrayOf<Any?>(name, value))
+            }
+        }
+
+        override fun getType(uri: Uri): String? = null
+        override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+        override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+        override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<String>?): Int = 0
+    }
+}

--- a/app/src/test/java/eu/darken/amply/charging/core/access/shizuku/ChargingControlUserServiceTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/access/shizuku/ChargingControlUserServiceTest.kt
@@ -40,6 +40,24 @@ class ChargingControlUserServiceTest {
     }
 
     @Test
+    fun `writeLineageSetting validates key and value before executing any command`() {
+        // Non-allowlisted Lineage key is rejected up-front (no `content` process is ever spawned).
+        runCatching {
+            service.writeLineageSetting("charging_control_start_time", "0")
+        }.exceptionOrNull().let {
+            it.shouldBeInstanceOf<IllegalArgumentException>()
+            it!!.message shouldContain "allowlisted"
+        }
+        // Out-of-domain value (schedule mode) is rejected likewise.
+        runCatching {
+            service.writeLineageSetting("charging_control_mode", "1")
+        }.exceptionOrNull().let {
+            it.shouldBeInstanceOf<IllegalArgumentException>()
+            it!!.message shouldContain "domain"
+        }
+    }
+
+    @Test
     fun `write policy accepts only in-domain values for every allowlisted key`() {
         // Accepted (validate() returns without throwing; the command itself is not run here).
         SettingWritePolicy.validate("secure", "charge_optimization_mode", "1")

--- a/app/src/test/java/eu/darken/amply/charging/core/access/shizuku/LineageSettingWritePolicyTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/access/shizuku/LineageSettingWritePolicyTest.kt
@@ -1,0 +1,56 @@
+package eu.darken.amply.charging.core.access.shizuku
+
+import eu.darken.amply.charging.core.access.LineageChargeReadout
+import eu.darken.amply.charging.core.access.LineageChargeReader
+import eu.darken.amply.charging.core.adapter.LineageChargingAdapter
+import eu.darken.amply.common.ca.toCaString
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+
+class LineageSettingWritePolicyTest {
+
+    @Test
+    fun `admits every canonical in-domain value`() {
+        LineageSettingWritePolicy.validate(LineageSettingWritePolicy.KEY_ENABLED, "0")
+        LineageSettingWritePolicy.validate(LineageSettingWritePolicy.KEY_ENABLED, "1")
+        LineageSettingWritePolicy.validate(LineageSettingWritePolicy.KEY_MODE, "3")
+        listOf("70", "75", "80", "85", "90", "95").forEach {
+            LineageSettingWritePolicy.validate(LineageSettingWritePolicy.KEY_LIMIT, it)
+        }
+    }
+
+    @Test
+    fun `rejects a non-allowlisted key`() {
+        shouldThrow<IllegalArgumentException> {
+            LineageSettingWritePolicy.validate("charging_control_start_time", "0")
+        }.message shouldContain "allowlisted"
+    }
+
+    @Test
+    fun `rejects out-of-domain and non-canonical values`() {
+        // Schedule modes / the invalid mode 0 are refused — only the hard cap (mode 3) is writable.
+        shouldThrow<IllegalArgumentException> { LineageSettingWritePolicy.validate(LineageSettingWritePolicy.KEY_MODE, "1") }
+        shouldThrow<IllegalArgumentException> { LineageSettingWritePolicy.validate(LineageSettingWritePolicy.KEY_MODE, "0") }
+        // Out-of-range and off-tick limits.
+        shouldThrow<IllegalArgumentException> { LineageSettingWritePolicy.validate(LineageSettingWritePolicy.KEY_LIMIT, "101") }
+        shouldThrow<IllegalArgumentException> { LineageSettingWritePolicy.validate(LineageSettingWritePolicy.KEY_LIMIT, "72") }
+        // Non-canonical numeric forms (exact-string domains reject these for free).
+        shouldThrow<IllegalArgumentException> { LineageSettingWritePolicy.validate(LineageSettingWritePolicy.KEY_LIMIT, "080") }
+        shouldThrow<IllegalArgumentException> { LineageSettingWritePolicy.validate(LineageSettingWritePolicy.KEY_ENABLED, "2") }
+    }
+
+    @Test
+    fun `every adapter-emitted mutation is inside the write domain`() {
+        val stubReader = object : LineageChargeReader {
+            override suspend fun readChargeControl() = LineageChargeReadout.Unreadable("unused".toCaString())
+        }
+        val adapter = LineageChargingAdapter(stubReader)
+        adapter.supportedPolicies.forEach { policy ->
+            adapter.mutationsFor(policy)?.forEach { mutation ->
+                // Throws (failing the test) if the adapter could emit a write the boundary rejects.
+                LineageSettingWritePolicy.validate(mutation.key, mutation.value)
+            }
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
@@ -2,6 +2,9 @@ package eu.darken.amply.charging.core.adapter
 
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.access.LineageChargeReadout
+import eu.darken.amply.charging.core.access.LineageChargeReader
+import eu.darken.amply.common.ca.toCaString
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -16,8 +19,16 @@ import org.robolectric.annotation.Config
 @Config(sdk = [34])
 class AdapterRegistrySelectionTest {
 
+    // Reads aren't exercised at the registry level (only probe); a stub reader suffices, and the test seam
+    // supplies a qualified codename so the live-selection/ordering paths stay covered.
+    private val stubReader = object : LineageChargeReader {
+        override suspend fun readChargeControl() = LineageChargeReadout.Unreadable("unused".toCaString())
+    }
+
     private val registry = AdapterRegistry(
         context = ApplicationProvider.getApplicationContext(),
+        lineage = LineageChargingAdapter(stubReader, setOf("oriole")),
+        lineageLab = LineageLabAdapter(),
         pixel = PixelChargingAdapter(),
         samsungModern = SamsungModernChargingAdapter(),
         samsungLegacy = SamsungLegacyChargingAdapter(),
@@ -118,5 +129,65 @@ class AdapterRegistrySelectionTest {
         registry.select(
             DeviceInfo("realme", "RMX3999", 34, "test"),
         ).adapter?.id shouldBe "oneplus-lab"
+    }
+
+    private fun lineage(
+        codename: String = "oriole",
+        manufacturer: String = "Google",
+        provider: Boolean = true,
+        systemUser: Boolean = true,
+        version: String? = "23.2",
+    ) = DeviceInfo(
+        manufacturer = manufacturer,
+        model = "TEST",
+        sdk = 36,
+        fingerprint = "test",
+        codename = codename,
+        lineageOsVersion = version,
+        hasLineageSettingsProvider = provider,
+        isSystemUser = systemUser,
+    )
+
+    @Test
+    fun `a qualified lineageos codename selects the live adapter with control`() {
+        val selection = registry.select(lineage(codename = "oriole"))
+        selection.adapter?.id shouldBe "lineageos-chargingcontrol-v1"
+        selection.support.controlEnabled shouldBe true
+    }
+
+    @Test
+    fun `a qualified lineageos device without the provider matches but disables control`() {
+        val selection = registry.select(lineage(codename = "oriole", provider = false))
+        selection.adapter?.id shouldBe "lineageos-chargingcontrol-v1"
+        selection.support.controlEnabled shouldBe false
+    }
+
+    @Test
+    fun `a secondary user on a qualified lineageos device disables control`() {
+        val selection = registry.select(lineage(codename = "oriole", systemUser = false))
+        selection.adapter?.id shouldBe "lineageos-chargingcontrol-v1"
+        selection.support.controlEnabled shouldBe false
+    }
+
+    @Test
+    fun `an unqualified lineageos codename falls through to the lineage lab adapter`() {
+        val selection = registry.select(lineage(codename = "raven")) // Pixel 6 Pro, not yet qualified
+        selection.adapter?.id shouldBe "lineageos-lab"
+        selection.support.controlEnabled shouldBe false
+    }
+
+    @Test
+    fun `a lineageos build on OEM hardware is handled by lineage, never the OEM lab adapter`() {
+        // The Lineage adapters precede all OEM adapters, so a custom-ROM build on Samsung/Xiaomi/OnePlus
+        // hardware is never swallowed by a manufacturer-based lab adapter.
+        registry.select(lineage(codename = "gts9", manufacturer = "samsung")).adapter?.id shouldBe "lineageos-lab"
+        registry.select(lineage(codename = "munch", manufacturer = "Xiaomi")).adapter?.id shouldBe "lineageos-lab"
+        registry.select(lineage(codename = "salami", manufacturer = "OnePlus")).adapter?.id shouldBe "lineageos-lab"
+    }
+
+    @Test
+    fun `a stock device is unaffected by the lineage adapters`() {
+        // lineageOsVersion == null → both Lineage adapters skip, OEM matching proceeds as before.
+        registry.select(samsung(80000)).adapter?.id shouldBe "samsung-oneui8-v1"
     }
 }

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/ContributionEligibilityTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/ContributionEligibilityTest.kt
@@ -3,6 +3,9 @@ package eu.darken.amply.charging.core.adapter
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.access.LineageChargeReadout
+import eu.darken.amply.charging.core.access.LineageChargeReader
+import eu.darken.amply.common.ca.toCaString
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,8 +15,13 @@ import org.robolectric.RobolectricTestRunner
 class ContributionEligibilityTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
+    private val stubReader = object : LineageChargeReader {
+        override suspend fun readChargeControl() = LineageChargeReadout.Unreadable("unused".toCaString())
+    }
     private val registry = AdapterRegistry(
         context = context,
+        lineage = LineageChargingAdapter(stubReader),
+        lineageLab = LineageLabAdapter(),
         pixel = PixelChargingAdapter(),
         samsungModern = SamsungModernChargingAdapter(),
         samsungLegacy = SamsungLegacyChargingAdapter(),

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapterTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapterTest.kt
@@ -1,0 +1,189 @@
+package eu.darken.amply.charging.core.adapter
+
+import eu.darken.amply.R
+import eu.darken.amply.charging.core.BackendKind
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.access.AccessBackend
+import eu.darken.amply.charging.core.access.BackendStatus
+import eu.darken.amply.charging.core.access.LineageChargeReadout
+import eu.darken.amply.charging.core.access.LineageChargeReader
+import eu.darken.amply.charging.core.access.SettingMutation
+import eu.darken.amply.charging.core.access.SettingNamespace
+import eu.darken.amply.charging.core.access.SettingRead
+import eu.darken.amply.common.ca.toCaString
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class LineageChargingAdapterTest {
+
+    private fun device(
+        codename: String = "oriole",
+        provider: Boolean = true,
+        systemUser: Boolean = true,
+        version: String? = "23.2",
+    ) = DeviceInfo(
+        manufacturer = "Google",
+        model = "Pixel 6",
+        sdk = 36,
+        fingerprint = "test",
+        codename = codename,
+        lineageOsVersion = version,
+        hasLineageSettingsProvider = provider,
+        isSystemUser = systemUser,
+    )
+
+    // Gate logic is exercised through the test seam; production ships an empty allowlist (asserted below).
+    private fun gated(vararg codenames: String) = LineageChargingAdapter(FakeLineage(), codenames.toSet())
+
+    @Test
+    fun `production adapter ships lab-only with an empty qualified allowlist`() {
+        LineageChargingAdapter.QUALIFIED_CODENAMES shouldBe emptySet()
+        // Even a fully-provisioned oriole is not live until a codename is qualified.
+        LineageChargingAdapter(FakeLineage()).probe(device()).matched shouldBe false
+    }
+
+    @Test
+    fun `probe gates on qualified codename, provider, and system user`() {
+        gated("oriole").probe(device()).let {
+            it.controlEnabled shouldBe true
+            it.detail shouldBe R.string.adapter_detail_lineageos_ready
+        }
+        gated("oriole").probe(device(version = null)).matched shouldBe false // not LineageOS
+        gated("oriole").probe(device(codename = "raven")).let {
+            it.matched shouldBe false // codename not in the qualified allowlist
+            it.detail shouldBe R.string.adapter_detail_requires_lineageos
+        }
+        gated("oriole").probe(device(provider = false)).let {
+            it.matched shouldBe true
+            it.controlEnabled shouldBe false
+            it.detail shouldBe R.string.adapter_detail_lineageos_no_provider
+        }
+        gated("oriole").probe(device(systemUser = false)).let {
+            it.controlEnabled shouldBe false
+            it.detail shouldBe R.string.adapter_detail_secondary_user
+        }
+    }
+
+    private suspend fun observed(enabled: String?, mode: String? = null, limit: String? = null): ChargeObservation {
+        val values = mutableMapOf<String, String>()
+        enabled?.let { values[LineageChargingAdapter.KEY_ENABLED] = it }
+        mode?.let { values[LineageChargingAdapter.KEY_MODE] = it }
+        limit?.let { values[LineageChargingAdapter.KEY_LIMIT] = it }
+        val fake = FakeLineage(values)
+        return LineageChargingAdapter(fake).read(fake)
+    }
+
+    @Test
+    fun `read maps restorable states to Verified`() = runTest {
+        observed(enabled = "0") shouldBe ChargeObservation.Verified(ChargePolicy.Unrestricted, BackendKind.SHIZUKU)
+        observed(enabled = "1", mode = "3", limit = "80") shouldBe
+            ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.SHIZUKU)
+        observed(enabled = "1", mode = "3", limit = "95") shouldBe
+            ChargeObservation.Verified(ChargePolicy.FixedLimit(95), BackendKind.SHIZUKU)
+    }
+
+    @Test
+    fun `read refuses schedules, off-tick and non-canonical limits, absent and malformed enabled`() = runTest {
+        listOf(
+            observed(enabled = "1", mode = "1", limit = "80"), // AUTO schedule
+            observed(enabled = "1", mode = "2", limit = "80"), // CUSTOM schedule
+            observed(enabled = "1", mode = "3", limit = "72"), // off-tick limit
+            observed(enabled = "1", mode = "3", limit = "080"), // non-canonical (leading zero)
+            observed(enabled = "1", mode = "3", limit = "+80"), // non-canonical (sign)
+            observed(enabled = "1", mode = "3", limit = " 80 "), // non-canonical (whitespace)
+            observed(enabled = "1", mode = "3", limit = null), // limit absent
+            observed(enabled = null), // enabled absent (unconfigured) — refuse rather than guess "off"
+            observed(enabled = "x"), // malformed
+        ).forEach {
+            it.shouldBeInstanceOf<ChargeObservation.Unknown>()
+            it.unrecognizedValue shouldBe true
+        }
+    }
+
+    @Test
+    fun `unreadable state is unknown but not flagged unrecognized`() = runTest {
+        val fake = FakeLineage(readable = false)
+        val result = LineageChargingAdapter(fake).read(fake)
+        result.shouldBeInstanceOf<ChargeObservation.Unknown>()
+        result.unrecognizedValue shouldBe false
+    }
+
+    @Test
+    fun `apply writes limit, then mode, then enabled and read-back verifies`() = runTest {
+        val fake = FakeLineage()
+        LineageChargingAdapter(fake).apply(ChargePolicy.FixedLimit(85), fake) shouldBe true
+        fake.writes shouldContainExactly listOf(
+            SettingMutation(SettingNamespace.LINEAGE_SYSTEM, LineageChargingAdapter.KEY_LIMIT, "85"),
+            SettingMutation(SettingNamespace.LINEAGE_SYSTEM, LineageChargingAdapter.KEY_MODE, "3"),
+            SettingMutation(SettingNamespace.LINEAGE_SYSTEM, LineageChargingAdapter.KEY_ENABLED, "1"),
+        )
+
+        val off = FakeLineage()
+        LineageChargingAdapter(off).apply(ChargePolicy.Unrestricted, off) shouldBe true
+        off.writes shouldContainExactly listOf(
+            SettingMutation(SettingNamespace.LINEAGE_SYSTEM, LineageChargingAdapter.KEY_ENABLED, "0"),
+        )
+    }
+
+    @Test
+    fun `apply rejects unsupported policies and dropped writes`() = runTest {
+        LineageChargingAdapter(FakeLineage()).apply(ChargePolicy.Adaptive, FakeLineage()) shouldBe false
+        LineageChargingAdapter(FakeLineage()).apply(ChargePolicy.PauseAtFull, FakeLineage()) shouldBe false
+        LineageChargingAdapter(FakeLineage()).apply(ChargePolicy.FixedLimit(72), FakeLineage()) shouldBe false // off-tick
+        // Writes report success but never land → read-back mismatch fails the apply.
+        val dropping = FakeLineage(dropWrites = true)
+        LineageChargingAdapter(dropping).apply(ChargePolicy.FixedLimit(80), dropping) shouldBe false
+    }
+
+    @Test
+    fun `supported policies cover every discrete tick plus unrestricted`() {
+        LineageChargingAdapter(FakeLineage()).supportedPolicies shouldBe
+            LineageChargingAdapter.SUPPORTED_LIMITS.map { ChargePolicy.FixedLimit(it) } + ChargePolicy.Unrestricted
+    }
+
+    @Test
+    fun `session capabilities`() {
+        val adapter = LineageChargingAdapter(FakeLineage())
+        adapter.sessionOverridePolicy shouldBe ChargePolicy.Unrestricted
+        adapter.defaultProtectivePolicy shouldBe ChargePolicy.FixedLimit(80)
+        adapter.verification shouldBe VerificationStrategy.SYNC_READBACK
+        adapter.preferShizukuForWrites shouldBe true
+        adapter.reconnectGestureSupported shouldBe false
+    }
+
+    /** One fake serving BOTH the write backend and the read snapshot from a shared map — mirrors the real
+     * provider, where a Shizuku `content insert` and a ContentResolver query hit the same store. */
+    private class FakeLineage(
+        private val values: MutableMap<String, String> = mutableMapOf(),
+        private val readable: Boolean = true,
+        private val dropWrites: Boolean = false,
+    ) : AccessBackend, LineageChargeReader {
+        override val kind = BackendKind.SHIZUKU
+        val writes = mutableListOf<SettingMutation>()
+
+        override suspend fun status() = BackendStatus(true, true, "test".toCaString())
+        override suspend fun read(namespace: SettingNamespace, key: String) =
+            SettingRead(false, error = "lineage reads use LineageChargeReader".toCaString())
+
+        override suspend fun write(mutation: SettingMutation): Boolean {
+            writes += mutation
+            if (!dropWrites) values[mutation.key] = mutation.value
+            return true
+        }
+
+        override suspend fun readChargeControl(): LineageChargeReadout = if (!readable) {
+            LineageChargeReadout.Unreadable("blocked".toCaString())
+        } else {
+            LineageChargeReadout.Values(
+                enabled = values[LineageChargingAdapter.KEY_ENABLED],
+                mode = values[LineageChargingAdapter.KEY_MODE],
+                limit = values[LineageChargingAdapter.KEY_LIMIT],
+            )
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/amply/diagnostics/core/DefaultContributionRepositoryTest.kt
+++ b/app/src/test/java/eu/darken/amply/diagnostics/core/DefaultContributionRepositoryTest.kt
@@ -1,0 +1,77 @@
+package eu.darken.amply.diagnostics.core
+
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.charging.core.access.BackendStatus
+import eu.darken.amply.charging.core.access.LineageChargeReadout
+import eu.darken.amply.charging.core.access.LineageChargeReader
+import eu.darken.amply.charging.core.access.NamespaceSnapshot
+import eu.darken.amply.charging.core.access.SettingNamespace
+import eu.darken.amply.charging.core.access.SettingsSnapshotSource
+import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.adapter.LineageChargingAdapter
+import eu.darken.amply.charging.core.adapter.LineageLabAdapter
+import eu.darken.amply.charging.core.adapter.OnePlusChargingAdapter
+import eu.darken.amply.charging.core.adapter.OnePlusLabAdapter
+import eu.darken.amply.charging.core.adapter.PixelChargingAdapter
+import eu.darken.amply.charging.core.adapter.SamsungLabAdapter
+import eu.darken.amply.charging.core.adapter.SamsungLegacyChargingAdapter
+import eu.darken.amply.charging.core.adapter.SamsungModernChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiLabAdapter
+import eu.darken.amply.common.ca.toCaString
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class DefaultContributionRepositoryTest {
+
+    private class RecordingSource : SettingsSnapshotSource {
+        val requested = mutableListOf<SettingNamespace>()
+        override suspend fun status() = BackendStatus(available = true, granted = true, detail = "test".toCaString())
+        override suspend fun snapshot(namespace: SettingNamespace): NamespaceSnapshot {
+            requested += namespace
+            return NamespaceSnapshot.Success(emptyMap())
+        }
+    }
+
+    private val stubReader = object : LineageChargeReader {
+        override suspend fun readChargeControl() = LineageChargeReadout.Unreadable("unused".toCaString())
+    }
+
+    private val registry = AdapterRegistry(
+        context = ApplicationProvider.getApplicationContext(),
+        lineage = LineageChargingAdapter(stubReader),
+        lineageLab = LineageLabAdapter(),
+        pixel = PixelChargingAdapter(),
+        samsungModern = SamsungModernChargingAdapter(),
+        samsungLegacy = SamsungLegacyChargingAdapter(),
+        samsungLab = SamsungLabAdapter(),
+        xiaomi = XiaomiChargingAdapter(),
+        xiaomiLab = XiaomiLabAdapter(),
+        onePlus = OnePlusChargingAdapter(),
+        onePlusLab = OnePlusLabAdapter(),
+    )
+
+    @Test
+    fun `capture requests exactly the three AOSP namespaces, never the lineage provider`() = runTest {
+        val source = RecordingSource()
+        val repo = DefaultContributionRepository(ApplicationProvider.getApplicationContext(), source, registry)
+
+        val result = repo.captureSnapshot()
+
+        result.shouldBeInstanceOf<CaptureResult.Success>()
+        source.requested shouldContainExactly listOf(
+            SettingNamespace.SECURE,
+            SettingNamespace.GLOBAL,
+            SettingNamespace.SYSTEM,
+        )
+        source.requested shouldNotContain SettingNamespace.LINEAGE_SYSTEM
+    }
+}

--- a/app/src/test/java/eu/darken/amply/main/core/DeviceSupportReporterTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/core/DeviceSupportReporterTest.kt
@@ -27,7 +27,9 @@ class DeviceSupportReporterTest {
         oneUiVersion = 61000,
         hyperOsVersion = null,
         oplusRomVersion = null,
+        lineageOsVersion = null,
         hasProtectBattery = true,
+        hasLineageSettingsProvider = false,
         adapterId = adapterId,
         adapterMatched = adapterId != null,
         adapterControlEnabled = false,
@@ -44,13 +46,15 @@ class DeviceSupportReporterTest {
     fun `format is deterministic and schema-tagged`() {
         val text = formatReport(report())
         text shouldStartWith "Amply device-support request"
-        text shouldContain "report_schema=6"
+        text shouldContain "report_schema=7"
         text shouldContain "manufacturer=Samsung"
         text shouldContain "model=SM-S911B"
         text shouldContain "one_ui_version=61000"
         text shouldContain "hyperos_version=none"
         text shouldContain "oplus_rom_version=none"
+        text shouldContain "lineageos_version=none"
         text shouldContain "has_protect_battery=true"
+        text shouldContain "has_lineage_settings_provider=false"
         text shouldContain "adapter=samsung-lab"
         text shouldContain "contribution_wanted=true"
         // Same input twice must produce byte-identical output.

--- a/docs/plans/lineageos-adapter.md
+++ b/docs/plans/lineageos-adapter.md
@@ -1,0 +1,130 @@
+# Plan: LineageOS charging-control adapter (revised after Codex review)
+
+## Goal
+Add a control adapter for **LineageOS's native Charging Control** so Amply can read and set the charge
+limit on **qualified** LineageOS devices, integrated with Amply's session/widget/tile. Ships **disabled
+(lab/diagnostics only) until physical qualification** on the prepared Pixel 6 + LineageOS.
+
+## Confirmed facts (source-verified)
+- Separate provider: authority `lineagesettings`, System table `content://lineagesettings/system`.
+  Keys: `charging_control_enabled` (0/1), `charging_control_mode` (1=AUTO,2=CUSTOM,3=LIMIT),
+  `charging_control_charging_limit` (70..100), `charging_control_start_time`, `charging_control_target_time`.
+- Hard percent cap = `enabled=1` + `mode=3` + `charging_control_charging_limit=N`.
+- Reads unguarded (world-readable provider). Writes need `lineageos.permission.WRITE_SETTINGS`, held by the
+  ADB shell UID → **writable via Shizuku only**, no root. Provider validates writes (mode 1..3, limit 70..100).
+- Lineage's `ChargingControlController` observes the keys and re-drives `vendor.lineage.health.IChargingControl`.
+- **Top risk:** HAL device-dependence — the setting can flip while the HAL never limits (`mIsLimitSet:false`).
+  Setting readback does NOT prove hardware enforcement; only on-device qualification does.
+
+## Scope decisions (v1)
+- **Ships lab-only until qualified.** Live control gated to a **qualified-codename allowlist** (empty until the
+  Pixel 6 passes) + `lineageOsVersion != null` + provider present + system user. All other Lineage builds →
+  new `LineageLabAdapter` (diagnostics + contribution). No "verified device" ledger row until qualification.
+- **Recognize only exactly-restorable states.** `read()` returns `Verified` only for states v1 can restore
+  precisely (the supported limit set + Unrestricted). Native AUTO/CUSTOM, any unsupported limit, or an ambiguous
+  absent key → `Unknown(unrecognizedValue=true)`, so a session **refuses rather than clobbers**. Absent-key
+  meaning is characterized on-device, not guessed.
+- **Writes require Shizuku** (`preferShizukuForWrites = true`); direct ContentResolver writes → `false`.
+- **Reads are unprivileged** — via a shared `LineageSettingsClient` (ContentResolver), same values on either backend.
+- **Verification = SYNC_READBACK** (readback equality of the configured trio). Boot-recovery convergence is a
+  **qualification gate** (see §5): confirm Lineage's controller consumes persisted settings at boot and reacts to
+  external changes; if a race appears, add delayed-rewrite/async handling before shipping. (No repository
+  verification-flow change; this does not touch `computeRefreshPending`.)
+- **Reconnect gesture:** unsupported.
+- **Limit set:** decided by the open question below (80-only vs discrete 70..95 range). Plan is written parametric
+  on `SUPPORTED_LIMITS`.
+
+## Changes
+
+### 1. Access primitive
+- `SettingNamespace`: add `LINEAGE_SYSTEM`. **Also** replace `SettingNamespace.entries` in
+  `DefaultContributionRepository` with an explicit `STANDARD_SETTINGS_NAMESPACES = [SECURE, GLOBAL, SYSTEM]`
+  so the contribution wizard never queries the Lineage provider (would fail capture on stock devices).
+  + regression test asserting stock capture requests exactly those three.
+- AIDL `IChargingControlService`: add **only** `boolean writeLineageSetting(String key, String value) = 5;`
+  (constant `/system/bin/content insert`, constant URI, argv-separated, no shell string). No read/snapshot AIDL.
+- `ChargingControlUserService`: implement `writeLineageSetting` via `runBoundedProcess` with
+  `content insert --uri content://lineagesettings/system --bind name:s:<key> --bind value:s:<val>`.
+  New `LineageSettingWritePolicy`: read+write **key allowlist** = the 3 control keys; write domains
+  enabled∈{"0","1"}, mode∈{"3"}, limit∈`SUPPORTED_LIMITS` as canonical strings; reject leading-zero forms.
+- `LineageSettingsClient` (new, app-process): `ContentResolver.query(content://lineagesettings/system,
+  projection=[name,value], selection="name=?", selectionArgs=[key])`, `use{}` cursor, validate cardinality/
+  columns, distinguish **absent** (no row) from **failure** (SecurityException/null cursor). One query returns
+  all three keys to avoid a torn read between separate queries.
+- `ShizukuSettingsBackend`: `LINEAGE_SYSTEM` read → `LineageSettingsClient`; write → `writeLineageSetting`.
+  Wrap **all** blocking user-service calls (existing `read`/`write` too, not only `snapshot`) in
+  `withContext(Dispatchers.IO)`; rethrow `CancellationException` instead of swallowing via broad `runCatching`.
+- `DirectSettingsBackend`: `LINEAGE_SYSTEM` read → `LineageSettingsClient`; write → `false`.
+
+### 2. Detection
+- `LineageOsDetector`: `ro.lineage.build.version` via `SystemPropertyReader` → `String?`.
+- `DeviceInfo`: `lineageOsVersion: String?`, `hasLineageSettingsProvider: Boolean`
+  (`packageManager.resolveContentProvider("lineagesettings", 0) != null`, fail-closed).
+- Manifest `<queries><provider android:authorities="lineagesettings"/></queries>` (+ the Lineage
+  charging-control deep-link intent) so package-visibility doesn't false-negative resolution.
+
+### 3. Adapters
+- `LineageChargingAdapter` (`id = "lineageos-chargingcontrol-v1"`):
+  - `probe`: `matched = lineageOsVersion != null && codename in QUALIFIED_CODENAMES`;
+    `controlEnabled = matched && hasLineageSettingsProvider && isSystemUser`;
+    `contributionWanted = false` (unqualified Lineage is handled by the lab adapter).
+  - `verification = SYNC_READBACK`, `preferShizukuForWrites = true`.
+  - `supportedPolicies = SUPPORTED_LIMITS.map(::FixedLimit) + Unrestricted`;
+    `defaultProtectivePolicy = FixedLimit(80)`; `sessionOverridePolicy = Unrestricted`.
+  - `read`: decode trio; `enabled=0`→`Unrestricted`; `enabled=1 & mode=3 & limit∈SUPPORTED_LIMITS`→
+    `FixedLimit(limit)` (guard `FixedLimit` 50..100 with range check); every other enabled state (mode 1/2,
+    unsupported limit, malformed) → `Unknown(unrecognizedValue=true)`; unreadable → `Unknown` (not flagged).
+  - `mutationsFor(FixedLimit p)` = limit→mode→enabled (`p`, `3`, `1`); `Unrestricted` = enabled `0`.
+    `apply` writes then read-back-verifies (Samsung/Oplus pattern).
+  - `observedSettingUris` = table URI + per-key URIs for enabled/mode/limit (register both forms; confirm which
+    the provider notifies at qualification).
+  - `nativeSettingsIntent`: Lineage charging-control deep link, fallback `ACTION_BATTERY_SAVER_SETTINGS`.
+- `LineageLabAdapter` (`DisabledLabAdapter`, `id = "lineageos-lab"`): `matches = lineageOsVersion != null`
+  (diagnostics/contribution for unqualified Lineage builds).
+- `AdapterRegistry`: prepend `lineage, lineageLab` **before all OEM adapters**.
+
+### 4. Least privilege
+- `AutoWssGrantCoordinator`: skip the WSS auto-grant when the selected adapter `preferShizukuForWrites`
+  (WSS can't write these providers). Fixes Lineage and incidentally Oplus. + policy/flow tests.
+
+### 5. Verification / boot recovery (qualification-gated)
+- Keep `SYNC_READBACK`. During qualification, physically confirm: setting persists across reboot, Lineage's
+  controller re-drives the HAL after a cold boot, and an external mid-session change is observed. If boot testing
+  reveals an observer-startup race, add a delayed-rewrite/async-configured strategy before enabling. `mIsLimitSet`
+  is a qualification signal only (below the limit `false` is expected), correlated with real charging current/
+  status at and above threshold — not a runtime apply check.
+
+### 6. Strings / docs / reporting
+- Strings: `adapter_name_lineageos`, `adapter_detail_requires_lineageos`,
+  `adapter_detail_lineageos_no_provider`, `adapter_detail_lineageos_ready`, reuse `secondary_user`.
+- Device-support report: include `lineageOsVersion` + `hasLineageSettingsProvider` (light schema add).
+- Onboarding/README: correct the "ADB/WSS **or** Shizuku" copy — this adapter (like Oplus) needs Shizuku for writes.
+- Docs: `.claude/rules/privileged-access.md` (gate + write-policy keys + known gap; ledger row only after
+  qualification), `.claude/rules/architecture.md` (adapter section), `.claude/CLAUDE.md` (adapter summary).
+
+### 7. Tests (JUnit5 + Kotest)
+- `LineageOsDetector.parse`.
+- Adapter `read` mapping: Verified only for restorable states; AUTO/CUSTOM/unsupported-limit/malformed →
+  `Unknown(unrecognizedValue=true)`; absent-key behavior; unreadable → `Unknown` unflagged.
+- `mutationsFor` ordering (limit→mode→enabled) + partial-failure/readback-mismatch fails apply.
+- `LineageSettingWritePolicy` domains: reject mode `1`, limit `101`, leading-zero `080`, non-allowlisted key.
+- `probe` matrix: Lineage builds reporting Google/Samsung/Xiaomi/OnePlus/Oppo/realme + stock (property absent);
+  qualified vs non-qualified codename; provider absent; secondary user.
+- `AdapterRegistry` precedence: Lineage adapters win over OEM lab adapters on Lineage builds.
+- Contribution capture requests exactly `[SECURE, GLOBAL, SYSTEM]` on a stock device (regression).
+- `AutoWssGrant` skips WSS for a `preferShizukuForWrites` adapter.
+
+### 8. Qualification (Pixel 6 + LineageOS, device pending)
+Full ledger protocol incl.: characterize absent keys; native 70/80/85/100 + AUTO/CUSTOM **refusal without
+mutation**; provider notification URI forms; **`dumpsys lineagehealth mIsLimitSet` + real charging cessation**
+wired/wireless below/at/above threshold; access tiers; shell-permission denial; binder death; rootless-Shizuku
+reboot recovery; sessions/boot recovery; R8 `foss` beta; both flavor unit suites + both debug assembles/lints.
+
+## Out of scope
+- Extending the contribution wizard to *capture* `lineagesettings` (only the regression guard is in scope).
+- Runtime `dumpsys` verification; schedule (AUTO/CUSTOM) modes; reconnect gesture.
+
+## Risks
+1. HAL absent/broken → write succeeds, no limit. Mitigated by qualified-codename gate + known gap.
+2. Lineage fork strips shell-UID write grant → write fails; caught by read-back verification.
+3. Provider notification URI form varies → register table + per-key; confirm at qualification.


### PR DESCRIPTION
## What changed

LineageOS phones are now recognised by Amply. Instead of a generic "unsupported device", a LineageOS
device gets accurate guidance that points at LineageOS's own **Charging control** (Settings → Battery) plus
the "help add support" contribution flow, and the setup copy no longer implies ADB works everywhere.

Direct charge control on LineageOS is **not enabled yet** — this ships **diagnostics-only**. A device is only
switched on after its charging hardware is physically verified to actually hold the limit (see below), and no
device has passed that bar yet.

## Technical Context

**Why diagnostics-only, and the qualification result.** LineageOS's charge control is HAL-backed and the HAL is
device-dependent — on some devices the setting flips but charging never stops. So control is gated to a
**physically-qualified device-codename allowlist that ships empty**; every LineageOS build otherwise falls to a
new `LineageLabAdapter`. A Pixel 6 (`oriole`) on LineageOS 20 was qualified: the software path works end-to-end —
both raw (`content` ops as the shell UID) and **through the app's real Shizuku backend** (`writeLineageSetting` →
read back `Verified(FixedLimit(80), SHIZUKU)`), and LineageOS's own controller observes the external write — **but
the HAL does not enforce the hard limit** (the battery charged straight past it). That's a **NO-GO**, so `oriole`
stays out of the allowlist. The adapter's provider/observer mechanism is proven; only per-device HAL enforcement
varies.

**How it's built.**
- New access surface `SettingNamespace.LINEAGE_SYSTEM` for the private `lineagesettings` provider (not an AOSP
  `settings` namespace). Reads are unprivileged (`LineageChargeReader` — one consistent-snapshot `ContentResolver`
  query). Writes are **Shizuku-only** (`content insert`; the shell UID holds `lineageos.permission.WRITE_SETTINGS`,
  which `WRITE_SECURE_SETTINGS` cannot cover) via a new `writeLineageSetting` AIDL op guarded by
  `LineageSettingWritePolicy` (enabled 0/1, mode 3, limit 70..95).
- `LineageChargingAdapter` (`SYNC_READBACK`, `preferShizukuForWrites`) + `LineageLabAdapter`, registered **before**
  all OEM adapters so a LineageOS build on any OEM hardware is handled by them. Decode is refuse-don't-clobber:
  only exactly-restorable states read as `Verified`; AUTO/CUSTOM schedules, off-tick/non-canonical limits and an
  absent `enabled` read as `Unknown(unrecognized)` so a session never overwrites the user's native choice.
- Least privilege: the WSS auto-grant is skipped for Shizuku-write adapters (also fixes OnePlus/ColorOS). The
  Shizuku backend's read/write moved to `Dispatchers.IO` with `CancellationException` preserved.
- The contribution wizard now snapshots exactly `secure`/`global`/`system`, never the Lineage provider.
- `OemGuideCard`: LineageOS-specific "Charging control" wording, icon inline with the title, right-aligned action.
- Device-support report gains `lineageOsVersion` + `hasLineageSettingsProvider` (`report_schema` 7).

**Verification.** Design and implementation both reviewed by a second opinion; all findings integrated. 349 unit
tests pass, R8-minified build + lintVital clean (both flavors). On-device: diagnostics smoke test (empty allowlist
→ `lineageos-lab`, no crash) and the live control demo above.

Opened as **draft** — complete as a diagnostics-only change; ready for review before it lands.
