### PR TITLE
Dashboard: Add a battery-statistics entry card

### DIFF
--- a/app/src/debug/java/eu/darken/amply/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/amply/screenshots/ScreenshotContent.kt
@@ -86,6 +86,7 @@ private fun DashboardShot(state: DashboardUiState) = PreviewWrapper {
         onAlarmTargetChange = {},
         onFixNotifications = {},
         onOpenBatteryDetail = {},
+        onOpenStats = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},

--- a/app/src/main/java/eu/darken/amply/common/flow/FlowCombine.kt
+++ b/app/src/main/java/eu/darken/amply/common/flow/FlowCombine.kt
@@ -1,0 +1,25 @@
+package eu.darken.amply.common.flow
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+/**
+ * Typed [combine] for six flows. Kotlin's stdlib provides typed overloads only up to five, which
+ * forces view-model state assembled from more sources into nested pre-combines. This mirrors the
+ * helper other darken projects (CAPod, SD Maid) ship so the combine can stay flat. Add higher
+ * arities here as they are needed.
+ */
+fun <T1, T2, T3, T4, T5, T6, R> combine(
+    flow1: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    flow6: Flow<T6>,
+    transform: suspend (T1, T2, T3, T4, T5, T6) -> R,
+): Flow<R> = combine(
+    combine(flow1, flow2, flow3) { a, b, c -> Triple(a, b, c) },
+    combine(flow4, flow5, flow6) { d, e, f -> Triple(d, e, f) },
+) { (a, b, c), (d, e, f) ->
+    transform(a, b, c, d, e, f)
+}

--- a/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
@@ -103,11 +103,12 @@ class MainActivity : ComponentActivity() {
                     val state by viewModel.state.collectAsState()
                     val debugState by settingsViewModel.debugState.collectAsState()
                     val contributionState by contributionViewModel.state.collectAsState()
-                    val statsState by statsViewModel.state.collectAsState()
-                    val statsDetail by statsViewModel.detailState.collectAsState()
                     var destination by rememberSaveable { mutableStateOf(SettingsDestination.DASHBOARD) }
                     // Where a back-out of the contribution wizard returns to (set on each entry).
                     var wizardOrigin by rememberSaveable { mutableStateOf(SettingsDestination.DASHBOARD) }
+                    // Battery statistics is reachable from both the dashboard card and the settings hub;
+                    // remember which so back returns there.
+                    var statsOrigin by rememberSaveable { mutableStateOf(SettingsDestination.SETTINGS) }
                     val leaveWizard = {
                         contributionViewModel.exitWizard()
                         destination = wizardOrigin
@@ -207,11 +208,13 @@ class MainActivity : ComponentActivity() {
                             SettingsDestination.SETTINGS,
                             SettingsDestination.RECONNECT_GESTURE,
                             SettingsDestination.BATTERY_DETAIL -> destination = SettingsDestination.DASHBOARD
-                            // The session detail returns to the stats list; the list returns to settings.
+                            // The session detail returns to the stats list; the list returns to wherever
+                            // it was opened from (dashboard card or settings hub).
                             SettingsDestination.STATS_SESSION_DETAIL -> {
                                 statsViewModel.closeSession()
                                 destination = SettingsDestination.STATS
                             }
+                            SettingsDestination.STATS -> destination = statsOrigin
                             else -> destination = SettingsDestination.SETTINGS
                         }
                     }
@@ -250,6 +253,10 @@ class MainActivity : ComponentActivity() {
                             onAlarmTargetChange = viewModel::setChargeAlarmTarget,
                             onFixNotifications = viewModel::openNotificationSettings,
                             onOpenBatteryDetail = { destination = SettingsDestination.BATTERY_DETAIL },
+                            onOpenStats = {
+                                statsOrigin = SettingsDestination.DASHBOARD
+                                destination = SettingsDestination.STATS
+                            },
                             onPinWidget = viewModel::requestPinWidget,
                             onAddTile = viewModel::requestAddTile,
                             onDismissQuickAccess = viewModel::dismissQuickAccess,
@@ -269,7 +276,10 @@ class MainActivity : ComponentActivity() {
                         SettingsDestination.SETTINGS -> SettingsScreen(
                             onBack = { destination = SettingsDestination.DASHBOARD },
                             onGeneral = { destination = SettingsDestination.GENERAL },
-                            onStats = { destination = SettingsDestination.STATS },
+                            onStats = {
+                                statsOrigin = SettingsDestination.SETTINGS
+                                destination = SettingsDestination.STATS
+                            },
                             // Offered whenever this device is one we want contribution data for (unsupported/lab),
                             // regardless of whether Shizuku is installed yet — the wizard nudges the install.
                             showDiagnostics = state.charging.contributionWanted,
@@ -337,29 +347,38 @@ class MainActivity : ComponentActivity() {
                             readout = state.batteryReadout,
                             onBack = { destination = SettingsDestination.DASHBOARD },
                         )
-                        SettingsDestination.STATS -> StatsScreen(
-                            state = statsState,
-                            onBack = { destination = SettingsDestination.SETTINGS },
-                            onCaptureEnabledChange = { enabled ->
-                                if (enabled) {
-                                    runWithNotifications(NotificationAction.ENABLE_STATS)
-                                } else {
-                                    statsViewModel.setCaptureEnabled(false)
-                                }
-                            },
-                            onOpenSession = { id ->
-                                statsViewModel.openSession(id)
-                                destination = SettingsDestination.STATS_SESSION_DETAIL
-                            },
-                            onClearData = statsViewModel::clearData,
-                        )
-                        SettingsDestination.STATS_SESSION_DETAIL -> StatsSessionDetailScreen(
-                            state = statsDetail,
-                            onBack = {
-                                statsViewModel.closeSession()
-                                destination = SettingsDestination.STATS
-                            },
-                        )
+                        // Collect the stats state only while its screens are shown, so the stats Room DB
+                        // isn't opened just by having the dashboard up — a user who never enables
+                        // statistics never creates stats.db.
+                        SettingsDestination.STATS -> {
+                            val statsState by statsViewModel.state.collectAsState()
+                            StatsScreen(
+                                state = statsState,
+                                onBack = { destination = statsOrigin },
+                                onCaptureEnabledChange = { enabled ->
+                                    if (enabled) {
+                                        runWithNotifications(NotificationAction.ENABLE_STATS)
+                                    } else {
+                                        statsViewModel.setCaptureEnabled(false)
+                                    }
+                                },
+                                onOpenSession = { id ->
+                                    statsViewModel.openSession(id)
+                                    destination = SettingsDestination.STATS_SESSION_DETAIL
+                                },
+                                onClearData = statsViewModel::clearData,
+                            )
+                        }
+                        SettingsDestination.STATS_SESSION_DETAIL -> {
+                            val statsDetail by statsViewModel.detailState.collectAsState()
+                            StatsSessionDetailScreen(
+                                state = statsDetail,
+                                onBack = {
+                                    statsViewModel.closeSession()
+                                    destination = SettingsDestination.STATS
+                                },
+                            )
+                        }
                     }
                 }
                 }

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -81,6 +81,7 @@ import eu.darken.amply.battery.ui.BatteryInfoCard
 import eu.darken.amply.main.ui.setup.AccessSetupGuide
 import eu.darken.amply.main.ui.setup.OemGuideCard
 import eu.darken.amply.main.ui.setup.UnsupportedDeviceCard
+import eu.darken.amply.stats.ui.StatsDashboardCard
 import kotlinx.coroutines.delay
 
 @Composable
@@ -98,6 +99,7 @@ fun DashboardScreen(
     onAlarmTargetChange: (Int) -> Unit,
     onFixNotifications: () -> Unit,
     onOpenBatteryDetail: () -> Unit,
+    onOpenStats: () -> Unit,
     onPinWidget: () -> Unit,
     onAddTile: () -> Unit,
     onDismissQuickAccess: () -> Unit,
@@ -199,6 +201,14 @@ fun DashboardScreen(
                             onOpenDetail = onOpenBatteryDetail,
                         )
                     }
+                    item {
+                        StatsDashboardCard(
+                            enabled = state.statsEnabled,
+                            lastSession = state.statsLastSession,
+                            sessionCount = state.statsSessionCount,
+                            onOpen = onOpenStats,
+                        )
+                    }
                     if (state.charging.contributionWanted) {
                         item {
                             UnsupportedDeviceCard(
@@ -267,6 +277,14 @@ fun DashboardScreen(
                         BatteryInfoCard(
                             readout = state.batteryReadout ?: BatteryReadout.UNKNOWN,
                             onOpenDetail = onOpenBatteryDetail,
+                        )
+                    }
+                    item {
+                        StatsDashboardCard(
+                            enabled = state.statsEnabled,
+                            lastSession = state.statsLastSession,
+                            sessionCount = state.statsSessionCount,
+                            onOpen = onOpenStats,
                         )
                     }
                     // Promote the widget/tile shortcuts only once setup is done (the setup guide above
@@ -815,6 +833,7 @@ private fun DashboardScreenPreview() = PreviewWrapper {
         onAlarmTargetChange = {},
         onFixNotifications = {},
         onOpenBatteryDetail = {},
+        onOpenStats = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -881,6 +900,7 @@ private fun DashboardScreenApplyingPreview() = PreviewWrapper {
         onAlarmTargetChange = {},
         onFixNotifications = {},
         onOpenBatteryDetail = {},
+        onOpenStats = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -949,6 +969,7 @@ private fun DashboardScreenSessionActivePreview() = PreviewWrapper {
         onAlarmTargetChange = {},
         onFixNotifications = {},
         onOpenBatteryDetail = {},
+        onOpenStats = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1019,6 +1040,7 @@ private fun DashboardScreenSessionRecordedPreview() = PreviewWrapper {
         onAlarmTargetChange = {},
         onFixNotifications = {},
         onOpenBatteryDetail = {},
+        onOpenStats = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1077,6 +1099,7 @@ private fun DashboardScreenWssOnlyPreview() = PreviewWrapper {
         onAlarmTargetChange = {},
         onFixNotifications = {},
         onOpenBatteryDetail = {},
+        onOpenStats = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1142,6 +1165,7 @@ private fun DashboardScreenSamsungPreview() = PreviewWrapper {
         onAlarmTargetChange = {},
         onFixNotifications = {},
         onOpenBatteryDetail = {},
+        onOpenStats = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1208,6 +1232,7 @@ private fun DashboardScreenOnePlusNeedsShizukuPreview() = PreviewWrapper {
         onAlarmTargetChange = {},
         onFixNotifications = {},
         onOpenBatteryDetail = {},
+        onOpenStats = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1252,6 +1277,7 @@ private fun DashboardScreenUnsupportedPreview() = PreviewWrapper {
         onAlarmTargetChange = {},
         onFixNotifications = {},
         onOpenBatteryDetail = {},
+        onOpenStats = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
@@ -29,6 +29,7 @@ import eu.darken.amply.common.AmplyLinks
 import eu.darken.amply.common.debug.logging.Logging
 import eu.darken.amply.common.debug.logging.log
 import eu.darken.amply.common.debug.logging.logTag
+import eu.darken.amply.common.flow.combine as combine6
 import eu.darken.amply.fullcharge.core.ChargeSessionManager
 import eu.darken.amply.fullcharge.core.ChargeSessionRecord
 import eu.darken.amply.fullcharge.core.ChargeSessionService
@@ -50,6 +51,9 @@ import eu.darken.amply.alarm.core.ChargeAlarmStore
 import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.battery.core.BatteryReadoutSource
 import eu.darken.amply.monitor.core.ChargeMonitorWatcher
+import eu.darken.amply.stats.core.ChargeSessionSummary
+import eu.darken.amply.stats.core.ChargeStatsRepository
+import eu.darken.amply.stats.core.StatsPreferences
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -58,7 +62,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -82,6 +88,10 @@ data class DashboardUiState(
     val alarm: ChargeAlarmConfig = ChargeAlarmConfig(),
     /** True when the OS/channel would suppress the charge-alarm alert (permission off or blocked). */
     val notificationsBlocked: Boolean = false,
+    val statsEnabled: Boolean = false,
+    /** Most recent finished charge session, for the dashboard teaser (null when none yet). */
+    val statsLastSession: ChargeSessionSummary? = null,
+    val statsSessionCount: Int = 0,
 )
 
 @HiltViewModel
@@ -95,6 +105,8 @@ class DashboardViewModel @Inject constructor(
     private val quickAccessStore: QuickAccessStore,
     private val batteryReadoutSource: BatteryReadoutSource,
     private val chargeAlarmStore: ChargeAlarmStore,
+    private val statsPreferences: StatsPreferences,
+    private val statsRepository: ChargeStatsRepository,
     private val watchers: Set<@JvmSuppressWildcards ChargeMonitorWatcher>,
 ) : ViewModel() {
     private val deviceReport = MutableStateFlow<DeviceSupportReport?>(null)
@@ -109,15 +121,29 @@ class DashboardViewModel @Inject constructor(
         fullChargeStore.quickFullChargeAnyLevel,
     ) { enabled, anyLevel -> enabled to anyLevel }
 
-    // Same five-flow ceiling: the live battery readout, the alarm config, and the notifications-
-    // blocked flag are pre-combined so the outer combine stays within the typed overloads.
+    // Grouped so the outer combine keeps one slot each: the live battery readout, the alarm config,
+    // and the notifications-blocked flag.
     private val unprivilegedExtras = combine(
         batteryReadoutSource.readouts(),
         chargeAlarmStore.config,
         notificationsBlocked,
     ) { readout, alarm, blocked -> Triple(readout, alarm, blocked) }
 
-    val state = combine(
+    // Battery-statistics dashboard teaser. The session/count reads (which open the stats Room DB)
+    // run only while capture is enabled — when it's off the card shows a promo, so a user who never
+    // turned stats on never gets an empty stats.db created just by opening the dashboard.
+    private val statsDashboard = statsPreferences.captureEnabled.flatMapLatest { enabled ->
+        if (!enabled) {
+            flowOf(StatsDashboard(enabled = false, lastSession = null, count = 0))
+        } else {
+            combine(
+                statsRepository.recentSessions(limit = 1),
+                statsRepository.sessionCount(),
+            ) { recent, count -> StatsDashboard(enabled = true, lastSession = recent.firstOrNull(), count = count) }
+        }
+    }
+
+    val state = combine6(
         combine(
             repository.state,
             fullChargeStore.session,
@@ -138,7 +164,8 @@ class DashboardViewModel @Inject constructor(
         quickAccessChecked,
         tileRequestPending,
         unprivilegedExtras,
-    ) { base, quickAccess, checked, tilePending, (readout, alarm, blocked) ->
+        statsDashboard,
+    ) { base, quickAccess, checked, tilePending, (readout, alarm, blocked), stats ->
         base.copy(
             quickAccess = quickAccess,
             quickAccessChecked = checked,
@@ -146,8 +173,17 @@ class DashboardViewModel @Inject constructor(
             batteryReadout = readout,
             alarm = alarm,
             notificationsBlocked = blocked,
+            statsEnabled = stats.enabled,
+            statsLastSession = stats.lastSession,
+            statsSessionCount = stats.count,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), DashboardUiState())
+
+    private data class StatsDashboard(
+        val enabled: Boolean,
+        val lastSession: ChargeSessionSummary?,
+        val count: Int,
+    )
 
     val adbGrantCommand: String
         get() = "adb shell pm grant ${context.packageName} android.permission.WRITE_SECURE_SETTINGS"

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
@@ -22,6 +22,9 @@ class ChargeStatsRepository @Inject constructor(
     fun recentSessions(limit: Int = DEFAULT_SESSION_LIMIT): Flow<List<ChargeSessionSummary>> =
         database.get().statsDao().finishedSessions(limit).map { rows -> rows.map(::toSummary) }
 
+    /** Count of finished sessions (for the dashboard teaser). */
+    fun sessionCount(): Flow<Int> = database.get().statsDao().finishedSessionCount()
+
     fun session(id: Long): Flow<ChargeSessionSummary?> =
         database.get().statsDao().sessionFlow(id).map { it?.let(::toSummary) }
 

--- a/app/src/main/java/eu/darken/amply/stats/core/db/StatsDao.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/db/StatsDao.kt
@@ -32,6 +32,10 @@ interface StatsDao {
     @Query("SELECT * FROM charge_sessions WHERE endedAtWallMillis IS NOT NULL ORDER BY startedAtWallMillis DESC LIMIT :limit")
     fun finishedSessions(limit: Int): Flow<List<ChargeSessionEntity>>
 
+    /** Count of finished sessions, for the dashboard teaser. */
+    @Query("SELECT COUNT(*) FROM charge_sessions WHERE endedAtWallMillis IS NOT NULL")
+    fun finishedSessionCount(): Flow<Int>
+
     @Query("SELECT * FROM charge_sessions WHERE id = :id")
     fun sessionFlow(id: Long): Flow<ChargeSessionEntity?>
 

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsDashboardCard.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsDashboardCard.kt
@@ -1,0 +1,131 @@
+package eu.darken.amply.stats.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.ShowChart
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.amply.R
+import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.PreviewWrapper
+import eu.darken.amply.stats.core.ChargeSessionSummary
+import eu.darken.amply.stats.core.ChargingType
+import eu.darken.amply.stats.core.StatsSealReason
+
+/**
+ * Dashboard entry point for battery statistics, alongside the other permission-free feature cards.
+ * A navigation card (no inline toggle): when capture is off it promotes the feature, when on it
+ * teases the latest session and count. Tapping it opens the full statistics screen, where the
+ * always-on capture is turned on with its persistent-notification caveat.
+ */
+@Composable
+fun StatsDashboardCard(
+    enabled: Boolean,
+    lastSession: ChargeSessionSummary?,
+    sessionCount: Int,
+    onOpen: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier
+                .clickable(onClick = onOpen)
+                .padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ShowChart,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    stringResource(R.string.dashboard_stats_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = stringResource(R.string.dashboard_stats_view_action),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            when {
+                !enabled -> Text(
+                    stringResource(R.string.dashboard_stats_promo),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                lastSession != null -> {
+                    val range = StatsFormat.percentRange(lastSession.startPercent, lastSession.endPercent)
+                    val duration = StatsFormat.duration(lastSession.durationMillis)
+                    val summary = if (duration != null) "$range  ·  $duration" else range
+                    Text(
+                        stringResource(R.string.dashboard_stats_last, summary),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        pluralStringResource(R.plurals.dashboard_stats_session_count, sessionCount, sessionCount),
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                else -> Text(
+                    stringResource(R.string.dashboard_stats_recording_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@AmplyPreview
+@Composable
+private fun StatsDashboardCardPreview() = PreviewWrapper {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        StatsDashboardCard(
+            enabled = true,
+            lastSession = ChargeSessionSummary(
+                id = 1,
+                startedAtWallMillis = 0,
+                endedAtWallMillis = 0,
+                durationMillis = 4_320_000,
+                startPercent = 42,
+                endPercent = 100,
+                chargingType = ChargingType.AC,
+                avgPowerMilliwatts = 12_000,
+                peakPowerMilliwatts = 27_000,
+                minTemperatureTenthsC = 280,
+                avgTemperatureTenthsC = 305,
+                maxTemperatureTenthsC = 330,
+                limitHit = false,
+                partial = false,
+                fullReachedAtWallMillis = 0,
+                sealReason = StatsSealReason.UNPLUGGED,
+            ),
+            sessionCount = 3,
+            onOpen = {},
+        )
+        StatsDashboardCard(enabled = false, lastSession = null, sessionCount = 0, onOpen = {})
+        StatsDashboardCard(enabled = true, lastSession = null, sessionCount = 0, onOpen = {})
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -466,6 +466,15 @@
     <!-- Battery statistics -->
     <string name="settings_stats_title">Battery statistics</string>
     <string name="settings_stats_subtitle">Detailed charge history, speed, and temperature</string>
+    <string name="dashboard_stats_title">Battery statistics</string>
+    <string name="dashboard_stats_view_action">View</string>
+    <string name="dashboard_stats_promo">See detailed charge history, speed, and temperature</string>
+    <string name="dashboard_stats_last">Last charge: %1$s</string>
+    <string name="dashboard_stats_recording_empty">Recording — no completed session yet</string>
+    <plurals name="dashboard_stats_session_count">
+        <item quantity="one">%1$d recorded session</item>
+        <item quantity="other">%1$d recorded sessions</item>
+    </plurals>
     <string name="stats_title">Battery statistics</string>
     <string name="stats_capture_title">Record statistics</string>
     <string name="stats_capture_subtitle">Records each charge in detail — level, charging speed, and temperature over time. While on, Amply keeps a permanent notification and runs continuously; you can turn it off any time.</string>

--- a/app/src/test/java/eu/darken/amply/common/flow/FlowCombineTest.kt
+++ b/app/src/test/java/eu/darken/amply/common/flow/FlowCombineTest.kt
@@ -1,0 +1,55 @@
+package eu.darken.amply.common.flow
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class FlowCombineTest {
+
+    @Test
+    fun `combine passes all six values in order and preserves types`() = runTest {
+        val result = combine(
+            flowOf(1),
+            flowOf("a"),
+            flowOf(true),
+            flowOf(2L),
+            flowOf(3.0),
+            flowOf('x'),
+        ) { a, b, c, d, e, f -> listOf(a, b, c, d, e, f) }.first()
+
+        result shouldBe listOf(1, "a", true, 2L, 3.0, 'x')
+    }
+
+    @Test
+    fun `changes in the first flow group propagate`() = runTest {
+        var latest: Int? = null
+        combine(
+            flowOf(1, 2),
+            flowOf("a"),
+            flowOf(true),
+            flowOf(0L),
+            flowOf(0.0),
+            flowOf('z'),
+        ) { a, _, _, _, _, _ -> a }.collect { latest = it }
+
+        latest shouldBe 2
+    }
+
+    @Test
+    fun `changes in the second flow group propagate`() = runTest {
+        // Guards the internal two-group implementation: a change in flow 5 must reach the result.
+        var latest: Double? = null
+        combine(
+            flowOf(1),
+            flowOf("a"),
+            flowOf(true),
+            flowOf(0L),
+            flowOf(1.0, 2.0),
+            flowOf('z'),
+        ) { _, _, _, _, e, _ -> e }.collect { latest = it }
+
+        latest shouldBe 2.0
+    }
+}

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenGestureTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenGestureTest.kt
@@ -46,6 +46,7 @@ class DashboardScreenGestureTest {
                 onAlarmTargetChange = {},
                 onFixNotifications = {},
                 onOpenBatteryDetail = {},
+                onOpenStats = {},
                 onPinWidget = {},
                 onAddTile = {},
                 onDismissQuickAccess = {},


### PR DESCRIPTION
## What changed

The battery-statistics feature is now reachable from the **dashboard**, next to the battery-info and charge-alarm cards — previously it lived only in Settings. It's a navigation card (no inline toggle):

- **Capture off** → a promo ("See detailed charge history, speed, and temperature").
- **Capture on** → a teaser of the latest session (level range · duration) and the recorded-session count.

Tapping the card opens the existing statistics screen, where the always-on capture is turned on with its full persistent-notification explanation. Back from the stats screen returns to wherever it was opened from (dashboard or Settings).

## Technical Context

- **Typed 6-flow `combine`** (`common/flow/FlowCombine.kt`): Kotlin's stdlib `combine` overloads stop at five, so the dashboard state was assembled with pre-combined groups. Rather than nest another pre-combine, this adds the typed 6-arg helper the darken ecosystem (CAPod/SD Maid) uses, keeping the outer combine flat. Implemented as two `Triple` sub-combines (type-safe, no unchecked casts); unit-tested for order and for propagation from both flow groups.
- **No `stats.db` for non-users**: the dashboard's session/count reads run only while capture is enabled (`flatMapLatest` on the opt-in flag), and — the part that actually closes the hole — the stats ViewModel state is now collected only while its screens are composed (moved out of the always-collected composition root). So a user who never enables statistics never opens/creates the stats Room DB just by using the app. (Caught in review: the `flatMapLatest` alone wasn't enough because the root always collected the stats state.)
- **Navigation**: the stats screen is reachable from two entry points now; a `rememberSaveable` `statsOrigin` records which so system/toolbar Back returns there. The session-detail sub-screen still returns to the list, which returns to the origin.
- New DAO `finishedSessionCount()` query is additive — **no Room schema change**, no migration.

## Verification
- 386 unit tests pass (incl. the new combine-extension tests); both flavors assemble; all `lintVital` variants clean. Codex-reviewed (findings integrated).
- Card visual states covered by `@AmplyPreview` (enabled-with-session, enabled-no-session, disabled). No on-device pass run for this follow-up — the card is a pure nav card and the navigation paths were traced in review; happy to do an on-device check if you'd like.

## Noted pre-existing (not addressed here)
The session-**detail** screen's selected id is in-memory, so a process death while on it shows a spinner until Back. This predates this change (it was already reachable from Settings) and is orthogonal to the card — flagging for a possible follow-up.