### PR TITLE
Stats: Keep the session-detail selection across process death

### DIFF
--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsViewModel.kt
@@ -3,6 +3,7 @@ package eu.darken.amply.stats.ui
 import android.content.Context
 import android.content.Intent
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -14,7 +15,6 @@ import eu.darken.amply.stats.core.ChargeStatsRecorder
 import eu.darken.amply.stats.core.ChargeStatsRepository
 import eu.darken.amply.stats.core.StatsPreferences
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -44,6 +44,7 @@ class StatsViewModel @Inject constructor(
     private val preferences: StatsPreferences,
     private val repository: ChargeStatsRepository,
     private val recorder: ChargeStatsRecorder,
+    private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
     val state: StateFlow<StatsUiState> = combine(
@@ -54,7 +55,11 @@ class StatsViewModel @Inject constructor(
         StatsUiState(captureEnabled = enabled, lastCaptureWallMillis = lastCapture, sessions = sessions)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS), StatsUiState())
 
-    private val selectedSessionId = MutableStateFlow<Long?>(null)
+    // Backed by SavedStateHandle so the open detail screen survives process death: the restored
+    // Activity comes back to STATS_SESSION_DETAIL (a saved destination), and the id it needs is
+    // restored here too, rather than defaulting to null and stranding the screen on a spinner.
+    private val selectedSessionId: StateFlow<Long?> =
+        savedStateHandle.getStateFlow(KEY_SELECTED_SESSION, null)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val detailState: StateFlow<StatsDetailState?> = selectedSessionId
@@ -72,11 +77,11 @@ class StatsViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS), null)
 
     fun openSession(id: Long) {
-        selectedSessionId.value = id
+        savedStateHandle[KEY_SELECTED_SESSION] = id
     }
 
     fun closeSession() {
-        selectedSessionId.value = null
+        savedStateHandle[KEY_SELECTED_SESSION] = null
     }
 
     /**
@@ -105,5 +110,6 @@ class StatsViewModel @Inject constructor(
 
     private companion object {
         const val STOP_TIMEOUT_MILLIS = 5_000L
+        const val KEY_SELECTED_SESSION = "stats.selected_session_id"
     }
 }


### PR DESCRIPTION
## What changed

Fixes the battery-statistics **session-detail** screen showing a loading spinner (until you press Back) after the OS kills and restores the app process while that screen is open.

## Technical Context

The navigation `destination` is `rememberSaveable`, so after process death the Activity correctly returns to the detail screen — but the selected session id lived in an in-memory `MutableStateFlow` in `StatsViewModel`, which a fresh (post-process-death) ViewModel defaults to `null`. The detail flow then emits `null` and the screen never leaves its loading state, because nothing re-supplies the id. Back recovers it, so it was a spinner-until-Back, not a hard hang.

The fix backs the id with `SavedStateHandle` (`getStateFlow` + `handle[key] = …`), so it's restored alongside the destination and the curve reloads automatically. Hilt provides `SavedStateHandle` to the `@HiltViewModel` constructor with no extra wiring.

- Only affects **true process death**; rotation/other config changes were already fine (ViewModels survive those).
- Reproduce with Developer Options → **"Don't keep activities"**, open a session's detail, background, return.
- Pre-existing issue, noted on the dashboard-card PR (#8) as a follow-up — this is that follow-up.

## Verification
- 414 unit tests pass, both flavors assemble, all `lintVital` clean.
- No unit test added: `StatsViewModel`'s deps are concrete Room/DataStore-coupled classes with no existing test harness, so a meaningful test would be a heavy Robolectric setup disproportionate to a 4-line, framework-guaranteed change — and a unit test can't truly exercise process-death restoration anyway. The definitive check is the on-device "Don't keep activities" repro above; happy to run it if you'd like.