### PR TITLE
General: Unify card design and spacing across the app

### DIFF
--- a/app/src/main/java/eu/darken/amply/battery/ui/BatteryDetailScreen.kt
+++ b/app/src/main/java/eu/darken/amply/battery/ui/BatteryDetailScreen.kt
@@ -1,7 +1,6 @@
 package eu.darken.amply.battery.ui
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -26,6 +24,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardDefaults
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
 
@@ -141,18 +141,13 @@ private fun ThermalSection(readout: BatteryReadout) {
 
 @Composable
 private fun DetailSection(title: String, content: @Composable () -> Unit) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Text(
-                title,
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.primary,
-            )
-            content()
-        }
+    AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+        Text(
+            title,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        content()
     }
 }
 

--- a/app/src/main/java/eu/darken/amply/battery/ui/BatteryInfoCard.kt
+++ b/app/src/main/java/eu/darken/amply/battery/ui/BatteryInfoCard.kt
@@ -1,25 +1,15 @@
 package eu.darken.amply.battery.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.BatteryStd
-import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.common.compose.AmplyNavigationCard
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
 
@@ -33,36 +23,18 @@ fun BatteryInfoCard(
     onOpenDetail: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Card(modifier = modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    Icons.Default.BatteryStd,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Text(
-                    stringResource(R.string.battery_info_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.weight(1f),
-                )
-                TextButton(onClick = onOpenDetail) {
-                    Text(stringResource(R.string.battery_info_details_action))
-                    Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
-                }
-            }
-            Text(
-                summaryLine(readout),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+    AmplyNavigationCard(
+        onClick = onOpenDetail,
+        onClickLabel = stringResource(R.string.battery_info_details_action),
+        title = stringResource(R.string.battery_info_title),
+        icon = Icons.Default.BatteryStd,
+        modifier = modifier,
+    ) {
+        Text(
+            summaryLine(readout),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/app/src/main/java/eu/darken/amply/common/compose/AmplyCard.kt
+++ b/app/src/main/java/eu/darken/amply/common/compose/AmplyCard.kt
@@ -1,0 +1,425 @@
+package eu.darken.amply.common.compose
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared card design-system layer. Every card surface in the app routes through these primitives so
+ * padding, spacing, tone, and navigation affordance stay consistent. The primitives standardize
+ * *structure*; per-card colour accents, icon tints, and title sizes stay explicit at the call site.
+ */
+object AmplyCardDefaults {
+    /** Single source of truth for card content inset — flip here to re-tune every card at once. */
+    val ContentPadding = 16.dp
+
+    /** Opt-in intra-card vertical rhythm. Not a base default: cards with manual spacers must not
+     * combine it with [Arrangement.spacedBy], or gaps double. */
+    val ItemSpacing = 8.dp
+
+    /** Extra breathing room reserved below a header title, on top of [ItemSpacing], so the
+     * title↔body gap doesn't read as cramped once the trailing control is floated out of the row. */
+    val HeaderContentSpacing = 4.dp
+
+    val ContentPaddingValues = PaddingValues(ContentPadding)
+}
+
+/**
+ * Named visual roles mapping the app's existing Material 3 container tiers. A tone controls the
+ * card's container/content colours **only** — never the header icon/title tint, which stays explicit
+ * where it carries meaning (status green, primary accents, etc.).
+ */
+enum class AmplyCardTone {
+    /** [CardDefaults.cardColors] — the default filled card (surfaceContainerHighest). */
+    Default,
+    SurfaceContainer,
+    SurfaceLow,
+    SurfaceHigh,
+    PrimaryContainer,
+    SecondaryContainer,
+    TertiaryContainer,
+}
+
+@Composable
+private fun AmplyCardTone.colors(): CardColors {
+    val scheme = MaterialTheme.colorScheme
+    return when (this) {
+        AmplyCardTone.Default -> CardDefaults.cardColors()
+        AmplyCardTone.SurfaceContainer -> CardDefaults.cardColors(
+            containerColor = scheme.surfaceContainer,
+            contentColor = scheme.onSurface,
+        )
+        AmplyCardTone.SurfaceLow -> CardDefaults.cardColors(
+            containerColor = scheme.surfaceContainerLow,
+            contentColor = scheme.onSurface,
+        )
+        AmplyCardTone.SurfaceHigh -> CardDefaults.cardColors(
+            containerColor = scheme.surfaceContainerHigh,
+            contentColor = scheme.onSurface,
+        )
+        AmplyCardTone.PrimaryContainer -> CardDefaults.cardColors(
+            containerColor = scheme.primaryContainer,
+            contentColor = scheme.onPrimaryContainer,
+        )
+        AmplyCardTone.SecondaryContainer -> CardDefaults.cardColors(
+            containerColor = scheme.secondaryContainer,
+            contentColor = scheme.onSecondaryContainer,
+        )
+        AmplyCardTone.TertiaryContainer -> CardDefaults.cardColors(
+            containerColor = scheme.tertiaryContainer,
+            contentColor = scheme.onTertiaryContainer,
+        )
+    }
+}
+
+/**
+ * Base card surface: full width, toned colours, and the shared content inset. The default vertical
+ * arrangement is [Arrangement.Top] (no auto-spacing) so cards that keep manual spacers don't get
+ * doubled gaps — opt into [AmplyCardDefaults.ItemSpacing] explicitly.
+ */
+@Composable
+fun AmplyCard(
+    modifier: Modifier = Modifier,
+    tone: AmplyCardTone = AmplyCardTone.Default,
+    contentPadding: PaddingValues = AmplyCardDefaults.ContentPaddingValues,
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    contentAlpha: Float = 1f,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = tone.colors(),
+    ) {
+        Column(
+            // Alpha on the content, not the card surface, so a disabled card dims its controls while
+            // its background stays opaque.
+            modifier = Modifier
+                .padding(contentPadding)
+                .alpha(contentAlpha),
+            verticalArrangement = verticalArrangement,
+            content = content,
+        )
+    }
+}
+
+/**
+ * Base card whose whole surface is the click target (ripple, shape-clipping, and enabled-state live
+ * on the surface). Carries an explicit localized [onClickLabel] and [Role.Button] so accessibility
+ * services announce the action — a bare clickable [Card] is otherwise unlabeled. Callers own the
+ * layout; use for compact rows that don't fit the standard header.
+ */
+@Composable
+fun AmplyClickableCard(
+    onClick: () -> Unit,
+    onClickLabel: String,
+    modifier: Modifier = Modifier,
+    tone: AmplyCardTone = AmplyCardTone.Default,
+    contentPadding: PaddingValues = AmplyCardDefaults.ContentPaddingValues,
+    verticalArrangement: Arrangement.Vertical = Arrangement.Top,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier
+            .fillMaxWidth()
+            .semantics {
+                role = Role.Button
+                onClick(label = onClickLabel, action = null)
+            },
+        colors = tone.colors(),
+    ) {
+        Column(
+            modifier = Modifier.padding(contentPadding),
+            verticalArrangement = verticalArrangement,
+            content = content,
+        )
+    }
+}
+
+/**
+ * Card whose whole surface toggles a boolean ([Role.Switch] semantics), for a feature the card is
+ * primarily a switch for. Inner interactive controls (a slider, a settings button) keep their own
+ * gestures — only taps outside them flip the toggle. Pair the header's trailing slot with
+ * [AmplyCardToggleIndicator], a read-only switch that mirrors [checked]; the surface owns the toggle,
+ * so the indicator must not carry its own `onCheckedChange`.
+ */
+@Composable
+fun AmplyToggleCard(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    tone: AmplyCardTone = AmplyCardTone.Default,
+    contentPadding: PaddingValues = AmplyCardDefaults.ContentPaddingValues,
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing),
+    contentAlpha: Float = 1f,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    // Clip to the card shape before toggleable so the tap target and ripple are bounded by the
+    // rounded corners rather than the full rectangle (a non-clickable Card clips inside its modifier).
+    val shape = CardDefaults.shape
+    Card(
+        shape = shape,
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .toggleable(
+                value = checked,
+                enabled = enabled,
+                role = Role.Switch,
+                onValueChange = onCheckedChange,
+            ),
+        colors = tone.colors(),
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(contentPadding)
+                .alpha(contentAlpha),
+            verticalArrangement = verticalArrangement,
+            content = content,
+        )
+    }
+}
+
+/**
+ * Read-only, slightly reduced [Switch] used as the trailing indicator of an [AmplyToggleCard]. It
+ * reflects [checked] but does not handle its own clicks — the surrounding card owns the toggle — so
+ * it never double-fires. Scaled down since it reads as status, not the primary tap target.
+ */
+@Composable
+fun AmplyCardToggleIndicator(checked: Boolean, enabled: Boolean = true) {
+    Switch(
+        checked = checked,
+        onCheckedChange = null,
+        enabled = enabled,
+        modifier = Modifier.scale(0.75f),
+    )
+}
+
+/**
+ * Standard card header: optional leading icon + weighted title + optional trailing slot. [iconTint]
+ * and [titleStyle] are explicit (defaults suit the common feature card) so a caller can preserve a
+ * meaningful accent; a card whose header can't be expressed here (state-dependent leading content,
+ * hero title) should lay out its own header inside [AmplyCard] instead.
+ *
+ * The [trailing] control is **floated**: the header is only as tall as the title line, and the
+ * control is pinned to the end, vertically centered on that line, overflowing symmetrically into the
+ * surrounding padding. This keeps the title↔body gap tight — a `Switch`/`IconButton` carries a 48dp
+ * minimum touch target that would otherwise inflate the whole header row and push the body down. The
+ * control keeps its full touch target (it just overlaps neighbouring empty space invisibly). Pass a
+ * single composable; wrap multiple controls in your own `Row`.
+ */
+@Composable
+fun AmplyCardHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    iconTint: Color = MaterialTheme.colorScheme.primary,
+    titleStyle: androidx.compose.ui.text.TextStyle = MaterialTheme.typography.titleMedium,
+    trailing: (@Composable () -> Unit)? = null,
+) {
+    if (trailing == null) {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(bottom = AmplyCardDefaults.HeaderContentSpacing),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (icon != null) {
+                Icon(icon, contentDescription = null, tint = iconTint)
+            }
+            Text(title, style = titleStyle, modifier = Modifier.weight(1f))
+        }
+        return
+    }
+    Layout(
+        modifier = modifier.fillMaxWidth(),
+        content = {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (icon != null) {
+                    Icon(icon, contentDescription = null, tint = iconTint)
+                }
+                Text(title, style = titleStyle)
+            }
+            // Box keeps the trailing slot to exactly one measurable regardless of what the caller
+            // emits (conditional/empty or multiple children), so the layout below can't crash.
+            Box { trailing() }
+        },
+    ) { measurables, constraints ->
+        val gap = 8.dp.roundToPx()
+        val bottomInset = AmplyCardDefaults.HeaderContentSpacing.roundToPx()
+        val loose = constraints.copy(minWidth = 0, minHeight = 0)
+        val trailingPlaceable = measurables[1].measure(loose)
+        val titleMaxWidth = (constraints.maxWidth - trailingPlaceable.width - gap).coerceAtLeast(0)
+        val titlePlaceable = measurables[0].measure(loose.copy(maxWidth = titleMaxWidth))
+        // Header reports the title height plus a little breathing room below; the (taller) trailing
+        // control is centered on the title line and overflows symmetrically into the padding.
+        val height = titlePlaceable.height + bottomInset
+        layout(constraints.maxWidth, height) {
+            // placeRelative mirrors for RTL: the title group sits at the logical start and the
+            // trailing control at the logical end.
+            titlePlaceable.placeRelative(0, 0)
+            trailingPlaceable.placeRelative(
+                x = constraints.maxWidth - trailingPlaceable.width,
+                y = (titlePlaceable.height - trailingPlaceable.height) / 2,
+            )
+        }
+    }
+}
+
+/**
+ * Navigation card: the whole card opens a destination ([onClick]) with an [onClickLabel] for
+ * accessibility, a standard header, and a decorative RTL-aware trailing chevron. Must contain no
+ * independent interactive controls — the surface owns the single tap.
+ */
+@Composable
+fun AmplyNavigationCard(
+    onClick: () -> Unit,
+    onClickLabel: String,
+    title: String,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    iconTint: Color = MaterialTheme.colorScheme.primary,
+    tone: AmplyCardTone = AmplyCardTone.Default,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    AmplyClickableCard(
+        onClick = onClick,
+        onClickLabel = onClickLabel,
+        modifier = modifier,
+        tone = tone,
+        verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing),
+    ) {
+        AmplyCardHeader(
+            title = title,
+            icon = icon,
+            iconTint = iconTint,
+            trailing = {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+        )
+        content()
+    }
+}
+
+/**
+ * Shared inset block for monospace report/command previews. Selectable text on an inset surface.
+ * When [maxHeight] is set the block caps at that height and scrolls (for long reports); when null it
+ * wraps to content with no scroll container (for short snippets like a link or a command). Replaces
+ * the ad-hoc nested-card/Surface implementations.
+ */
+@Composable
+fun AmplyCodeBlock(
+    text: String,
+    modifier: Modifier = Modifier,
+    containerColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+    maxHeight: Dp? = null,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.small,
+        color = containerColor,
+    ) {
+        SelectionContainer {
+            Text(
+                text = text,
+                modifier = Modifier
+                    .then(
+                        if (maxHeight != null) {
+                            Modifier
+                                .heightIn(max = maxHeight)
+                                .verticalScroll(rememberScrollState())
+                        } else {
+                            Modifier
+                        },
+                    )
+                    .padding(12.dp),
+                style = MaterialTheme.typography.bodySmall,
+                fontFamily = FontFamily.Monospace,
+            )
+        }
+    }
+}
+
+@AmplyPreview
+@Composable
+private fun AmplyCardPreview() = PreviewWrapper {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+            AmplyCardHeader(
+                title = "Default card",
+                icon = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            )
+            Text(
+                "A neutral feature card with a standard header.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        AmplyNavigationCard(
+            onClick = {},
+            onClickLabel = "Open details",
+            title = "Navigation card",
+            icon = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+        ) {
+            Text(
+                "Whole card is the tap target; chevron is decorative.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        AmplyCard(tone = AmplyCardTone.PrimaryContainer) {
+            Text("Primary-container tone (hero CTA).", style = MaterialTheme.typography.bodyMedium)
+        }
+        AmplyCodeBlock(text = "adb shell settings put secure example 1", maxHeight = 120.dp)
+    }
+}

--- a/app/src/main/java/eu/darken/amply/diagnostics/ui/ContributionWizardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/diagnostics/ui/ContributionWizardScreen.kt
@@ -1,28 +1,21 @@
 package eu.darken.amply.diagnostics.ui
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
@@ -41,10 +34,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
 import eu.darken.amply.charging.core.access.BackendStatus
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardDefaults
+import eu.darken.amply.common.compose.AmplyCodeBlock
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
 import eu.darken.amply.common.compose.asComposable
@@ -207,44 +202,39 @@ private fun ShizukuCard(
     onAllowShizuku: () -> Unit,
 ) {
     val ready = shizuku?.ready == true
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Text(
-                stringResource(
-                    if (ready) {
-                        R.string.contribution_shizuku_ready_title
-                    } else {
-                        R.string.contribution_shizuku_required_title
-                    },
-                ),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Text(
-                shizuku?.detail?.asComposable() ?: stringResource(R.string.contribution_shizuku_checking),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            when {
-                shizuku == null || ready -> Unit
-                !shizuku.installed -> {
-                    Text(
-                        stringResource(R.string.contribution_shizuku_not_installed_body),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Button(onClick = onOpenShizuku) {
-                        Text(stringResource(R.string.contribution_install_shizuku))
-                    }
+    AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+        Text(
+            stringResource(
+                if (ready) {
+                    R.string.contribution_shizuku_ready_title
+                } else {
+                    R.string.contribution_shizuku_required_title
+                },
+            ),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Text(
+            shizuku?.detail?.asComposable() ?: stringResource(R.string.contribution_shizuku_checking),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        when {
+            shizuku == null || ready -> Unit
+            !shizuku.installed -> {
+                Text(
+                    stringResource(R.string.contribution_shizuku_not_installed_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Button(onClick = onOpenShizuku) {
+                    Text(stringResource(R.string.contribution_install_shizuku))
                 }
-                shizuku.available && !shizuku.granted -> Button(onClick = onAllowShizuku) {
-                    Text(stringResource(R.string.contribution_allow_shizuku))
-                }
-                !shizuku.available -> Button(onClick = onOpenShizuku) {
-                    Text(stringResource(R.string.contribution_open_shizuku))
-                }
+            }
+            shizuku.available && !shizuku.granted -> Button(onClick = onAllowShizuku) {
+                Text(stringResource(R.string.contribution_allow_shizuku))
+            }
+            !shizuku.available -> Button(onClick = onOpenShizuku) {
+                Text(stringResource(R.string.contribution_open_shizuku))
             }
         }
     }
@@ -371,31 +361,26 @@ private fun ModeCard(
     mode: ModeSummary,
     onSetEffect: (Int, String) -> Unit,
 ) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Text(mode.label, style = MaterialTheme.typography.titleMedium)
-            mode.changedFromPrevious?.let {
-                Text(
-                    stringResource(R.string.contribution_changed_count, it),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
+    AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+        Text(mode.label, style = MaterialTheme.typography.titleMedium)
+        mode.changedFromPrevious?.let {
             Text(
-                stringResource(R.string.contribution_effect_prompt),
+                stringResource(R.string.contribution_changed_count, it),
                 style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                EFFECT_CHOICES.forEach { (token, labelRes) ->
-                    FilterChip(
-                        selected = mode.effect == token,
-                        onClick = { onSetEffect(index, token) },
-                        label = { Text(stringResource(labelRes)) },
-                    )
-                }
+        }
+        Text(
+            stringResource(R.string.contribution_effect_prompt),
+            style = MaterialTheme.typography.bodySmall,
+        )
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            EFFECT_CHOICES.forEach { (token, labelRes) ->
+                FilterChip(
+                    selected = mode.effect == token,
+                    onClick = { onSetEffect(index, token) },
+                    label = { Text(stringResource(labelRes)) },
+                )
             }
         }
     }
@@ -434,43 +419,38 @@ private fun ReviewRowCard(
     onRevealRow: (SettingId) -> Unit,
     onToggleInclude: (SettingId) -> Unit,
 ) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            when {
-                row.disclosure == Disclosure.AUTO -> {
-                    Text(row.id.display, style = MaterialTheme.typography.titleSmall)
-                    Text(
-                        stringResource(R.string.contribution_review_auto),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-                    ReviewValues(row.values)
+    AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+        when {
+            row.disclosure == Disclosure.AUTO -> {
+                Text(row.id.display, style = MaterialTheme.typography.titleSmall)
+                Text(
+                    stringResource(R.string.contribution_review_auto),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                ReviewValues(row.values)
+            }
+            !row.revealed -> {
+                // Whole row stays hidden until revealed — key name included, since a setting name can itself
+                // carry an identifier. Only after Reveal is the name shown (locally) and offered for inclusion.
+                Text(
+                    stringResource(R.string.contribution_review_hidden),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                OutlinedButton(onClick = { onRevealRow(row.id) }) {
+                    Text(stringResource(R.string.contribution_review_reveal))
                 }
-                !row.revealed -> {
-                    // Whole row stays hidden until revealed — key name included, since a setting name can itself
-                    // carry an identifier. Only after Reveal is the name shown (locally) and offered for inclusion.
-                    Text(
-                        stringResource(R.string.contribution_review_hidden),
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+            }
+            else -> {
+                Text(row.id.display, style = MaterialTheme.typography.titleSmall)
+                ReviewValues(row.values)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Checkbox(
+                        checked = row.included,
+                        onCheckedChange = { onToggleInclude(row.id) },
                     )
-                    OutlinedButton(onClick = { onRevealRow(row.id) }) {
-                        Text(stringResource(R.string.contribution_review_reveal))
-                    }
-                }
-                else -> {
-                    Text(row.id.display, style = MaterialTheme.typography.titleSmall)
-                    ReviewValues(row.values)
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Checkbox(
-                            checked = row.included,
-                            onCheckedChange = { onToggleInclude(row.id) },
-                        )
-                        Text(stringResource(R.string.contribution_review_include))
-                    }
+                    Text(stringResource(R.string.contribution_review_include))
                 }
             }
         }
@@ -498,23 +478,7 @@ private fun LazyListScope.deliverStep(
     item { SectionTitle(stringResource(R.string.contribution_deliver_title)) }
     item { BodyText(stringResource(R.string.contribution_deliver_preview)) }
     item {
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            shape = RoundedCornerShape(8.dp),
-            color = MaterialTheme.colorScheme.surfaceVariant,
-        ) {
-            SelectionContainer {
-                Text(
-                    text = state.reportText ?: "",
-                    modifier = Modifier
-                        .heightIn(max = 260.dp)
-                        .verticalScroll(rememberScrollState())
-                        .padding(12.dp),
-                    style = MaterialTheme.typography.bodySmall,
-                    fontFamily = FontFamily.Monospace,
-                )
-            }
-        }
+        AmplyCodeBlock(text = state.reportText ?: "", maxHeight = 260.dp)
     }
     if (state.deliveryTooLargeBytes != null) {
         item { BodyText(stringResource(R.string.contribution_too_large)) }

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/ChargeAlarmCard.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/ChargeAlarmCard.kt
@@ -3,16 +3,12 @@ package eu.darken.amply.main.ui.dashboard
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.NotificationsActive
 import androidx.compose.material.icons.filled.WarningAmber
-import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -26,7 +22,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
 import eu.darken.amply.alarm.core.ChargeAlarmConfig
+import eu.darken.amply.common.compose.AmplyCardHeader
+import eu.darken.amply.common.compose.AmplyCardToggleIndicator
 import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.AmplyToggleCard
 import eu.darken.amply.common.compose.PreviewWrapper
 
 /**
@@ -49,65 +48,53 @@ fun ChargeAlarmCard(
         mutableFloatStateOf(config.targetPercent.toFloat())
     }
 
-    Card(modifier = modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
+    AmplyToggleCard(
+        checked = config.enabled,
+        onCheckedChange = onEnabledChange,
+        modifier = modifier,
+    ) {
+        AmplyCardHeader(
+            title = stringResource(R.string.dashboard_alarm_title),
+            icon = Icons.Default.NotificationsActive,
+            trailing = { AmplyCardToggleIndicator(config.enabled) },
+        )
+        Text(
+            stringResource(
+                if (config.enabled) R.string.dashboard_alarm_body_on else R.string.dashboard_alarm_body_off,
+            ),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            stringResource(R.string.dashboard_alarm_target_label, sliderValue.toInt()),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Slider(
+            value = sliderValue,
+            onValueChange = { sliderValue = it },
+            onValueChangeFinished = { onTargetChange(sliderValue.toInt()) },
+            valueRange = ChargeAlarmConfig.MIN_TARGET_PERCENT.toFloat()..ChargeAlarmConfig.MAX_TARGET_PERCENT.toFloat(),
+            // Range 50..100 in steps of 5 → 9 interior stops.
+            steps = ALARM_SLIDER_STEPS,
+        )
+        if (config.enabled && notificationsBlocked) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(
-                    Icons.Default.NotificationsActive,
+                    Icons.Default.WarningAmber,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = MaterialTheme.colorScheme.error,
                 )
                 Text(
-                    stringResource(R.string.dashboard_alarm_title),
-                    style = MaterialTheme.typography.titleMedium,
+                    stringResource(R.string.dashboard_alarm_notifications_blocked),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
                     modifier = Modifier.weight(1f),
                 )
-                Switch(checked = config.enabled, onCheckedChange = onEnabledChange)
-            }
-            Text(
-                stringResource(
-                    if (config.enabled) R.string.dashboard_alarm_body_on else R.string.dashboard_alarm_body_off,
-                ),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Text(
-                stringResource(R.string.dashboard_alarm_target_label, sliderValue.toInt()),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            Slider(
-                value = sliderValue,
-                onValueChange = { sliderValue = it },
-                onValueChangeFinished = { onTargetChange(sliderValue.toInt()) },
-                valueRange = ChargeAlarmConfig.MIN_TARGET_PERCENT.toFloat()..ChargeAlarmConfig.MAX_TARGET_PERCENT.toFloat(),
-                // Range 50..100 in steps of 5 → 9 interior stops.
-                steps = ALARM_SLIDER_STEPS,
-            )
-            if (config.enabled && notificationsBlocked) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        Icons.Default.WarningAmber,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.error,
-                    )
-                    Text(
-                        stringResource(R.string.dashboard_alarm_notifications_blocked),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.weight(1f),
-                    )
-                    TextButton(onClick = onFixNotifications) {
-                        Text(stringResource(R.string.dashboard_alarm_notifications_fix_action))
-                    }
+                TextButton(onClick = onFixNotifications) {
+                    Text(stringResource(R.string.dashboard_alarm_notifications_fix_action))
                 }
             }
         }

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -24,8 +24,6 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
@@ -38,7 +36,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -49,7 +46,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -70,7 +66,12 @@ import eu.darken.amply.charging.core.settlingTarget
 import eu.darken.amply.common.ca.CaString
 import eu.darken.amply.common.ca.caString
 import eu.darken.amply.common.ca.toCaString
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardHeader
+import eu.darken.amply.common.compose.AmplyCardToggleIndicator
+import eu.darken.amply.common.compose.AmplyCardTone
 import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.AmplyToggleCard
 import eu.darken.amply.common.compose.PreviewWrapper
 import eu.darken.amply.common.compose.asComposable
 import eu.darken.amply.fullcharge.core.ChargeSessionRecord
@@ -371,98 +372,95 @@ private fun StatusCard(
     val settling = state.charging.isSettling(now)
     val verified = observation is ChargeObservation.Verified
 
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
-    ) {
-        Column(Modifier.padding(20.dp)) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                if (settling) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(24.dp),
-                        strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.tertiary,
-                    )
-                } else {
-                    Icon(
-                        imageVector = if (verified) Icons.Default.CheckCircle else Icons.Default.Security,
-                        contentDescription = null,
-                        tint = if (verified) Color(0xFF1A7F5A) else MaterialTheme.colorScheme.tertiary,
-                    )
-                }
-                Text(
-                    when {
-                        settling -> stringResource(R.string.dashboard_applying)
-                        presentation == SessionPresentation.ACTIVE ->
-                            stringResource(R.string.dashboard_session_once_title)
-                        else -> observation.title().asComposable()
-                    },
-                    style = MaterialTheme.typography.titleLarge,
-                    modifier = Modifier.weight(1f),
-                )
-            }
-            if (!settling) {
-                // One explanatory line: during a one-time charge, which policy comes back; otherwise
-                // what the current policy does. Phrased as definitions so it stays honest when the
-                // observation is only "last requested". Sits directly under the title; the
-                // provenance line below is closer to metadata.
-                val explanation = if (presentation == SessionPresentation.ACTIVE) {
-                    state.session?.let {
-                        stringResource(R.string.dashboard_session_returns, it.restorePolicy.shortLabel().asComposable())
-                    }
-                } else {
-                    observation.policyOrNull()?.description()?.asComposable()
-                }
-                explanation?.let {
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        it,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-            // Divider marks the boundary between "what the current policy is" (title + explanation)
-            // above and the provenance metadata below — where the reading comes from and which device.
-            Spacer(Modifier.height(12.dp))
-            HorizontalDivider()
-            Spacer(Modifier.height(12.dp))
-            Text(
-                observation.detail().asComposable(),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.height(4.dp))
-            Text(
-                stringResource(
-                    R.string.dashboard_device_line,
-                    state.charging.device.model,
-                    state.charging.device.sdk,
-                ),
-                style = MaterialTheme.typography.labelMedium,
-            )
+    AmplyCard(tone = AmplyCardTone.SurfaceContainer) {
+        // Custom header: state-dependent leading spinner/icon, hero titleLarge, and dynamic tint —
+        // not expressible via the standard AmplyCardHeader, so laid out inline.
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             if (settling) {
-                val target = state.charging.settlingTarget()?.shortLabel()?.asComposable()
-                    ?: stringResource(R.string.dashboard_settling_fallback_target)
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    stringResource(R.string.dashboard_waiting_target, target),
-                    style = MaterialTheme.typography.labelMedium,
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp,
                     color = MaterialTheme.colorScheme.tertiary,
                 )
             } else {
-                // The repository's apply message describes the request the settling line already
-                // narrates, so only show it once settling has resolved.
-                state.charging.message?.let {
-                    Text(
-                        it.asComposable(),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.primary,
-                    )
+                Icon(
+                    imageVector = if (verified) Icons.Default.CheckCircle else Icons.Default.Security,
+                    contentDescription = null,
+                    tint = if (verified) Color(0xFF1A7F5A) else MaterialTheme.colorScheme.tertiary,
+                )
+            }
+            Text(
+                when {
+                    settling -> stringResource(R.string.dashboard_applying)
+                    presentation == SessionPresentation.ACTIVE ->
+                        stringResource(R.string.dashboard_session_once_title)
+                    else -> observation.title().asComposable()
+                },
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        if (!settling) {
+            // One explanatory line: during a one-time charge, which policy comes back; otherwise
+            // what the current policy does. Phrased as definitions so it stays honest when the
+            // observation is only "last requested". Sits directly under the title; the
+            // provenance line below is closer to metadata.
+            val explanation = if (presentation == SessionPresentation.ACTIVE) {
+                state.session?.let {
+                    stringResource(R.string.dashboard_session_returns, it.restorePolicy.shortLabel().asComposable())
                 }
+            } else {
+                observation.policyOrNull()?.description()?.asComposable()
+            }
+            explanation?.let {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        // Divider marks the boundary between "what the current policy is" (title + explanation)
+        // above and the provenance metadata below — where the reading comes from and which device.
+        Spacer(Modifier.height(12.dp))
+        HorizontalDivider()
+        Spacer(Modifier.height(12.dp))
+        Text(
+            observation.detail().asComposable(),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            stringResource(
+                R.string.dashboard_device_line,
+                state.charging.device.model,
+                state.charging.device.sdk,
+            ),
+            style = MaterialTheme.typography.labelMedium,
+        )
+        if (settling) {
+            val target = state.charging.settlingTarget()?.shortLabel()?.asComposable()
+                ?: stringResource(R.string.dashboard_settling_fallback_target)
+            Spacer(Modifier.height(4.dp))
+            Text(
+                stringResource(R.string.dashboard_waiting_target, target),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.tertiary,
+            )
+        } else {
+            // The repository's apply message describes the request the settling line already
+            // narrates, so only show it once settling has resolved.
+            state.charging.message?.let {
+                Text(
+                    it.asComposable(),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
             }
         }
     }
@@ -478,54 +476,49 @@ private fun FullChargeCard(
     // Any session record offers the restore action; only an observed full-charge policy (verified
     // or last requested) claims the one-time charge is running.
     val active = presentation != SessionPresentation.NONE
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
-    ) {
-        Column(Modifier.padding(16.dp)) {
-            Text(
-                when (presentation) {
-                    SessionPresentation.NONE -> stringResource(R.string.dashboard_fullcharge_idle_title)
-                    SessionPresentation.ACTIVE -> stringResource(R.string.dashboard_fullcharge_active_title)
-                    SessionPresentation.RECORDED -> stringResource(R.string.dashboard_fullcharge_recorded_title)
-                },
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-            )
+    AmplyCard(tone = AmplyCardTone.PrimaryContainer) {
+        Text(
             when (presentation) {
-                // The status card explains an ACTIVE session; repeating it here would duplicate.
-                SessionPresentation.ACTIVE -> Unit
-                SessionPresentation.NONE -> Text(
-                    stringResource(R.string.dashboard_fullcharge_idle_body),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                SessionPresentation.RECORDED -> Text(
-                    stringResource(R.string.dashboard_fullcharge_recorded_body),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            }
-            Spacer(Modifier.height(8.dp))
-            Button(
-                onClick = if (active) onRestore else onStart,
-                // Restore also writes, so it needs a working backend too — gating only on `active`
-                // would keep it enabled after Shizuku drops mid-session on a Shizuku-only adapter,
-                // where tapping it just fails. The Shizuku-required banner guides reconnection.
-                enabled = canControl,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Icon(
-                    if (active) Icons.Default.PowerSettingsNew else Icons.Default.BatteryChargingFull,
-                    contentDescription = null,
-                )
-                Text(
-                    if (active) {
-                        stringResource(R.string.dashboard_fullcharge_restore)
-                    } else {
-                        stringResource(R.string.dashboard_fullcharge_start)
-                    },
-                    Modifier.padding(start = 8.dp),
-                )
-            }
+                SessionPresentation.NONE -> stringResource(R.string.dashboard_fullcharge_idle_title)
+                SessionPresentation.ACTIVE -> stringResource(R.string.dashboard_fullcharge_active_title)
+                SessionPresentation.RECORDED -> stringResource(R.string.dashboard_fullcharge_recorded_title)
+            },
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        when (presentation) {
+            // The status card explains an ACTIVE session; repeating it here would duplicate.
+            SessionPresentation.ACTIVE -> Unit
+            SessionPresentation.NONE -> Text(
+                stringResource(R.string.dashboard_fullcharge_idle_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            SessionPresentation.RECORDED -> Text(
+                stringResource(R.string.dashboard_fullcharge_recorded_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+        Spacer(Modifier.height(8.dp))
+        Button(
+            onClick = if (active) onRestore else onStart,
+            // Restore also writes, so it needs a working backend too — gating only on `active`
+            // would keep it enabled after Shizuku drops mid-session on a Shizuku-only adapter,
+            // where tapping it just fails. The Shizuku-required banner guides reconnection.
+            enabled = canControl,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(
+                if (active) Icons.Default.PowerSettingsNew else Icons.Default.BatteryChargingFull,
+                contentDescription = null,
+            )
+            Text(
+                if (active) {
+                    stringResource(R.string.dashboard_fullcharge_restore)
+                } else {
+                    stringResource(R.string.dashboard_fullcharge_start)
+                },
+                Modifier.padding(start = 8.dp),
+            )
         }
     }
 }
@@ -545,14 +538,10 @@ private fun PolicyCard(
         }
         .map { it to it.choiceLabel() }
     val selectedPolicy = selectedPolicyFor(state.session, state.charging.observation)
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(Modifier.padding(start = 20.dp, end = 20.dp, top = 8.dp, bottom = 20.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    stringResource(R.string.dashboard_policy_card_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.weight(1f),
-                )
+    AmplyCard {
+        AmplyCardHeader(
+            title = stringResource(R.string.dashboard_policy_card_title),
+            trailing = {
                 TextButton(
                     onClick = onNativeSettings,
                     contentPadding = PaddingValues(horizontal = 8.dp),
@@ -568,33 +557,33 @@ private fun PolicyCard(
                         style = MaterialTheme.typography.labelLarge,
                     )
                 }
-            }
-            Spacer(Modifier.height(8.dp))
-            val choiceEnabled = state.charging.canApply && !state.charging.busy
-            if (choices.size <= 4) {
-                SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
-                    choices.forEachIndexed { index, (policy, label) ->
-                        SegmentedButton(
-                            selected = selectedPolicy == policy,
-                            onClick = { onApply(policy) },
-                            enabled = choiceEnabled,
-                            shape = SegmentedButtonDefaults.itemShape(index, choices.size),
-                        ) {
-                            Text(label)
-                        }
+            },
+        )
+        Spacer(Modifier.height(8.dp))
+        val choiceEnabled = state.charging.canApply && !state.charging.busy
+        if (choices.size <= 4) {
+            SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+                choices.forEachIndexed { index, (policy, label) ->
+                    SegmentedButton(
+                        selected = selectedPolicy == policy,
+                        onClick = { onApply(policy) },
+                        enabled = choiceEnabled,
+                        shape = SegmentedButtonDefaults.itemShape(index, choices.size),
+                    ) {
+                        Text(label)
                     }
                 }
-            } else {
-                // More options than a segmented row can fit legibly (Samsung: four limits + two modes).
-                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    choices.forEach { (policy, label) ->
-                        FilterChip(
-                            selected = selectedPolicy == policy,
-                            onClick = { onApply(policy) },
-                            enabled = choiceEnabled,
-                            label = { Text(label) },
-                        )
-                    }
+            }
+        } else {
+            // More options than a segmented row can fit legibly (Samsung: four limits + two modes).
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                choices.forEach { (policy, label) ->
+                    FilterChip(
+                        selected = selectedPolicy == policy,
+                        onClick = { onApply(policy) },
+                        enabled = choiceEnabled,
+                        label = { Text(label) },
+                    )
                 }
             }
         }
@@ -612,47 +601,38 @@ private fun QuickFullChargeCard(
     // When the gesture can neither be used nor turned off, dim the whole card so it reads as
     // disabled like the other controls, instead of showing a full-colour but inert toggle.
     val interactive = enabled || canControl
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier
-                .padding(start=20.dp,end=20.dp,top=12.dp,bottom=20.dp)
-                .alpha(if (interactive) 1f else 0.38f),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(Icons.Default.Bolt, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
-                Text(
-                    stringResource(R.string.dashboard_reconnect_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.weight(1f),
-                )
-                if (enabled) {
-                    IconButton(onClick = onOpenSettings, enabled = interactive) {
-                        Icon(
-                            Icons.TwoTone.Settings,
-                            contentDescription = stringResource(R.string.dashboard_reconnect_settings_action),
-                        )
+    AmplyToggleCard(
+        checked = enabled,
+        onCheckedChange = onEnabledChange,
+        enabled = interactive,
+        contentAlpha = if (interactive) 1f else 0.38f,
+    ) {
+        AmplyCardHeader(
+            title = stringResource(R.string.dashboard_reconnect_title),
+            icon = Icons.Default.Bolt,
+            trailing = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (enabled) {
+                        IconButton(onClick = onOpenSettings, enabled = interactive) {
+                            Icon(
+                                Icons.TwoTone.Settings,
+                                contentDescription = stringResource(R.string.dashboard_reconnect_settings_action),
+                            )
+                        }
                     }
+                    AmplyCardToggleIndicator(checked = enabled, enabled = interactive)
                 }
-                Switch(
-                    checked = enabled,
-                    onCheckedChange = onEnabledChange,
-                    enabled = enabled || canControl,
-                )
-            }
-            Text(
-                when {
-                    enabled && anyLevel -> stringResource(R.string.dashboard_reconnect_body_on_any_level)
-                    enabled -> stringResource(R.string.dashboard_reconnect_body_on)
-                    else -> stringResource(R.string.dashboard_reconnect_body_off)
-                },
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+            },
+        )
+        Text(
+            when {
+                enabled && anyLevel -> stringResource(R.string.dashboard_reconnect_body_on_any_level)
+                enabled -> stringResource(R.string.dashboard_reconnect_body_on)
+                else -> stringResource(R.string.dashboard_reconnect_body_off)
+            },
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 
@@ -697,39 +677,34 @@ private fun ShizukuBanner(
     onOpen: () -> Unit,
     onAllow: () -> Unit,
 ) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
-    ) {
-        Column(Modifier.padding(16.dp)) {
+    AmplyCard(tone = AmplyCardTone.TertiaryContainer) {
+        Text(
+            stringResource(
+                if (requiredForControl) R.string.dashboard_shizuku_required_title
+                else R.string.dashboard_shizuku_title,
+            ),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            stringResource(
+                if (requiredForControl) R.string.dashboard_shizuku_required_body
+                else R.string.dashboard_shizuku_body,
+            ),
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Spacer(Modifier.height(8.dp))
+        FilledTonalButton(
+            onClick = if (running) onAllow else onOpen,
+            modifier = Modifier.align(Alignment.End),
+        ) {
             Text(
-                stringResource(
-                    if (requiredForControl) R.string.dashboard_shizuku_required_title
-                    else R.string.dashboard_shizuku_title,
-                ),
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = FontWeight.SemiBold,
+                if (running) {
+                    stringResource(R.string.dashboard_shizuku_allow)
+                } else {
+                    stringResource(R.string.dashboard_shizuku_open)
+                },
             )
-            Text(
-                stringResource(
-                    if (requiredForControl) R.string.dashboard_shizuku_required_body
-                    else R.string.dashboard_shizuku_body,
-                ),
-                style = MaterialTheme.typography.bodySmall,
-            )
-            Spacer(Modifier.height(8.dp))
-            FilledTonalButton(
-                onClick = if (running) onAllow else onOpen,
-                modifier = Modifier.align(Alignment.End),
-            ) {
-                Text(
-                    if (running) {
-                        stringResource(R.string.dashboard_shizuku_allow)
-                    } else {
-                        stringResource(R.string.dashboard_shizuku_open)
-                    },
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/QuickAccessCard.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/QuickAccessCard.kt
@@ -1,27 +1,25 @@
 package eu.darken.amply.main.ui.dashboard
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Widgets
-import androidx.compose.material3.Card
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardDefaults
+import eu.darken.amply.common.compose.AmplyCardHeader
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
 import eu.darken.amply.main.core.QuickAccessState
@@ -50,57 +48,48 @@ fun QuickAccessCard(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Card(modifier = modifier.fillMaxWidth()) {
-        Column(Modifier.padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 20.dp)) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    Icons.Default.Widgets,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Text(
-                    stringResource(R.string.dashboard_quickaccess_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.weight(1f),
-                )
+    AmplyCard(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing),
+    ) {
+        AmplyCardHeader(
+            title = stringResource(R.string.dashboard_quickaccess_title),
+            icon = Icons.Default.Widgets,
+            trailing = {
                 IconButton(onClick = onDismiss) {
                     Icon(
                         Icons.Default.Close,
                         contentDescription = stringResource(R.string.dashboard_quickaccess_dismiss),
                     )
                 }
-            }
-            Text(
-                stringResource(R.string.dashboard_quickaccess_body),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(Modifier.height(12.dp))
-            // Weighted so long labels wrap inside the buttons instead of overflowing the row; a
-            // surface that is already added drops its button and the other expands to full width.
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                if (!widgetAdded) {
-                    FilledTonalButton(
-                        onClick = onPinWidget,
-                        modifier = Modifier.weight(1f),
-                    ) {
-                        Text(stringResource(R.string.dashboard_quickaccess_add_widget))
-                    }
+            },
+        )
+        Text(
+            stringResource(R.string.dashboard_quickaccess_body),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        // Weighted so long labels wrap inside the buttons instead of overflowing the row; a
+        // surface that is already added drops its button and the other expands to full width.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (!widgetAdded) {
+                FilledTonalButton(
+                    onClick = onPinWidget,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(R.string.dashboard_quickaccess_add_widget))
                 }
-                if (!tileAdded) {
-                    FilledTonalButton(
-                        onClick = onAddTile,
-                        enabled = !tileRequestPending,
-                        modifier = Modifier.weight(1f),
-                    ) {
-                        Text(stringResource(R.string.dashboard_quickaccess_add_tile))
-                    }
+            }
+            if (!tileAdded) {
+                FilledTonalButton(
+                    onClick = onAddTile,
+                    enabled = !tileRequestPending,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(R.string.dashboard_quickaccess_add_tile))
                 }
             }
         }

--- a/app/src/main/java/eu/darken/amply/main/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/onboarding/OnboardingScreen.kt
@@ -26,8 +26,6 @@ import androidx.compose.material.icons.twotone.BatteryChargingFull
 import androidx.compose.material.icons.twotone.Bolt
 import androidx.compose.material.icons.twotone.Restore
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -39,7 +37,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -48,7 +45,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.PaddingValues
 import eu.darken.amply.R
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardTone
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
 
@@ -176,27 +176,27 @@ private fun OnboardingWelcomePage(onNext: () -> Unit) = OnboardingScaffold(
         )
     }
 
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+    // Exception to the uniform card inset: the rows own their own horizontal padding, so this card
+    // keeps only the vertical inset and passes 0 horizontal.
+    AmplyCard(
+        tone = AmplyCardTone.SurfaceLow,
+        contentPadding = PaddingValues(vertical = 8.dp),
     ) {
-        Column(Modifier.padding(vertical = 8.dp)) {
-            FeatureRow(
-                icon = Icons.TwoTone.Restore,
-                title = stringResource(R.string.onboarding_feature_protection_title),
-                body = stringResource(R.string.onboarding_feature_protection_body),
-            )
-            FeatureRow(
-                icon = Icons.TwoTone.BatteryChargingFull,
-                title = stringResource(R.string.onboarding_feature_fullcharge_title),
-                body = stringResource(R.string.onboarding_feature_fullcharge_body),
-            )
-            FeatureRow(
-                icon = Icons.TwoTone.Bolt,
-                title = stringResource(R.string.onboarding_feature_shortcut_title),
-                body = stringResource(R.string.onboarding_feature_shortcut_body),
-            )
-        }
+        FeatureRow(
+            icon = Icons.TwoTone.Restore,
+            title = stringResource(R.string.onboarding_feature_protection_title),
+            body = stringResource(R.string.onboarding_feature_protection_body),
+        )
+        FeatureRow(
+            icon = Icons.TwoTone.BatteryChargingFull,
+            title = stringResource(R.string.onboarding_feature_fullcharge_title),
+            body = stringResource(R.string.onboarding_feature_fullcharge_body),
+        )
+        FeatureRow(
+            icon = Icons.TwoTone.Bolt,
+            title = stringResource(R.string.onboarding_feature_shortcut_title),
+            body = stringResource(R.string.onboarding_feature_shortcut_body),
+        )
     }
 }
 
@@ -217,22 +217,19 @@ private fun OnboardingCaveatsPage(onContinue: () -> Unit) = OnboardingScaffold(
     )
 
     CaveatCard(
-        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        tone = AmplyCardTone.TertiaryContainer,
         title = stringResource(R.string.onboarding_caveat_support_title),
         body = stringResource(R.string.onboarding_caveat_support_body),
     )
 
     CaveatCard(
-        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-        contentColor = MaterialTheme.colorScheme.onSurface,
+        tone = AmplyCardTone.SurfaceHigh,
         title = stringResource(R.string.onboarding_caveat_setup_title),
         body = stringResource(R.string.onboarding_caveat_setup_body),
     )
 
     CaveatCard(
-        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-        contentColor = MaterialTheme.colorScheme.onSurface,
+        tone = AmplyCardTone.SurfaceHigh,
         title = stringResource(R.string.onboarding_caveat_restore_title),
         body = stringResource(R.string.onboarding_caveat_restore_body),
     )
@@ -243,20 +240,14 @@ private const val ONBOARDING_PAGE_COUNT = 2
 
 @Composable
 private fun CaveatCard(
-    containerColor: Color,
-    contentColor: Color,
+    tone: AmplyCardTone,
     title: String,
     body: String,
 ) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = containerColor, contentColor = contentColor),
-    ) {
-        Column(Modifier.padding(20.dp)) {
-            Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-            Spacer(Modifier.height(8.dp))
-            Text(body, style = MaterialTheme.typography.bodyMedium)
-        }
+    AmplyCard(tone = tone) {
+        Text(title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.height(8.dp))
+        Text(body, style = MaterialTheme.typography.bodyMedium)
     }
 }
 

--- a/app/src/main/java/eu/darken/amply/main/ui/setup/AccessSetupGuide.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/setup/AccessSetupGuide.kt
@@ -1,22 +1,17 @@
 package eu.darken.amply.main.ui.setup
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
@@ -24,10 +19,8 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
@@ -38,6 +31,10 @@ import eu.darken.amply.charging.core.access.AccessSnapshot
 import eu.darken.amply.charging.core.access.BackendStatus
 import eu.darken.amply.common.AmplyLinks
 import eu.darken.amply.common.ca.toCaString
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardHeader
+import eu.darken.amply.common.compose.AmplyCardTone
+import eu.darken.amply.common.compose.AmplyCodeBlock
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
 import eu.darken.amply.main.ui.dashboard.DashboardUiState
@@ -63,159 +60,128 @@ fun AccessSetupGuide(
     val shizukuRunning = access?.shizuku?.available == true
     val shizukuReady = access?.shizuku?.ready == true
 
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = if (wssReady) {
-                MaterialTheme.colorScheme.secondaryContainer
-            } else {
-                MaterialTheme.colorScheme.surfaceContainerHigh
-            },
-        ),
+    AmplyCard(
+        modifier = modifier,
+        tone = if (wssReady) AmplyCardTone.SecondaryContainer else AmplyCardTone.SurfaceHigh,
     ) {
-        Column(Modifier.padding(20.dp)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    // A wrench reads as "setup work"; the shield the status card uses implied protection
-                    // was already active. The ready state keeps the check to signal completion.
-                    imageVector = if (wssReady) Icons.Default.CheckCircle else Icons.Default.Build,
-                    contentDescription = null,
-                    tint = if (wssReady) {
-                        MaterialTheme.colorScheme.primary
+        AmplyCardHeader(
+            title = if (wssReady) {
+                stringResource(R.string.setup_access_ready_title)
+            } else {
+                stringResource(R.string.setup_access_setup_title)
+            },
+            // A wrench reads as "setup work"; the shield the status card uses implied protection
+            // was already active. The ready state keeps the check to signal completion.
+            icon = if (wssReady) Icons.Default.CheckCircle else Icons.Default.Build,
+            iconTint = if (wssReady) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            titleStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = if (wssReady) {
+                stringResource(R.string.setup_access_ready_body)
+            } else {
+                stringResource(R.string.setup_access_setup_body)
+            },
+            style = MaterialTheme.typography.bodyMedium,
+        )
+
+        if (!wssReady) {
+            Spacer(Modifier.height(20.dp))
+            Text(stringResource(R.string.setup_access_option_shizuku), style = MaterialTheme.typography.labelLarge)
+            Text(
+                stringResource(R.string.setup_access_shizuku_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(8.dp))
+            when {
+                shizukuReady -> Button(
+                    onClick = onGrantWss,
+                    enabled = !state.charging.grantingWss,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    if (state.charging.grantingWss) {
+                        CircularProgressIndicator(
+                            // Follow the (disabled) button's content color rather than a fixed onPrimary,
+                            // which would under-contrast against the disabled container in light themes.
+                            modifier = Modifier.size(18.dp),
+                            strokeWidth = 2.dp,
+                            color = LocalContentColor.current,
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(R.string.setup_access_granting_shizuku))
                     } else {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    },
-                )
-                Text(
-                    text = if (wssReady) {
-                        stringResource(R.string.setup_access_ready_title)
-                    } else {
-                        stringResource(R.string.setup_access_setup_title)
-                    },
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    modifier = Modifier.weight(1f),
-                )
+                        Text(stringResource(R.string.setup_access_grant_shizuku))
+                    }
+                }
+                shizukuRunning -> FilledTonalButton(
+                    onClick = onAllowShizuku,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(R.string.setup_access_allow_shizuku))
+                }
+                else -> FilledTonalButton(
+                    onClick = onOpenShizuku,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(R.string.setup_access_open_shizuku))
+                }
+            }
+
+            Spacer(Modifier.height(20.dp))
+            Text(stringResource(R.string.setup_access_option_computer), style = MaterialTheme.typography.labelLarge)
+
+            // Primary computer path: the browser (WebUSB) helper, which grants over USB
+            // without a local ADB install. The link is opened on the *computer* the phone is
+            // plugged into — a phone cannot host itself — so we surface a copyable link, not
+            // an "open" action that would launch the phone's own browser.
+            Text(
+                stringResource(R.string.setup_access_webusb_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(8.dp))
+            AmplyCodeBlock(
+                text = AmplyLinks.WEB_ADB,
+                containerColor = MaterialTheme.colorScheme.surface,
+            )
+            Spacer(Modifier.height(4.dp))
+            FilledTonalButton(onClick = onCopyWebUsbLink, modifier = Modifier.fillMaxWidth()) {
+                Icon(Icons.Default.ContentCopy, contentDescription = null)
+                Text(stringResource(R.string.setup_access_copy_webusb), Modifier.padding(start = 8.dp))
+            }
+
+            // Fallback for users who already have ADB set up on that computer.
+            Spacer(Modifier.height(12.dp))
+            Text(
+                stringResource(R.string.setup_access_adb_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(8.dp))
+            AmplyCodeBlock(
+                text = adbCommand,
+                containerColor = MaterialTheme.colorScheme.surface,
+            )
+            Spacer(Modifier.height(4.dp))
+            FilledTonalButton(onClick = onCopyAdb, modifier = Modifier.fillMaxWidth()) {
+                Icon(Icons.Default.ContentCopy, contentDescription = null)
+                Text(stringResource(R.string.setup_access_copy_adb), Modifier.padding(start = 8.dp))
             }
             Spacer(Modifier.height(8.dp))
             Text(
-                text = if (wssReady) {
-                    stringResource(R.string.setup_access_ready_body)
-                } else {
-                    stringResource(R.string.setup_access_setup_body)
-                },
-                style = MaterialTheme.typography.bodyMedium,
+                // An external `adb pm grant` fires no OS callback, but while this card is shown Amply
+                // polls for the grant (see monitorAccessWhileAwaitingGrant); the note reassures the user
+                // it is detected automatically, with manual Refresh as a fallback.
+                stringResource(R.string.setup_access_adb_refresh_note),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-
-            if (!wssReady) {
-                Spacer(Modifier.height(20.dp))
-                Text(stringResource(R.string.setup_access_option_shizuku), style = MaterialTheme.typography.labelLarge)
-                Text(
-                    stringResource(R.string.setup_access_shizuku_hint),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(Modifier.height(8.dp))
-                when {
-                    shizukuReady -> Button(
-                        onClick = onGrantWss,
-                        enabled = !state.charging.grantingWss,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        if (state.charging.grantingWss) {
-                            CircularProgressIndicator(
-                                // Follow the (disabled) button's content color rather than a fixed onPrimary,
-                                // which would under-contrast against the disabled container in light themes.
-                                modifier = Modifier.size(18.dp),
-                                strokeWidth = 2.dp,
-                                color = LocalContentColor.current,
-                            )
-                            Spacer(Modifier.width(8.dp))
-                            Text(stringResource(R.string.setup_access_granting_shizuku))
-                        } else {
-                            Text(stringResource(R.string.setup_access_grant_shizuku))
-                        }
-                    }
-                    shizukuRunning -> FilledTonalButton(
-                        onClick = onAllowShizuku,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Text(stringResource(R.string.setup_access_allow_shizuku))
-                    }
-                    else -> FilledTonalButton(
-                        onClick = onOpenShizuku,
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        Text(stringResource(R.string.setup_access_open_shizuku))
-                    }
-                }
-
-                Spacer(Modifier.height(20.dp))
-                Text(stringResource(R.string.setup_access_option_computer), style = MaterialTheme.typography.labelLarge)
-
-                // Primary computer path: the browser (WebUSB) helper, which grants over USB
-                // without a local ADB install. The link is opened on the *computer* the phone is
-                // plugged into — a phone cannot host itself — so we surface a copyable link, not
-                // an "open" action that would launch the phone's own browser.
-                Text(
-                    stringResource(R.string.setup_access_webusb_hint),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(Modifier.height(8.dp))
-                Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
-                    SelectionContainer {
-                        Text(
-                            text = AmplyLinks.WEB_ADB,
-                            modifier = Modifier.padding(12.dp),
-                            style = MaterialTheme.typography.bodySmall,
-                            fontFamily = FontFamily.Monospace,
-                        )
-                    }
-                }
-                Spacer(Modifier.height(4.dp))
-                FilledTonalButton(onClick = onCopyWebUsbLink, modifier = Modifier.fillMaxWidth()) {
-                    Icon(Icons.Default.ContentCopy, contentDescription = null)
-                    Text(stringResource(R.string.setup_access_copy_webusb), Modifier.padding(start = 8.dp))
-                }
-
-                // Fallback for users who already have ADB set up on that computer.
-                Spacer(Modifier.height(12.dp))
-                Text(
-                    stringResource(R.string.setup_access_adb_hint),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(Modifier.height(8.dp))
-                Card(colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)) {
-                    SelectionContainer {
-                        Text(
-                            text = adbCommand,
-                            modifier = Modifier.padding(12.dp),
-                            style = MaterialTheme.typography.bodySmall,
-                            fontFamily = FontFamily.Monospace,
-                        )
-                    }
-                }
-                Spacer(Modifier.height(4.dp))
-                FilledTonalButton(onClick = onCopyAdb, modifier = Modifier.fillMaxWidth()) {
-                    Icon(Icons.Default.ContentCopy, contentDescription = null)
-                    Text(stringResource(R.string.setup_access_copy_adb), Modifier.padding(start = 8.dp))
-                }
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    // An external `adb pm grant` fires no OS callback, but while this card is shown Amply
-                    // polls for the grant (see monitorAccessWhileAwaitingGrant); the note reassures the user
-                    // it is detected automatically, with manual Refresh as a fallback.
-                    stringResource(R.string.setup_access_adb_refresh_note),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/setup/OemGuideCard.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/setup/OemGuideCard.kt
@@ -3,14 +3,10 @@ package eu.darken.amply.main.ui.setup
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.twotone.BatteryChargingFull
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -21,6 +17,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardDefaults
+import eu.darken.amply.common.compose.AmplyCardHeader
+import eu.darken.amply.common.compose.AmplyCardTone
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
 
@@ -37,46 +37,29 @@ fun OemGuideCard(
     modifier: Modifier = Modifier,
     isLineageOs: Boolean = false,
 ) {
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-        ),
+    AmplyCard(
+        modifier = modifier,
+        tone = AmplyCardTone.SecondaryContainer,
+        verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing),
     ) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+        AmplyCardHeader(
+            title = stringResource(R.string.setup_oem_guide_title),
+            icon = Icons.TwoTone.BatteryChargingFull,
+            iconTint = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+        Text(
+            stringResource(oemInstructions(manufacturer, isLineageOs)),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        FilledTonalButton(
+            onClick = onOpenSettings,
+            modifier = Modifier.align(Alignment.End),
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Icon(
-                    Icons.TwoTone.BatteryChargingFull,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-                Text(
-                    stringResource(R.string.setup_oem_guide_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
-            }
+            Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null)
             Text(
-                stringResource(oemInstructions(manufacturer, isLineageOs)),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                stringResource(R.string.setup_oem_guide_open_action),
+                modifier = Modifier.padding(start = 8.dp),
             )
-            FilledTonalButton(
-                onClick = onOpenSettings,
-                modifier = Modifier.align(Alignment.End),
-            ) {
-                Icon(Icons.AutoMirrored.Filled.OpenInNew, contentDescription = null)
-                Text(
-                    stringResource(R.string.setup_oem_guide_open_action),
-                    modifier = Modifier.padding(start = 8.dp),
-                )
-            }
         }
     }
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/setup/UnsupportedDeviceCard.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/setup/UnsupportedDeviceCard.kt
@@ -2,13 +2,8 @@ package eu.darken.amply.main.ui.setup
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.OpenInNew
 import androidx.compose.material.icons.twotone.ContentCopy
@@ -16,8 +11,6 @@ import androidx.compose.material.icons.twotone.Email
 import androidx.compose.material.icons.twotone.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -32,10 +25,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardDefaults
+import eu.darken.amply.common.compose.AmplyCardHeader
+import eu.darken.amply.common.compose.AmplyCardTone
+import eu.darken.amply.common.compose.AmplyCodeBlock
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
 
@@ -59,82 +56,66 @@ fun UnsupportedDeviceCard(
 ) {
     var showDialog by remember { mutableStateOf(false) }
 
-    Card(
-        modifier = modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-        ),
+    AmplyCard(
+        modifier = modifier,
+        tone = AmplyCardTone.SurfaceHigh,
+        verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing),
     ) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+        AmplyCardHeader(
+            title = stringResource(R.string.setup_unsupported_title),
+            icon = Icons.TwoTone.Info,
+            titleStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+        )
+        Text(
+            text = stringResource(R.string.setup_unsupported_body, manufacturer),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Text(
+            text = stringResource(R.string.setup_unsupported_shares_note),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        // Primary path: the guided wizard, which produces the far more useful setting-discovery report.
+        Button(
+            onClick = onOpenWizard,
+            modifier = Modifier.fillMaxWidth(),
         ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    Icons.TwoTone.Info,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Text(
-                    text = stringResource(R.string.setup_unsupported_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
-            }
+            Icon(Icons.AutoMirrored.TwoTone.OpenInNew, contentDescription = null)
             Text(
-                text = stringResource(R.string.setup_unsupported_body, manufacturer),
-                style = MaterialTheme.typography.bodyMedium,
+                stringResource(R.string.setup_unsupported_wizard_action),
+                Modifier.padding(start = 8.dp),
             )
-            Text(
-                text = stringResource(R.string.setup_unsupported_shares_note),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            // Primary path: the guided wizard, which produces the far more useful setting-discovery report.
-            Button(
-                onClick = onOpenWizard,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Icon(Icons.AutoMirrored.TwoTone.OpenInNew, contentDescription = null)
-                Text(
-                    stringResource(R.string.setup_unsupported_wizard_action),
-                    Modifier.padding(start = 8.dp),
-                )
-            }
-            // Secondary: send just the non-privileged device metadata (no Shizuku needed).
-            OutlinedButton(
-                onClick = {
-                    onPrepareReport()
-                    showDialog = true
-                },
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(stringResource(R.string.setup_unsupported_request_action))
-            }
+        }
+        // Secondary: send just the non-privileged device metadata (no Shizuku needed).
+        OutlinedButton(
+            onClick = {
+                onPrepareReport()
+                showDialog = true
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(R.string.setup_unsupported_request_action))
+        }
 
-            HorizontalDivider(Modifier.padding(vertical = 4.dp))
+        HorizontalDivider(Modifier.padding(vertical = 4.dp))
 
+        Text(
+            text = stringResource(R.string.setup_unsupported_email_note),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        OutlinedButton(
+            onClick = onEmail,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(Icons.TwoTone.Email, contentDescription = null)
             Text(
-                text = stringResource(R.string.setup_unsupported_email_note),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                stringResource(R.string.setup_unsupported_email_action),
+                Modifier.padding(start = 8.dp),
             )
-            OutlinedButton(
-                onClick = onEmail,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Icon(Icons.TwoTone.Email, contentDescription = null)
-                Text(
-                    stringResource(R.string.setup_unsupported_email_action),
-                    Modifier.padding(start = 8.dp),
-                )
-            }
-            TextButton(onClick = onHelp, modifier = Modifier.align(Alignment.End)) {
-                Text(stringResource(R.string.setup_unsupported_help_action))
-            }
+        }
+        TextButton(onClick = onHelp, modifier = Modifier.align(Alignment.End)) {
+            Text(stringResource(R.string.setup_unsupported_help_action))
         }
     }
 
@@ -145,23 +126,11 @@ fun UnsupportedDeviceCard(
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     Text(stringResource(R.string.setup_unsupported_dialog_body))
-                    Card(
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                        ),
-                    ) {
-                        SelectionContainer {
-                            Text(
-                                text = reportPreview ?: "…",
-                                modifier = Modifier
-                                    .heightIn(max = 220.dp)
-                                    .verticalScroll(rememberScrollState())
-                                    .padding(12.dp),
-                                style = MaterialTheme.typography.bodySmall,
-                                fontFamily = FontFamily.Monospace,
-                            )
-                        }
-                    }
+                    AmplyCodeBlock(
+                        text = reportPreview ?: "…",
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+                        maxHeight = 220.dp,
+                    )
                     TextButton(
                         onClick = onCopyReport,
                         enabled = reportPreview != null,

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsDashboardCard.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsDashboardCard.kt
@@ -1,25 +1,18 @@
 package eu.darken.amply.stats.ui
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.ShowChart
-import androidx.compose.material3.Card
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
+import eu.darken.amply.common.compose.AmplyNavigationCard
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
 import eu.darken.amply.stats.core.ChargeSessionSummary
@@ -40,60 +33,39 @@ fun StatsDashboardCard(
     onOpen: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Card(modifier = modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier
-                .clickable(onClick = onOpen)
-                .padding(start = 20.dp, end = 20.dp, top = 12.dp, bottom = 20.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    Icons.AutoMirrored.Filled.ShowChart,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
+    AmplyNavigationCard(
+        onClick = onOpen,
+        onClickLabel = stringResource(R.string.dashboard_stats_view_action),
+        title = stringResource(R.string.dashboard_stats_title),
+        icon = Icons.AutoMirrored.Filled.ShowChart,
+        modifier = modifier,
+    ) {
+        when {
+            !enabled -> Text(
+                stringResource(R.string.dashboard_stats_promo),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            lastSession != null -> {
+                val range = StatsFormat.percentRange(lastSession.startPercent, lastSession.endPercent)
+                val duration = StatsFormat.duration(lastSession.durationMillis)
+                val summary = if (duration != null) "$range  ·  $duration" else range
+                Text(
+                    stringResource(R.string.dashboard_stats_last, summary),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Text(
-                    stringResource(R.string.dashboard_stats_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.weight(1f),
-                )
-                Icon(
-                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                    contentDescription = stringResource(R.string.dashboard_stats_view_action),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            when {
-                !enabled -> Text(
-                    stringResource(R.string.dashboard_stats_promo),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                lastSession != null -> {
-                    val range = StatsFormat.percentRange(lastSession.startPercent, lastSession.endPercent)
-                    val duration = StatsFormat.duration(lastSession.durationMillis)
-                    val summary = if (duration != null) "$range  ·  $duration" else range
-                    Text(
-                        stringResource(R.string.dashboard_stats_last, summary),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Text(
-                        pluralStringResource(R.plurals.dashboard_stats_session_count, sessionCount, sessionCount),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                else -> Text(
-                    stringResource(R.string.dashboard_stats_recording_empty),
-                    style = MaterialTheme.typography.bodyMedium,
+                    pluralStringResource(R.plurals.dashboard_stats_session_count, sessionCount, sessionCount),
+                    style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
+            else -> Text(
+                stringResource(R.string.dashboard_stats_recording_empty),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsScreen.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsScreen.kt
@@ -1,7 +1,6 @@
 package eu.darken.amply.stats.ui
 
 import android.text.format.DateUtils
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,13 +14,11 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -36,7 +33,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
+import eu.darken.amply.common.compose.AmplyCardHeader
+import eu.darken.amply.common.compose.AmplyCardToggleIndicator
+import eu.darken.amply.common.compose.AmplyClickableCard
 import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.AmplyToggleCard
 import eu.darken.amply.common.compose.PreviewWrapper
 import eu.darken.amply.stats.core.ChargeSessionSummary
 import eu.darken.amply.stats.core.ChargingType
@@ -152,47 +153,36 @@ private fun CaptureCard(
     lastCaptureWallMillis: Long?,
     onCaptureEnabledChange: (Boolean) -> Unit,
 ) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    stringResource(R.string.stats_capture_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.weight(1f),
-                )
-                Switch(checked = enabled, onCheckedChange = onCaptureEnabledChange)
-            }
+    AmplyToggleCard(checked = enabled, onCheckedChange = onCaptureEnabledChange) {
+        AmplyCardHeader(
+            title = stringResource(R.string.stats_capture_title),
+            trailing = { AmplyCardToggleIndicator(enabled) },
+        )
+        Text(
+            stringResource(R.string.stats_capture_subtitle),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (enabled) {
+            val lastText = lastCaptureWallMillis?.let {
+                DateUtils.getRelativeTimeSpanString(it).toString()
+            } ?: stringResource(R.string.stats_capture_never)
             Text(
-                stringResource(R.string.stats_capture_subtitle),
-                style = MaterialTheme.typography.bodyMedium,
+                stringResource(R.string.stats_capture_last_recorded, lastText),
+                style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            if (enabled) {
-                val lastText = lastCaptureWallMillis?.let {
-                    DateUtils.getRelativeTimeSpanString(it).toString()
-                } ?: stringResource(R.string.stats_capture_never)
-                Text(
-                    stringResource(R.string.stats_capture_last_recorded, lastText),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
         }
     }
 }
 
 @Composable
 private fun SessionRow(session: ChargeSessionSummary, onClick: () -> Unit) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier
-                .clickable(onClick = onClick)
-                .padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
+    AmplyClickableCard(
+        onClick = onClick,
+        onClickLabel = stringResource(R.string.stats_session_open_action),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     DateUtils.getRelativeTimeSpanString(session.startedAtWallMillis).toString(),

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsSessionDetailScreen.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsSessionDetailScreen.kt
@@ -2,7 +2,6 @@ package eu.darken.amply.stats.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -27,6 +25,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardDefaults
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
 import eu.darken.amply.common.compose.chart.ChartPoint
@@ -103,60 +103,53 @@ private fun CurveCard(curve: List<ChargeCurvePoint>) {
     val percentColor = MaterialTheme.colorScheme.primary
     val powerColor = MaterialTheme.colorScheme.tertiary
     val tempColor = MaterialTheme.colorScheme.error
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                stringResource(R.string.stats_detail_curve_title),
-                style = MaterialTheme.typography.titleSmall,
-                color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(bottom = 4.dp),
-            )
-            LineChart(
-                series = listOf(
-                    ChartSeries(
-                        label = stringResource(R.string.stats_curve_series_percent),
-                        color = percentColor,
-                        points = curve.map { ChartPoint(it.elapsedFromStartMillis.toFloat(), it.percent?.toFloat()) },
-                    ),
-                    ChartSeries(
-                        label = stringResource(R.string.stats_curve_series_power),
-                        color = powerColor,
-                        points = curve.map { ChartPoint(it.elapsedFromStartMillis.toFloat(), it.powerMilliwatts?.toFloat()) },
-                    ),
-                    ChartSeries(
-                        label = stringResource(R.string.stats_curve_series_temperature),
-                        color = tempColor,
-                        points = curve.map { ChartPoint(it.elapsedFromStartMillis.toFloat(), it.temperatureTenthsC?.toFloat()) },
-                    ),
+    AmplyCard {
+        Text(
+            stringResource(R.string.stats_detail_curve_title),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(bottom = 4.dp),
+        )
+        LineChart(
+            series = listOf(
+                ChartSeries(
+                    label = stringResource(R.string.stats_curve_series_percent),
+                    color = percentColor,
+                    points = curve.map { ChartPoint(it.elapsedFromStartMillis.toFloat(), it.percent?.toFloat()) },
                 ),
-                emptyLabel = stringResource(R.string.stats_curve_empty),
-            )
-        }
+                ChartSeries(
+                    label = stringResource(R.string.stats_curve_series_power),
+                    color = powerColor,
+                    points = curve.map { ChartPoint(it.elapsedFromStartMillis.toFloat(), it.powerMilliwatts?.toFloat()) },
+                ),
+                ChartSeries(
+                    label = stringResource(R.string.stats_curve_series_temperature),
+                    color = tempColor,
+                    points = curve.map { ChartPoint(it.elapsedFromStartMillis.toFloat(), it.temperatureTenthsC?.toFloat()) },
+                ),
+            ),
+            emptyLabel = stringResource(R.string.stats_curve_empty),
+        )
     }
 }
 
 @Composable
 private fun SummaryCard(summary: ChargeSessionSummary) {
     val notReported = stringResource(R.string.battery_value_not_reported)
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier.padding(20.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            DetailRow(stringResource(R.string.stats_detail_level), StatsFormat.percentRange(summary.startPercent, summary.endPercent))
-            DetailRow(stringResource(R.string.stats_detail_duration), StatsFormat.duration(summary.durationMillis) ?: notReported)
-            DetailRow(stringResource(R.string.stats_detail_charging_type), stringResource(chargingTypeLabel(summary.chargingType)))
-            DetailRow(stringResource(R.string.stats_detail_avg_power), StatsFormat.power(summary.avgPowerMilliwatts) ?: notReported)
-            DetailRow(stringResource(R.string.stats_detail_peak_power), StatsFormat.power(summary.peakPowerMilliwatts) ?: notReported)
-            DetailRow(
-                stringResource(R.string.stats_detail_temperature),
-                StatsFormat.temperatureRange(summary.minTemperatureTenthsC, summary.maxTemperatureTenthsC) ?: notReported,
-            )
-            DetailRow(
-                stringResource(R.string.stats_detail_limit_likely),
-                stringResource(if (summary.limitHit) R.string.stats_value_yes else R.string.stats_value_no),
-            )
-        }
+    AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+        DetailRow(stringResource(R.string.stats_detail_level), StatsFormat.percentRange(summary.startPercent, summary.endPercent))
+        DetailRow(stringResource(R.string.stats_detail_duration), StatsFormat.duration(summary.durationMillis) ?: notReported)
+        DetailRow(stringResource(R.string.stats_detail_charging_type), stringResource(chargingTypeLabel(summary.chargingType)))
+        DetailRow(stringResource(R.string.stats_detail_avg_power), StatsFormat.power(summary.avgPowerMilliwatts) ?: notReported)
+        DetailRow(stringResource(R.string.stats_detail_peak_power), StatsFormat.power(summary.peakPowerMilliwatts) ?: notReported)
+        DetailRow(
+            stringResource(R.string.stats_detail_temperature),
+            StatsFormat.temperatureRange(summary.minTemperatureTenthsC, summary.maxTemperatureTenthsC) ?: notReported,
+        )
+        DetailRow(
+            stringResource(R.string.stats_detail_limit_likely),
+            stringResource(if (summary.limitHit) R.string.stats_value_yes else R.string.stats_value_no),
+        )
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -494,6 +494,7 @@
     <string name="stats_action_cancel">Cancel</string>
     <string name="stats_session_partial">Partial</string>
     <string name="stats_session_limit_likely">Limit likely reached</string>
+    <string name="stats_session_open_action">View session</string>
     <string name="stats_detail_title">Charge session</string>
     <string name="stats_detail_curve_title">Charge curve</string>
     <string name="stats_curve_empty">No curve data for this session</string>


### PR DESCRIPTION
## What changed

Cards across the app (dashboard, battery, statistics, setup, onboarding, and the contribution wizard) now share one consistent look — the same padding, the same header layout, and the same tap behaviour. Previously each card was built by hand with its own spacing and affordances, so similar-looking cards behaved differently.

User-visible improvements:

- The **Battery** card and the **Battery statistics** card now behave identically: the whole card is tappable to open its detail screen. (The Battery card previously exposed only a small "Details" button while the statistics card was fully tappable.)
- **Toggle cards** (Charge alarm, Reconnect for 100%, and Statistics capture) can now be toggled by tapping anywhere on the card. Their switches are smaller on/off indicators, and the description sits a consistent distance below the title. The inline target slider and the settings gear still work on their own.
- The monospace command/report blocks (permission setup, contribution wizard, unsupported-device dialog) now look the same everywhere.

## Technical Context

- Introduces `common/compose/AmplyCard.kt` as the single source of truth: `AmplyCard` / `AmplyClickableCard` / `AmplyNavigationCard` / `AmplyToggleCard`, `AmplyCardHeader`, `AmplyCardToggleIndicator`, `AmplyCodeBlock`, and an `AmplyCardTone` enum (tone controls container/content colour only — never header tint). Every card routes through it; no raw Material `Card` remains outside this file.
- Uniform 16dp content padding via one token. Header trailing controls are **floated** through a custom `Layout` so a `Switch`/`IconButton`'s 48dp minimum touch target no longer inflates the header row and pushes the body down; a small header-content token keeps a consistent ~12dp title-to-body gap. `placeRelative` keeps the floated layout RTL-correct.
- Navigation cards use `Card(onClick=)` with a labelled `Role.Button`; toggle cards use `Modifier.toggleable` (`Role.Switch`), shape-clipped so the ripple/target respect the rounded corners. Inline controls (the alarm slider, the reconnect gear) keep their own gestures and stay independent accessibility nodes — no double-fire.
- No behavioural change to charge control, temporary sessions, or the status card's settling/spinner logic (reskinned only). Colours, icon tints, and title sizes are preserved per card, so this is structural unification rather than a re-theme.

## Verification

414 unit tests pass on both `foss` and `gplay` flavors, lint is clean, both flavors assemble, screenshot sources compile, and it was smoke-tested on a Pixel 7a (whole-card navigation, whole-card toggle both directions, the slider adjusting the target without toggling, and the reconnect gear still opening settings).
