### PR TITLE
Stats: Only tag "limit likely reached" once charging actually stops

### DIFF
--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRecorder.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRecorder.kt
@@ -114,7 +114,7 @@ class ChargeStatsRecorder @Inject constructor(
         )
         when (val transition = StatsSessionEngine.decide(openSession != null, previousPlugged, sample.plugged, recordDue)) {
             is StatsTransition.Open -> openNewSession(sample, transition.partial)
-            is StatsTransition.Append -> if (transition.record) appendSample(sample)
+            is StatsTransition.Append -> if (transition.record) appendSample(sample) else latchEvidence(sample)
             is StatsTransition.Seal -> sealCurrent(
                 reason = transition.reason,
                 endWallMillis = sample.wallMillis,
@@ -151,6 +151,7 @@ class ChargeStatsRecorder @Inject constructor(
                 chargingStatus = readout.chargingStatus,
                 batteryStatus = tick.batteryStatus,
                 percent = percent,
+                currentNowMicroamps = readout.currentNowMicroamps,
             ),
         )
     }
@@ -177,6 +178,19 @@ class ChargeStatsRecorder @Inject constructor(
         }
         openSession = folded
         markRecorded(sample)
+    }
+
+    /**
+     * Persist a below-cadence sample's sticky evidence (see [StatsSessionEngine.latchEvidence]) so a
+     * limit hold or override that starts and ends within one cadence window isn't lost when the
+     * sample itself is dropped. Writes only when a flag actually flips — at most once per flag per
+     * session — and never touches aggregates or the curve.
+     */
+    private suspend fun latchEvidence(sample: StatsSample) {
+        val current = openSession ?: return
+        val updated = StatsSessionEngine.latchEvidence(current, sample) ?: return
+        database.get().statsDao().updateSession(updated)
+        openSession = updated
     }
 
     private suspend fun sealCurrent(

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsLimitHitDetector.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsLimitHitDetector.kt
@@ -1,6 +1,7 @@
 package eu.darken.amply.stats.core
 
 import android.os.BatteryManager
+import kotlin.math.abs
 
 /**
  * Pure heuristic for whether an OEM charge limit appears to be holding the battery *right now*. The
@@ -8,26 +9,48 @@ import android.os.BatteryManager
  * rather than asserting it, because — unlike the privileged adapters — this is inferred from public
  * battery state without Shizuku.
  *
- * Two signals, strongest first:
- *  - the hidden Pixel charge-policy state ([android.os.BatteryManager.EXTRA_CHARGING_STATUS] == 4,
- *    "long life"/limit hold — the same value [eu.darken.amply.fullcharge.core.QuickFullChargeGesture]
- *    keys its arming on), and
- *  - a generic fallback: plugged, reported NOT_CHARGING, and below full.
+ * A hold means charging has actually *stopped* below full, not merely that a charge-limit *mode* is
+ * enabled. Pixel keeps [android.os.BatteryManager.EXTRA_CHARGING_STATUS] == [HARDWARE_HOLD_STATE]
+ * ("long life") set for the entire fixed-limit session — including while charging at over 1 A far
+ * below the cap — so that value alone is not evidence of a hold. Two signals, strongest first:
+ *  - plugged, below full, and the battery reports NOT_CHARGING: the reliable, OEM-agnostic signal,
+ *    and the only one used when the platform doesn't report charge current; and
+ *  - a Pixel refinement for the brief window where the cap is already holding but the status still
+ *    reads CHARGING: long-life mode with charge current collapsed to ~0.
  */
 object StatsLimitHitDetector {
 
     /** EXTRA_CHARGING_STATUS value meaning the charge policy is holding the battery below 100%. */
     const val HARDWARE_HOLD_STATE = 4
 
+    /**
+     * Charge-current magnitude (µA) at/under which the battery isn't meaningfully gaining charge.
+     * Measured hold noise on a held Pixel is ≤ ~19 mA while active charging is ≥ ~500 mA, so 50 mA
+     * cleanly separates a held cap from real charging. Compared as a magnitude so the OEM-defined
+     * current sign doesn't matter.
+     */
+    const val HOLD_CURRENT_THRESHOLD_MICROAMPS = 50_000
+
     fun heldNow(
         plugged: Boolean,
         chargingStatus: Int?,
         batteryStatus: Int?,
         percent: Int?,
+        currentNowMicroamps: Int?,
     ): Boolean {
         if (!plugged) return false
-        if (chargingStatus == HARDWARE_HOLD_STATE) return true
-        val belowFull = percent == null || percent < 100
-        return batteryStatus == BatteryManager.BATTERY_STATUS_NOT_CHARGING && belowFull
+        // A known level below full is required to claim a limit was reached; an unknown level is not
+        // evidence of anything.
+        if (percent == null || percent >= 100) return false
+        // Reliable and OEM-agnostic: the charger has stopped feeding the battery below full. This is
+        // also the fallback when charge current isn't reported.
+        if (batteryStatus == BatteryManager.BATTERY_STATUS_NOT_CHARGING) return true
+        // Pixel transitional hold: long-life mode is capping at the limit but the status still reads
+        // CHARGING for a moment. Only a hold once current has actually collapsed to ~0 — mode alone
+        // stays set the whole session (e.g. 1.3 A at 69 %), which is the false positive this guards.
+        return chargingStatus == HARDWARE_HOLD_STATE &&
+            batteryStatus == BatteryManager.BATTERY_STATUS_CHARGING &&
+            currentNowMicroamps != null &&
+            abs(currentNowMicroamps) < HOLD_CURRENT_THRESHOLD_MICROAMPS
     }
 }

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsSessionEngine.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsSessionEngine.kt
@@ -93,6 +93,22 @@ object StatsSessionEngine {
     }
 
     /**
+     * Merge a below-cadence sample's sticky evidence ([ChargeSessionEntity.limitHitEvidence] /
+     * [ChargeSessionEntity.overrideSeen]) into [session] without folding aggregates or advancing the
+     * curve. Returns the updated entity, or null when neither flag changed so the recorder can skip
+     * the write. A hold or override can begin and end entirely between two recorded points, so this
+     * captures that evidence even when [StatsCadence] drops the sample itself.
+     */
+    fun latchEvidence(session: ChargeSessionEntity, sample: StatsSample): ChargeSessionEntity? {
+        val limitHitEvidence = session.limitHitEvidence || sample.limitHeldNow
+        val overrideSeen = session.overrideSeen || sample.overrideActive
+        if (limitHitEvidence == session.limitHitEvidence && overrideSeen == session.overrideSeen) {
+            return null
+        }
+        return session.copy(limitHitEvidence = limitHitEvidence, overrideSeen = overrideSeen)
+    }
+
+    /**
      * Close [session]. [endWallMillis]/[endElapsedMillis]/[endPercent] come from the unplug tick when
      * available, else the session's last recorded values (recovery/disable seals). The final open
      * interval is credited before averaging so the tail isn't lost.

--- a/app/src/test/java/eu/darken/amply/stats/core/StatsLimitHitDetectorTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/StatsLimitHitDetectorTest.kt
@@ -13,26 +13,30 @@ class StatsLimitHitDetectorTest {
             chargingStatus = StatsLimitHitDetector.HARDWARE_HOLD_STATE,
             batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
             percent = 80,
+            currentNowMicroamps = 0,
         ) shouldBe false
     }
 
     @Test
-    fun `hardware hold state signals a limit`() {
-        StatsLimitHitDetector.heldNow(
-            plugged = true,
-            chargingStatus = StatsLimitHitDetector.HARDWARE_HOLD_STATE,
-            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
-            percent = 80,
-        ) shouldBe true
-    }
-
-    @Test
-    fun `not-charging below full is a heuristic hold`() {
+    fun `not-charging below full is a hold`() {
         StatsLimitHitDetector.heldNow(
             plugged = true,
             chargingStatus = 0,
             batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
             percent = 80,
+            currentNowMicroamps = 0,
+        ) shouldBe true
+    }
+
+    @Test
+    fun `not-charging below full is a hold even when current is unreported`() {
+        // Devices that don't expose charge current must still latch via the NOT_CHARGING fallback.
+        StatsLimitHitDetector.heldNow(
+            plugged = true,
+            chargingStatus = 0,
+            batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+            percent = 80,
+            currentNowMicroamps = null,
         ) shouldBe true
     }
 
@@ -43,6 +47,7 @@ class StatsLimitHitDetectorTest {
             chargingStatus = 0,
             batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
             percent = 100,
+            currentNowMicroamps = 0,
         ) shouldBe false
     }
 
@@ -53,6 +58,71 @@ class StatsLimitHitDetectorTest {
             chargingStatus = 0,
             batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
             percent = 50,
+            currentNowMicroamps = 1_300_000,
+        ) shouldBe false
+    }
+
+    @Test
+    fun `long-life mode while actively charging is not a hold`() {
+        // The reported false positive: Pixel reports EXTRA_CHARGING_STATUS==4 for the whole
+        // fixed-limit session, including a 5 s plug at 68 % pulling 0.56 A toward the cap.
+        StatsLimitHitDetector.heldNow(
+            plugged = true,
+            chargingStatus = StatsLimitHitDetector.HARDWARE_HOLD_STATE,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            percent = 68,
+            currentNowMicroamps = 563_281,
+        ) shouldBe false
+    }
+
+    @Test
+    fun `long-life mode holding at the cap with near-zero current is a hold`() {
+        // The transitional window: the cap is holding but status still reads CHARGING; current has
+        // already collapsed to ~0 (measured hold noise on a held Pixel).
+        StatsLimitHitDetector.heldNow(
+            plugged = true,
+            chargingStatus = StatsLimitHitDetector.HARDWARE_HOLD_STATE,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            percent = 80,
+            currentNowMicroamps = -18_750,
+        ) shouldBe true
+    }
+
+    @Test
+    fun `long-life mode with near-zero current but not a charging status is not a hold`() {
+        // The near-zero-current refinement only rescues the CHARGING transitional window. FULL /
+        // DISCHARGING / unknown with mode 4 is not the documented hold and must not latch.
+        StatsLimitHitDetector.heldNow(
+            plugged = true,
+            chargingStatus = StatsLimitHitDetector.HARDWARE_HOLD_STATE,
+            batteryStatus = BatteryManager.BATTERY_STATUS_FULL,
+            percent = 80,
+            currentNowMicroamps = 0,
+        ) shouldBe false
+    }
+
+    @Test
+    fun `unknown percent is never a hold`() {
+        // Without a known level we can't claim a limit was reached, even when not charging.
+        StatsLimitHitDetector.heldNow(
+            plugged = true,
+            chargingStatus = 0,
+            batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+            percent = null,
+            currentNowMicroamps = 0,
+        ) shouldBe false
+    }
+
+    @Test
+    fun `long-life mode with unreported current is not a hold`() {
+        // Without NOT_CHARGING or a current reading we can't tell a hold from active charging, so
+        // stay conservative rather than latch a false positive.
+        StatsLimitHitDetector.heldNow(
+            plugged = true,
+            chargingStatus = StatsLimitHitDetector.HARDWARE_HOLD_STATE,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            percent = 80,
+            currentNowMicroamps = null,
         ) shouldBe false
     }
 }

--- a/app/src/test/java/eu/darken/amply/stats/core/StatsSessionEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/StatsSessionEngineTest.kt
@@ -144,6 +144,43 @@ class StatsSessionEngineTest {
     }
 
     @Test
+    fun `latchEvidence captures a hold seen only in a below-cadence sample`() {
+        val opened = StatsSessionEngine.open(sample(elapsed = 0, limit = false), partial = false)
+        opened.limitHitEvidence shouldBe false
+        val updated = StatsSessionEngine.latchEvidence(opened, sample(elapsed = 5_000, limit = true))
+        updated?.limitHitEvidence shouldBe true
+    }
+
+    @Test
+    fun `latchEvidence captures an override seen only in a below-cadence sample`() {
+        val opened = StatsSessionEngine.open(sample(elapsed = 0), partial = false)
+        val updated = StatsSessionEngine.latchEvidence(opened, sample(elapsed = 5_000, override = true))
+        updated?.overrideSeen shouldBe true
+    }
+
+    @Test
+    fun `latchEvidence returns null when no sticky flag changes`() {
+        val opened = StatsSessionEngine.open(sample(elapsed = 0, limit = true), partial = false)
+        // Already latched → no write needed.
+        StatsSessionEngine.latchEvidence(opened, sample(elapsed = 5_000, limit = true)) shouldBe null
+        // No new evidence at all → no write needed.
+        StatsSessionEngine.latchEvidence(
+            StatsSessionEngine.open(sample(elapsed = 0), partial = false),
+            sample(elapsed = 5_000),
+        ) shouldBe null
+    }
+
+    @Test
+    fun `latchEvidence leaves aggregates and the curve untouched`() {
+        val opened = StatsSessionEngine.open(sample(elapsed = 0, power = 1000), partial = false)
+        val updated = StatsSessionEngine.latchEvidence(opened, sample(elapsed = 5_000, power = 9999, limit = true))
+        // Only the sticky flag moved — sample count / running power endpoint / timestamps unchanged.
+        updated?.runningSampleCount shouldBe opened.runningSampleCount
+        updated?.runningLastPowerMilliwatts shouldBe opened.runningLastPowerMilliwatts
+        updated?.runningLastElapsedRealtimeMillis shouldBe opened.runningLastElapsedRealtimeMillis
+    }
+
+    @Test
     fun `a doze gap is clamped so it cannot overweight one reading`() {
         // 1000 mW then a 1-hour gap: only MAX_WEIGHT_GAP_MILLIS of it is credited.
         var s = StatsSessionEngine.open(sample(elapsed = 0, power = 1000), partial = false)


### PR DESCRIPTION
**What changed**

The battery-statistics list could tag a charge session "Limit likely reached" when no limit was actually reached — including a recorded session that charged from 68% to 68% over a few seconds. The tag now appears only when charging genuinely stopped below full (an OEM charge limit holding the battery), so it means what it says.

**Technical Context**

The per-sample heuristic (`StatsLimitHitDetector`) latched on `EXTRA_CHARGING_STATUS == 4`. On Pixel that "long life" value is a fixed-limit *mode* flag set for the entire session — including while charging at over 1 A far below the cap — not a "currently held" signal. Confirmed against a Pixel 9 Pro's recorded data: a ~6 s plug at 68% (a single sample, charging at 0.56 A) was flagged, and a real session was flagged from its first 69% sample rather than on reaching the 80% cap.

`heldNow` now requires charging to have actually stopped:

- `NOT_CHARGING` below a known-full level — OEM-agnostic, and the only signal used when charge current isn't reported (some devices don't expose it); or
- the Pixel transitional window where mode 4 still reads `CHARGING` but current has already collapsed to ~0 (`|I| < 50 mA`, comfortably between measured hold noise ≤19 mA and real charging ≥500 mA; compared as a magnitude so the OEM-defined current sign doesn't matter).

An unknown battery level is no longer treated as below-full.

Because that signal is narrower than "mode active at session open", a hold that begins and ends within a single cadence window could otherwise be dropped along with its sample. `StatsSessionEngine.latchEvidence` now latches limit/override evidence from below-cadence samples without writing a curve point or touching aggregates.

Existing recorded rows keep their stored flag (no migration); only new sessions are affected. Pure-logic change — no capability-gate or requalification impact.

**Testing**

`StatsLimitHitDetectorTest` (10) covers the corrected heuristic — the real 68% actively-charging repro, the `NOT_CHARGING` fallback with current unreported, the Pixel transitional hold, and non-CHARGING/unknown-level rejection. `StatsSessionEngineTest` (16) adds the below-cadence evidence latch. All stats tests pass on the JDK 21 toolchain.
