### PR TITLE
General: Add automatic PR labeling (paths + title-based type)

### DIFF
--- a/.claude/rules/commit-guidelines.md
+++ b/.claude/rules/commit-guidelines.md
@@ -61,3 +61,25 @@ user-facing behavior change" plus a brief internal note.
 
 **Technical Context** — what the diff can't show: *why* this approach, root cause for fixes, non-obvious side effects,
 and review guidance. Keep it scannable; don't restate the diff.
+
+### Labels
+
+PRs are labeled automatically by `.github/workflows/labeler.yml` (config `.github/labeler.yml`). It runs on
+open/edit/synchronize, so labels appear a short time after opening and update when the title or diff changes:
+
+- **Area labels** from the changed paths — `Translations`, `FOSS`, `Google Play`, `Build/Deploy`. These are synced
+  to the current diff (a reverted path drops its label).
+- **One exclusive type label** from the title + diff — a `Fix:` title prefix → `bug`; a docs-only (`*.md`) diff →
+  `documentation`; anything else → `enhancement`. The workflow keeps exactly one of these three.
+
+**After opening a PR, check the applied labels and adjust — don't assume they're complete or correct:**
+
+- The workflow **cannot** infer device/OEM labels (`ROM: *`, `api: NN`, `device support`, `Shizuku`). Add those by
+  hand when the change is device- or ROM-specific.
+- The type heuristic keys on the `Fix:` prefix, so a bug fix written with a bare descriptive title (no prefix) lands
+  as `enhancement` — correct it manually. Same for any other misclassification.
+- The labeler runs from the **default branch**, so a PR that itself edits the labeler workflow/config isn't labeled
+  by its own version — label such a PR by hand.
+- It is **PR-only**; issues are still labeled manually (see the issue label taxonomy).
+
+Because it only ever manages the labels above, manually-added labels (device/OEM/`triage`/etc.) are left untouched.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,34 @@
+# Path-based PR labels, applied by actions/labeler (see .github/workflows/labeler.yml).
+# These describe WHERE the change is. The mutually-exclusive TYPE label
+# (enhancement / bug / documentation) is decided from the PR title + diff in that workflow, not
+# here, so "documentation" is intentionally NOT a path label. Every name below must already exist
+# in the repo (this config never creates labels).
+
+"Translations":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/**/res/values-*/**"
+
+"FOSS":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/foss/**"
+
+"Google Play":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "app/src/gplay/**"
+
+"Build/Deploy":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "buildSrc/**"
+          - "gradle/**"
+          - "gradlew"
+          - "gradlew.bat"
+          - "tools/release/**"
+          - "fastlane/**"
+          - "**/*.gradle"
+          - "**/*.gradle.kts"
+          - "gradle.properties"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,72 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+# pull_request_target runs with the base repo's token so labels can be applied to PRs from forks.
+# No PR head code is checked out or executed here — only the changed-file list and the PR title are
+# read via the API — so the write-scoped token is never exposed to untrusted code.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply labels
+    runs-on: ubuntu-latest
+    steps:
+      # Area / flavor / build labels from the changed paths (config: .github/labeler.yml).
+      # sync-labels keeps these in step with the current diff (a reverted path drops its label).
+      - name: Label by changed paths
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 #v7.0.0
+        with:
+          sync-labels: true
+
+      # Exactly one mutually-exclusive TYPE label, from the title convention
+      # (.claude/rules/commit-guidelines.md): a "Fix:" prefix -> bug; a docs-only diff ->
+      # documentation; anything else -> enhancement. The other two type labels are removed so an
+      # edited title/diff can't leave a stale type. Path labels above are left untouched.
+      - name: Label by title and diff
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9.0.0
+        with:
+          script: |
+            const TYPE_LABELS = ["bug", "documentation", "enhancement"];
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+            const issue_number = pr.number;
+
+            let type;
+            if (/^Fix:/i.test(pr.title || "")) {
+              type = "bug";
+            } else {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: issue_number,
+              });
+              const docsOnly = files.length > 0 && files.every((f) => f.filename.endsWith(".md"));
+              type = docsOnly ? "documentation" : "enhancement";
+            }
+
+            const current = (
+              await github.paginate(github.rest.issues.listLabelsOnIssue, { owner, repo, issue_number })
+            ).map((l) => l.name);
+
+            for (const stale of TYPE_LABELS) {
+              if (stale !== type && current.includes(stale)) {
+                // Tolerate a concurrent run having already removed it (404).
+                await github.rest.issues
+                  .removeLabel({ owner, repo, issue_number, name: stale })
+                  .catch((e) => {
+                    if (e.status !== 404) throw e;
+                  });
+              }
+            }
+            if (!current.includes(type)) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [type] });
+            }


### PR DESCRIPTION
## What changed

Pull requests are now labeled automatically, so they don't rely on the author remembering (PR #13 landed unlabeled — this closes that gap). Two complementary mechanisms:

**Path labels — *where* the change is** (`actions/labeler` + `.github/labeler.yml`):
| Label | Matches |
|---|---|
| `Translations` | `app/src/**/res/values-*/**` |
| `FOSS` | `app/src/foss/**` |
| `Google Play` | `app/src/gplay/**` |
| `Build/Deploy` | `.github/**`, `buildSrc/**`, `gradle/**`, `gradlew*`, `tools/release/**`, `fastlane/**`, gradle scripts/props |

`sync-labels: true`, so a path label is dropped if its files leave the diff.

**Type label — *what kind* of change** (one `github-script` step): a `Fix:` title prefix → `bug`; a docs-only diff (`*.md` only) → `documentation`; everything else → `enhancement`. Exactly one of these three is kept — the step removes the other two, so editing a title or diff can't leave a stale type. `documentation` is deliberately a *type* label only (not path-based) to avoid a two-namespace collision.

## Technical Context

- **Security:** runs on `pull_request_target` with `contents: read` + `pull-requests: write` and **no checkout** — only the changed-file list and PR title are read via the API, so the write-scoped token is never exposed to untrusted PR head code (avoids the "pwn request" pattern). Both actions are pinned to full commit SHAs (`actions/labeler` v7.0.0, `actions/github-script` v9.0.0), matching the repo's existing pinning convention.
- **Permissions:** `pull-requests: write` is sufficient for adding/removing *existing* labels on a PR (the GitHub permission mapping accepts either pull-requests or issues write for the labels endpoint). `issues: write` is intentionally omitted — the workflow must never create labels; all referenced labels already exist.
- **Label model:** `enhancement`/`bug`/`documentation` are treated as a mutually-exclusive type set managed solely by the type step; path/ROM/api and any manually-added labels are never touched by it.
- Reviewed by Codex (security + correctness); its findings (label exclusivity, `sync-labels`, strict `^Fix:`, empty-PR guard, gradlew globs) are all incorporated.

## Note

Because `pull_request_target` loads the workflow from the **default branch**, this PR can't exercise the new workflow on itself — it starts working once merged. I've applied `Build/Deploy` + `enhancement` here by hand to mirror what it will do.

Follow-up (not in scope): backfilling labels on already-open PRs, if any.