### PR TITLE
Onboarding: Make it clear the app does not work on every device

### DIFF
--- a/app/src/androidTest/java/eu/darken/amply/main/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/eu/darken/amply/main/ui/MainActivityTest.kt
@@ -29,9 +29,9 @@ class MainActivityTest {
         // Next is pinned at the bottom, so it must be visible without scrolling. It reveals the
         // caveats page with its caveat cards, still without the setup guide.
         composeRule.onNodeWithText(str(R.string.onboarding_next_action)).assertIsDisplayed().performClick()
+        composeRule.onNodeWithText(str(R.string.onboarding_caveat_compat_title)).assertIsDisplayed()
         composeRule.onNodeWithText(str(R.string.onboarding_caveat_support_title)).assertIsDisplayed()
         composeRule.onNodeWithText(str(R.string.onboarding_caveat_setup_title)).assertIsDisplayed()
-        composeRule.onNodeWithText(str(R.string.onboarding_caveat_restore_title)).assertExists()
         composeRule.onNodeWithText(str(R.string.onboarding_continue_action)).assertIsDisplayed()
         composeRule.onNodeWithText("Option 1 · Shizuku").assertDoesNotExist()
 

--- a/app/src/main/java/eu/darken/amply/main/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/onboarding/OnboardingScreen.kt
@@ -218,6 +218,12 @@ private fun OnboardingCaveatsPage(onContinue: () -> Unit) = OnboardingScaffold(
 
     CaveatCard(
         tone = AmplyCardTone.TertiaryContainer,
+        title = stringResource(R.string.onboarding_caveat_compat_title),
+        body = stringResource(R.string.onboarding_caveat_compat_body),
+    )
+
+    CaveatCard(
+        tone = AmplyCardTone.SurfaceHigh,
         title = stringResource(R.string.onboarding_caveat_support_title),
         body = stringResource(R.string.onboarding_caveat_support_body),
     )
@@ -226,12 +232,6 @@ private fun OnboardingCaveatsPage(onContinue: () -> Unit) = OnboardingScaffold(
         tone = AmplyCardTone.SurfaceHigh,
         title = stringResource(R.string.onboarding_caveat_setup_title),
         body = stringResource(R.string.onboarding_caveat_setup_body),
-    )
-
-    CaveatCard(
-        tone = AmplyCardTone.SurfaceHigh,
-        title = stringResource(R.string.onboarding_caveat_restore_title),
-        body = stringResource(R.string.onboarding_caveat_restore_body),
     )
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,12 +50,12 @@
     <string name="onboarding_next_action">Next</string>
     <string name="onboarding_continue_action">Get started</string>
     <string name="onboarding_caveats_title">Before you start</string>
-    <string name="onboarding_caveat_support_title">Support grows device by device</string>
-    <string name="onboarding_caveat_support_body">Charge control is mapped one device at a time. Right now, direct control works on Pixel 6a and newer phones running Android 15 or later, on Samsung devices with verified One UI versions, on verified Xiaomi devices, and on OnePlus, Oppo, and Realme devices on ColorOS 15. On other devices, Amply explains why control is unavailable, and where a device report can help expand support, the dashboard lets you send one.</string>
-    <string name="onboarding_caveat_setup_title">One-time setup on supported devices</string>
-    <string name="onboarding_caveat_setup_body">Changing the charge policy requires a permission that apps cannot grant themselves. You grant it once, using either a single command from a computer over ADB or the Shizuku app on this phone. Some devices require Shizuku specifically. If your device is supported, the dashboard walks you through the right option.</string>
-    <string name="onboarding_caveat_restore_title">Protection returns on its own</string>
-    <string name="onboarding_caveat_restore_body">When you allow a one-time full charge, Amply restores your protective limit as soon as the battery is full, when you unplug, or after a safety timeout. This relies on Amply staying alive in the background. If the app gets force-stopped during a session, opening Amply again resumes monitoring and restores the limit once it is due.</string>
+    <string name="onboarding_caveat_compat_title">Amply does not work on every device</string>
+    <string name="onboarding_caveat_compat_body">Charge control needs support from your device’s ROM, and a permission that apps cannot grant themselves — you set it up by hand.</string>
+    <string name="onboarding_caveat_support_title">Supported devices</string>
+    <string name="onboarding_caveat_support_body">Currently: Pixel 6a or newer phones on Android 15+, Samsung on verified One UI versions, Xiaomi on HyperOS 2, and OnePlus, Oppo, or Realme on ColorOS 15. Amply checks your exact device and shows what works.</string>
+    <string name="onboarding_caveat_setup_title">Manual setup required</string>
+    <string name="onboarding_caveat_setup_body">You grant the permission yourself — with one ADB command from a computer, or through the Shizuku app. Some devices require Shizuku. The dashboard walks you through the right option.</string>
     <string name="onboarding_page_progress">Page %1$d of %2$d</string>
 
     <!-- Charging policy labels -->


### PR DESCRIPTION
**What changed**

- The second onboarding page now leads with a highlighted warning card titled "Amply does not work on every device", saying up front that charge control needs support from the device's ROM plus a permission the user has to grant by hand.
- The two cards below it were rewritten much shorter: "Supported devices" (Pixel 6a+ phones on Android 15+, verified Samsung One UI, Xiaomi HyperOS 2, OnePlus/Oppo/Realme ColorOS 15) and "Manual setup required" (one ADB command or Shizuku; some devices need Shizuku).
- The third card ("Protection returns on its own") is removed — the page is now noticeably shorter and focused on expectation-setting before first use.

**Technical Context**

- Goal is expectation management: users should know before rating that this is a hands-on, limited-device-support app. The support copy is deliberately qualified ("Amply checks your exact device and shows what works") instead of an exact gate dump, so it won't drift from the adapter capability gates; the dashboard stays the authoritative per-device answer.
- The setup copy keeps the ADB-vs-Shizuku distinction ("Some devices require Shizuku") because the two grant paths are not interchangeable on all supported OEMs.
- The instrumented onboarding test asserted the removed restore-card string; it now asserts the new lead card instead.
- Removing the restore card drops onboarding's only force-stop caveat; a dashboard warning card after an interrupted session is planned as a separate follow-up.
- Verified: unit tests for both flavors, androidTest compilation, and an emulator walk of the full onboarding flow (default, font scale 1.3, landscape; completion persists across force-stop + relaunch).
