### PR TITLE
Dashboard: Warn when a full-charge session was interrupted

### DIFF
--- a/app/src/debug/java/eu/darken/amply/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/amply/screenshots/ScreenshotContent.kt
@@ -104,6 +104,7 @@ private fun DashboardShot(state: DashboardUiState) = PreviewWrapper {
         onOpenSupportIssue = {},
         onEmailSupport = {},
         onHelp = {},
+        onDismissInterruption = {},
     )
 }
 

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/BootRecoveryFlow.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/BootRecoveryFlow.kt
@@ -54,10 +54,30 @@ class BootRecoveryFlow(private val hooks: Hooks) {
         SUPERSEDED,
     }
 
-    suspend fun run(): Outcome {
+    /**
+     * Outcome plus the facts an interruption assessor needs to decide whether the flow actually did
+     * restore work: [restoreAttempted] (the flow called [Hooks.restoreSession]), [rewrites] (re-write
+     * attempts issued, including a failed final one), and [retryRemaining] (a pending target is still
+     * persisted on exit, so a later start will retry).
+     */
+    data class Result(
+        val outcome: Outcome,
+        val restoreAttempted: Boolean,
+        val rewrites: Int,
+        val retryRemaining: Boolean,
+    )
+
+    suspend fun run(): Result {
+        var restoreAttempted = false
+        var rewrites = 0
         val sessionTarget = hooks.currentSessionTarget()
         val pendingTarget = hooks.pendingTarget()
-        val target = pendingTarget ?: sessionTarget ?: return Outcome.NOTHING_TO_DO
+        val target = pendingTarget ?: sessionTarget ?: return Result(
+            outcome = Outcome.NOTHING_TO_DO,
+            restoreAttempted = false,
+            rewrites = 0,
+            retryRemaining = false,
+        )
         var staleIntended: ChargePolicy? = null
         if (pendingTarget != null) {
             // The pending target is always the newest intent: setPersistentPolicy persists it
@@ -76,17 +96,22 @@ class BootRecoveryFlow(private val hooks: Hooks) {
         } else {
             hooks.setPendingTarget(target)
             log(TAG) { "Recovery: restoring ${target.stableId}" }
+            restoreAttempted = true
             if (!hooks.restoreSession()) {
                 log(TAG, Logging.Priority.ERROR) { "Restore failed; session remains persisted" }
                 hooks.notifyFailure(writeFailed = true)
                 hooks.clearPendingTarget()
-                return Outcome.RESTORE_FAILED
+                return Result(
+                    outcome = Outcome.RESTORE_FAILED,
+                    restoreAttempted = true,
+                    rewrites = rewrites,
+                    retryRemaining = false,
+                )
             }
         }
 
         val startedAt = hooks.elapsedRealtime()
         var lastWriteAt = startedAt
-        var rewrites = 0
         while (true) {
             hooks.tick()
             val intended = hooks.intendedTarget()
@@ -95,7 +120,12 @@ class BootRecoveryFlow(private val hooks: Hooks) {
                 // were converging; never write the boot target over a newer choice.
                 log(TAG) { "Boot recovery superseded by ${intended.stableId}" }
                 hooks.clearPendingTarget()
-                return Outcome.SUPERSEDED
+                return Result(
+                    outcome = Outcome.SUPERSEDED,
+                    restoreAttempted = restoreAttempted,
+                    rewrites = rewrites,
+                    retryRemaining = false,
+                )
             }
             val now = hooks.elapsedRealtime()
             val snapshot = hooks.batterySnapshot()
@@ -121,14 +151,24 @@ class BootRecoveryFlow(private val hooks: Hooks) {
                         // write) should be retried by the next service start.
                         log(TAG, Logging.Priority.ERROR) { "Boot recovery re-write failed" }
                         hooks.notifyFailure(writeFailed = true)
-                        return Outcome.GAVE_UP
+                        return Result(
+                            outcome = Outcome.GAVE_UP,
+                            restoreAttempted = restoreAttempted,
+                            rewrites = rewrites,
+                            retryRemaining = true,
+                        )
                     }
                     lastWriteAt = hooks.elapsedRealtime()
                 }
                 RecoveryDecision.DONE_OK -> {
                     log(TAG) { "Boot recovery finished for ${target.stableId}" }
                     hooks.clearPendingTarget()
-                    return Outcome.CONVERGED
+                    return Result(
+                        outcome = Outcome.CONVERGED,
+                        restoreAttempted = restoreAttempted,
+                        rewrites = rewrites,
+                        retryRemaining = false,
+                    )
                 }
                 RecoveryDecision.GIVE_UP -> {
                     log(TAG, Logging.Priority.ERROR) {
@@ -136,7 +176,12 @@ class BootRecoveryFlow(private val hooks: Hooks) {
                     }
                     hooks.notifyFailure(writeFailed = false)
                     hooks.clearPendingTarget()
-                    return Outcome.GAVE_UP
+                    return Result(
+                        outcome = Outcome.GAVE_UP,
+                        restoreAttempted = restoreAttempted,
+                        rewrites = rewrites,
+                        retryRemaining = false,
+                    )
                 }
             }
         }

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionManager.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionManager.kt
@@ -8,6 +8,7 @@ import eu.darken.amply.charging.core.ChargingPreferences
 import eu.darken.amply.fullcharge.core.FullChargeStore
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,6 +17,8 @@ class ChargeSessionManager @Inject constructor(
     private val repository: ChargingRepository,
     private val preferences: ChargingPreferences,
     private val sessionStore: FullChargeStore,
+    private val processIdentity: ProcessIdentity,
+    private val bootCountProvider: BootCountProvider,
 ) {
     private val mutex = Mutex()
 
@@ -74,8 +77,20 @@ class ChargeSessionManager @Inject constructor(
         }
         val restorePolicy = (decision as SessionStartDecision.Start).restorePolicy
 
-        // Persist recovery state before removing the limit.
-        sessionStore.startSession(restorePolicy, nowMillis)
+        // Persist recovery state before removing the limit. Stamp this process's identity so a later
+        // pickup can tell whether the session survived a process death (interruption detection), and a
+        // stable work id that survives ownership adoption so a later restore can resolve the warning.
+        sessionStore.startSession(
+            restorePolicy = restorePolicy,
+            startedAtMillis = nowMillis,
+            workId = UUID.randomUUID().toString(),
+            provenance = WorkProvenance(
+                token = processIdentity.token,
+                pid = processIdentity.pid,
+                bootCount = bootCountProvider.current(),
+                createdAtMillis = nowMillis,
+            ),
+        )
         val result = repository.applyTemporary(overridePolicy)
         if (result.success) {
             result

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.UUID
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -47,6 +48,9 @@ class ChargeSessionService : Service() {
     @Inject lateinit var adapterRegistry: AdapterRegistry
     @Inject lateinit var repository: ChargingRepository
     @Inject lateinit var preferences: ChargingPreferences
+    @Inject lateinit var interruptionAssessor: InterruptionAssessor
+    @Inject lateinit var processIdentity: ProcessIdentity
+    @Inject lateinit var bootCountProvider: BootCountProvider
 
     // Optional, permission-free battery observers (charge alarm, …), contributed via @IntoSet.
     @Inject lateinit var watchers: Set<@JvmSuppressWildcards ChargeMonitorWatcher>
@@ -73,6 +77,10 @@ class ChargeSessionService : Service() {
     @Volatile private var monitorReady = false
     private var settingObserverRegistered = false
     @Volatile private var restoring = false
+    // One-shot interruption assessment for a freshly resumed persisted session: set when
+    // beginOrResume picks up an existing session, consumed by the first battery evaluation, and
+    // cleared on any session start/clear so a stale assessment can never leak into a later session.
+    @Volatile private var pendingSessionAssessment: InterruptionAssessor.PickupAssessment? = null
 
     private val batteryReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -171,8 +179,11 @@ class ChargeSessionService : Service() {
     }
 
     private suspend fun beginOrResume() {
-        if (fullChargeStore.currentSession() == null) {
+        val existing = fullChargeStore.currentSession()
+        if (existing == null) {
             log(TAG) { "Starting a one-time full-charge session" }
+            // A brand-new session in this process is not an interruption; drop any stale assessment.
+            pendingSessionAssessment = null
             val result = manager.begin()
             if (!result.success) {
                 log(TAG, Logging.Priority.WARN) { "Unable to start full-charge session: ${result.message}" }
@@ -181,6 +192,10 @@ class ChargeSessionService : Service() {
                 SurfaceUpdater.updateNow(this)
                 return
             }
+        } else {
+            // Resuming a persisted session: assess whether this process is picking up work a dead
+            // process left behind. Threaded (one-shot) into the first battery evaluation below.
+            pendingSessionAssessment = interruptionAssessor.captureSessionPickup(existing)
         }
         quickGesture.reset()
         registerSettingObserver()
@@ -311,6 +326,9 @@ class ChargeSessionService : Service() {
         val session = fullChargeStore.currentSession()
 
         if (session != null) {
+            // One-shot: only the first evaluation after a pickup carries an interruption assessment.
+            val assessment = pendingSessionAssessment
+            pendingSessionAssessment = null
             val full = status == BatteryManager.BATTERY_STATUS_FULL || percent >= 100
             val decision = SessionDecisionEngine.decide(
                 session = session,
@@ -320,7 +338,13 @@ class ChargeSessionService : Service() {
             )
             when (decision) {
                 SessionDecision.MARK_CONNECTED -> {
-                    manager.markConnected()
+                    // markConnectedAndAdopt folds CONNECTED + owner adoption into one edit when this
+                    // is an assessed pickup; otherwise the plain markConnected path applies.
+                    if (assessment != null) {
+                        interruptionAssessor.onSessionDecision(assessment, decision)
+                    } else {
+                        manager.markConnected()
+                    }
                     startAsForeground(SessionNotifications.session(this, connected = true))
                 }
                 // Restore is safety-critical and holds commandMutex: run it BEFORE any optional
@@ -331,12 +355,15 @@ class ChargeSessionService : Service() {
                 SessionDecision.RESTORE_DISCONNECTED,
                 SessionDecision.RESTORE_ARM_TIMEOUT,
                 SessionDecision.RESTORE_SAFETY_TIMEOUT -> {
-                    restoreAndContinue()
+                    restoreAndContinue(assessment)
                     return
                 }
-                SessionDecision.CONTINUE -> startAsForeground(
-                    SessionNotifications.session(this, connected = plugged || session.connectedSeen),
-                )
+                SessionDecision.CONTINUE -> {
+                    if (assessment != null) interruptionAssessor.onSessionDecision(assessment, decision)
+                    startAsForeground(
+                        SessionNotifications.session(this, connected = plugged || session.connectedSeen),
+                    )
+                }
             }
             // Non-restore session tick: let watchers observe it (the alarm claims the cycle here).
             dispatchWatchers(plugged, percent, status, sessionOwned = true, battery, observedAtElapsed)
@@ -485,12 +512,25 @@ class ChargeSessionService : Service() {
         unregisterSettingObserver()
         startAsForeground(SessionNotifications.recovering(this))
         recoveryJob = scope.launch {
-            val outcome = BootRecoveryFlow(recoveryHooks).run()
-            log(TAG) { "Boot recovery outcome: $outcome" }
-            commandMutex.withLock {
-                // continueGestureOrStop() awaits a surface update on every terminal branch, so no path here
-                // leaves the widget/tile un-pushed (some paths push more than once — updateAll is idempotent).
-                continueGestureOrStop()
+            // Assess whether this recovery is picking up work a dead process left behind, BEFORE the
+            // flow mutates the pending target.
+            val pickup = interruptionAssessor.captureRecoveryPickup()
+            val result = BootRecoveryFlow(recoveryHooks).run()
+            log(TAG) { "Boot recovery outcome: ${result.outcome}" }
+            // A converged recovery restored the protective policy, so clear any lingering alarm.
+            if (result.outcome == BootRecoveryFlow.Outcome.CONVERGED) {
+                SessionNotifications.cancelRecovery(this@ChargeSessionService)
+            }
+            try {
+                interruptionAssessor.onRecoveryFinished(pickup, result)
+            } finally {
+                // In finally so an interruption-bookkeeping failure can never strand the recovering
+                // foreground state.
+                commandMutex.withLock {
+                    // continueGestureOrStop() awaits a surface update on every terminal branch, so no path here
+                    // leaves the widget/tile un-pushed (some paths push more than once — updateAll is idempotent).
+                    continueGestureOrStop()
+                }
             }
         }
     }
@@ -498,8 +538,12 @@ class ChargeSessionService : Service() {
     private val recoveryHooks = object : BootRecoveryFlow.Hooks {
         override suspend fun currentSessionTarget() = fullChargeStore.currentSession()?.restorePolicy
         override suspend fun pendingTarget() = fullChargeStore.pendingRecoveryTarget()
-        override suspend fun setPendingTarget(policy: ChargePolicy) =
-            fullChargeStore.setPendingRecoveryTarget(policy)
+        override suspend fun setPendingTarget(policy: ChargePolicy) {
+            // A session-only recovery seeds the pending target from the session it is recovering, so it
+            // continues the SAME owed work — inherit the session's work id; otherwise mint a fresh one.
+            val workId = fullChargeStore.currentSession()?.workId ?: UUID.randomUUID().toString()
+            fullChargeStore.setPendingRecoveryTarget(policy, workId, currentWorkProvenance())
+        }
 
         override suspend fun clearPendingTarget() = fullChargeStore.clearPendingRecoveryTarget()
         override suspend fun restoreSession() = manager.restore().success
@@ -536,11 +580,16 @@ class ChargeSessionService : Service() {
         override fun elapsedRealtime() = SystemClock.elapsedRealtime()
     }
 
-    private suspend fun restoreAndContinue() {
+    private suspend fun restoreAndContinue(
+        assessment: InterruptionAssessor.PickupAssessment? = null,
+    ) {
         log(TAG) { "Restoring the saved charging policy" }
         restoring = true
         monitorReady = false
         unregisterSettingObserver()
+        // Read the stable work id before the restore clears the session record, so a later upgrade of
+        // a still-pending interruption event can be matched to it (the owner token is not stable).
+        val restoreWorkId = fullChargeStore.currentSession()?.workId
         val result = try {
             manager.restore()
         } finally {
@@ -550,6 +599,7 @@ class ChargeSessionService : Service() {
         }
         if (!result.success) {
             log(TAG, Logging.Priority.ERROR) { "Charging-policy restoration failed: ${result.message}" }
+            interruptionAssessor.onSessionRestoreFinished(assessment, success = false)
             // The session stays persisted for a retry on the next start (foreground nudge, manual
             // restore, boot). Resuming monitoring here would immediately re-evaluate the same
             // restore condition and loop on the failing write, so stop instead — in a finally, so
@@ -562,6 +612,11 @@ class ChargeSessionService : Service() {
             }
             return
         }
+        // Restore succeeded: cancel any lingering "needs attention" notification, upgrade a prior
+        // still-pending interruption event for this work, and record the catch-up outcome.
+        SessionNotifications.cancelRecovery(this)
+        interruptionAssessor.onRestoreSucceeded(restoreWorkId)
+        interruptionAssessor.onSessionRestoreFinished(assessment, success = true)
         quickGesture.reset()
         SurfaceUpdater.updateNow(this)
         continueGestureOrStop()
@@ -580,8 +635,9 @@ class ChargeSessionService : Service() {
         }
         // Persist the intended end state as the recovery target BEFORE the risky write and before dropping
         // the session, so a failed write or a mid-write process death still converges here on next boot
-        // instead of leaving charging in whatever transient state the session had.
-        fullChargeStore.setPendingRecoveryTarget(policy)
+        // instead of leaving charging in whatever transient state the session had. An explicit persistent
+        // choice is new owed work, so it gets a fresh work id.
+        fullChargeStore.setPendingRecoveryTarget(policy, UUID.randomUUID().toString(), currentWorkProvenance())
         restoring = true
         monitorReady = false
         try {
@@ -594,6 +650,10 @@ class ChargeSessionService : Service() {
             val result = repository.reapplyPersistent(policy)
             if (result.success) {
                 fullChargeStore.clearPendingRecoveryTarget()
+                // An explicit persistent choice is the desired end state; clear any non-successful
+                // interruption warning it supersedes and drop the recovery notification.
+                SessionNotifications.cancelRecovery(this)
+                interruptionAssessor.onExplicitPolicyWrite()
             } else {
                 log(TAG, Logging.Priority.ERROR) { "Persistent policy write failed: ${result.message}" }
                 SessionNotifications.showRecovery(this)
@@ -607,6 +667,14 @@ class ChargeSessionService : Service() {
         continueGestureOrStop()
     }
 
+    /** Stamp persisted recovery work with this process's identity + the current boot count. */
+    private fun currentWorkProvenance() = WorkProvenance(
+        token = processIdentity.token,
+        pid = processIdentity.pid,
+        bootCount = bootCountProvider.current(),
+        createdAtMillis = System.currentTimeMillis(),
+    )
+
     // The gesture's arming preconditions (hardware charging-state 4) are Pixel-specific; on
     // adapters without that signal the monitor would never arm and must not run.
     private fun reconnectGestureAvailable() =
@@ -614,6 +682,8 @@ class ChargeSessionService : Service() {
 
     private fun stopMonitoring() {
         monitorReady = false
+        // Drop any un-consumed pickup assessment so it can never leak into a later session/monitor run.
+        pendingSessionAssessment = null
         // A rapid disable/re-enable can reuse this service instance; neither stale gesture state
         // (an old reconnect window) nor already-queued evaluations from this run may survive into
         // the next monitoring run.

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/FullChargeModule.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/FullChargeModule.kt
@@ -1,0 +1,27 @@
+package eu.darken.amply.fullcharge.core
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/** The system boot counter, abstracted so interruption bookkeeping stays pure-JVM testable. */
+fun interface BootCountProvider {
+    fun current(): Int?
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object FullChargeModule {
+    @Provides
+    @Singleton
+    fun bootCountProvider(@ApplicationContext context: Context): BootCountProvider =
+        BootCountProvider { ServiceDispatch.currentBootCount(context) }
+
+    @Provides
+    @Singleton
+    fun exitSource(impl: ProcessExitSource): ExitSource = impl
+}

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/FullChargeStore.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/FullChargeStore.kt
@@ -14,10 +14,29 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Provenance of persisted work: which process created it and during which boot. Used to spot work
+ * that survived a process death ([token] mismatch) within the same boot ([bootCount] match). A null
+ * value marks a legacy record written before provenance existed.
+ */
+data class WorkProvenance(
+    val token: String,
+    val pid: Int,
+    val bootCount: Int?,
+    val createdAtMillis: Long,
+)
+
 data class ChargeSessionRecord(
     val restorePolicy: ChargePolicy,
     val startedAtMillis: Long,
     val connectedSeen: Boolean,
+    val provenance: WorkProvenance? = null,
+    /**
+     * Stable correlation id for the owed work, generated once at creation and preserved across
+     * process-adoption (unlike [WorkProvenance.token], which is re-stamped to the current owner). An
+     * interruption event ties back to this so a later restore can resolve it. Null on legacy records.
+     */
+    val workId: String? = null,
 )
 
 @Singleton
@@ -34,12 +53,19 @@ class FullChargeStore @Inject constructor(
 
     suspend fun currentSession(): ChargeSessionRecord? = session.first()
 
-    suspend fun startSession(restorePolicy: ChargePolicy, startedAtMillis: Long) {
+    suspend fun startSession(
+        restorePolicy: ChargePolicy,
+        startedAtMillis: Long,
+        workId: String? = null,
+        provenance: WorkProvenance? = null,
+    ) {
         dataStore.store.edit {
             it[SESSION_ACTIVE] = true
             it[SESSION_RESTORE_POLICY] = restorePolicy.stableId
             it[SESSION_STARTED_AT] = startedAtMillis
             it[SESSION_CONNECTED] = false
+            workId?.let { id -> it[SESSION_WORK_ID] = id } ?: it.remove(SESSION_WORK_ID)
+            it.writeSessionProvenance(provenance)
         }
     }
 
@@ -49,24 +75,75 @@ class FullChargeStore @Inject constructor(
         }
     }
 
+    /** Adopt the current process as the session's owner and flag CONNECTED in a single atomic edit. */
+    suspend fun markConnectedAndAdopt(provenance: WorkProvenance) {
+        dataStore.store.edit { prefs ->
+            if (prefs[SESSION_ACTIVE] != true) return@edit
+            prefs[SESSION_CONNECTED] = true
+            prefs.writeSessionProvenance(provenance)
+        }
+    }
+
+    /** Re-stamp the active session's provenance to the current process, if a session is present. */
+    suspend fun adoptSessionOwner(provenance: WorkProvenance) {
+        dataStore.store.edit { prefs ->
+            if (prefs[SESSION_ACTIVE] != true) return@edit
+            prefs.writeSessionProvenance(provenance)
+        }
+    }
+
     suspend fun clearSession() {
         dataStore.store.edit {
             it.remove(SESSION_ACTIVE)
             it.remove(SESSION_RESTORE_POLICY)
             it.remove(SESSION_STARTED_AT)
             it.remove(SESSION_CONNECTED)
+            it.remove(SESSION_WORK_ID)
+            it.remove(SESSION_OWNER_TOKEN)
+            it.remove(SESSION_OWNER_PID)
+            it.remove(SESSION_BOOT_COUNT)
+            it.remove(SESSION_OWNER_SET_AT)
         }
     }
 
     suspend fun pendingRecoveryTarget(): ChargePolicy? =
         dataStore.store.data.first()[RECOVERY_PENDING_TARGET]?.let(ChargePolicy::fromStableId)
 
-    suspend fun setPendingRecoveryTarget(policy: ChargePolicy) {
-        dataStore.store.edit { it[RECOVERY_PENDING_TARGET] = policy.stableId }
+    suspend fun pendingRecoveryProvenance(): WorkProvenance? =
+        dataStore.store.data.first().recoveryProvenance()
+
+    suspend fun pendingRecoveryWorkId(): String? =
+        dataStore.store.data.first()[RECOVERY_WORK_ID]
+
+    suspend fun setPendingRecoveryTarget(
+        policy: ChargePolicy,
+        workId: String? = null,
+        provenance: WorkProvenance? = null,
+    ) {
+        dataStore.store.edit {
+            it[RECOVERY_PENDING_TARGET] = policy.stableId
+            workId?.let { id -> it[RECOVERY_WORK_ID] = id } ?: it.remove(RECOVERY_WORK_ID)
+            it.writeRecoveryProvenance(provenance)
+        }
+    }
+
+    /** Re-stamp the pending recovery target's provenance to the current process, if one is present. */
+    suspend fun adoptRecoveryOwner(provenance: WorkProvenance) {
+        dataStore.store.edit { prefs ->
+            if (prefs[RECOVERY_PENDING_TARGET] == null) return@edit
+            prefs.writeRecoveryProvenance(provenance)
+        }
     }
 
     suspend fun clearPendingRecoveryTarget() {
-        dataStore.store.edit { it.remove(RECOVERY_PENDING_TARGET) }
+        dataStore.store.edit {
+            it.remove(RECOVERY_PENDING_TARGET)
+            it.remove(RECOVERY_WORK_ID)
+            it.remove(RECOVERY_OWNER_TOKEN)
+            it.remove(RECOVERY_OWNER_PID)
+            it.remove(RECOVERY_BOOT_COUNT)
+            it.remove(RECOVERY_SET_AT)
+        }
     }
 
     /** The boot count during which Amply last ran — used to spot re-delivered BOOT_COMPLETED broadcasts. */
@@ -95,7 +172,65 @@ class FullChargeStore @Inject constructor(
             restorePolicy = policy,
             startedAtMillis = prefs[SESSION_STARTED_AT] ?: 0L,
             connectedSeen = prefs[SESSION_CONNECTED] ?: false,
+            provenance = prefs.sessionProvenance(),
+            workId = prefs[SESSION_WORK_ID],
         )
+    }
+
+    // A record is only stamped with provenance when a token is present; a missing token (legacy
+    // record) decodes to null so the assessor treats it as un-owned and adopts it silently.
+    private fun Preferences.sessionProvenance(): WorkProvenance? {
+        val token = this[SESSION_OWNER_TOKEN] ?: return null
+        return WorkProvenance(
+            token = token,
+            pid = this[SESSION_OWNER_PID] ?: -1,
+            bootCount = this[SESSION_BOOT_COUNT],
+            // The owner timestamp is written on every (re-)stamp; fall back to the session start for
+            // legacy records that predate it.
+            createdAtMillis = this[SESSION_OWNER_SET_AT] ?: this[SESSION_STARTED_AT] ?: 0L,
+        )
+    }
+
+    private fun Preferences.recoveryProvenance(): WorkProvenance? {
+        val token = this[RECOVERY_OWNER_TOKEN] ?: return null
+        return WorkProvenance(
+            token = token,
+            pid = this[RECOVERY_OWNER_PID] ?: -1,
+            bootCount = this[RECOVERY_BOOT_COUNT],
+            createdAtMillis = this[RECOVERY_SET_AT] ?: 0L,
+        )
+    }
+
+    private fun androidx.datastore.preferences.core.MutablePreferences.writeSessionProvenance(
+        provenance: WorkProvenance?,
+    ) {
+        if (provenance == null) {
+            remove(SESSION_OWNER_TOKEN)
+            remove(SESSION_OWNER_PID)
+            remove(SESSION_BOOT_COUNT)
+            remove(SESSION_OWNER_SET_AT)
+            return
+        }
+        this[SESSION_OWNER_TOKEN] = provenance.token
+        this[SESSION_OWNER_PID] = provenance.pid
+        provenance.bootCount?.let { this[SESSION_BOOT_COUNT] = it } ?: remove(SESSION_BOOT_COUNT)
+        this[SESSION_OWNER_SET_AT] = provenance.createdAtMillis
+    }
+
+    private fun androidx.datastore.preferences.core.MutablePreferences.writeRecoveryProvenance(
+        provenance: WorkProvenance?,
+    ) {
+        if (provenance == null) {
+            remove(RECOVERY_OWNER_TOKEN)
+            remove(RECOVERY_OWNER_PID)
+            remove(RECOVERY_BOOT_COUNT)
+            remove(RECOVERY_SET_AT)
+            return
+        }
+        this[RECOVERY_OWNER_TOKEN] = provenance.token
+        this[RECOVERY_OWNER_PID] = provenance.pid
+        provenance.bootCount?.let { this[RECOVERY_BOOT_COUNT] = it } ?: remove(RECOVERY_BOOT_COUNT)
+        this[RECOVERY_SET_AT] = provenance.createdAtMillis
     }
 
     private companion object {
@@ -103,9 +238,19 @@ class FullChargeStore @Inject constructor(
         val SESSION_RESTORE_POLICY = stringPreferencesKey("session.restore_policy")
         val SESSION_STARTED_AT = longPreferencesKey("session.started_at")
         val SESSION_CONNECTED = booleanPreferencesKey("session.connected_seen")
+        val SESSION_WORK_ID = stringPreferencesKey("session.work_id")
+        val SESSION_OWNER_TOKEN = stringPreferencesKey("session.owner_token")
+        val SESSION_OWNER_PID = intPreferencesKey("session.owner_pid")
+        val SESSION_BOOT_COUNT = intPreferencesKey("session.boot_count")
+        val SESSION_OWNER_SET_AT = longPreferencesKey("session.owner_set_at")
         val QUICK_FULL_CHARGE_ENABLED = booleanPreferencesKey("fullcharge.quick_replug_enabled")
         val QUICK_FULL_CHARGE_ANY_LEVEL = booleanPreferencesKey("fullcharge.quick_replug_any_level")
         val RECOVERY_PENDING_TARGET = stringPreferencesKey("recovery.pending_target")
+        val RECOVERY_WORK_ID = stringPreferencesKey("recovery.work_id")
+        val RECOVERY_OWNER_TOKEN = stringPreferencesKey("recovery.owner_token")
+        val RECOVERY_OWNER_PID = intPreferencesKey("recovery.owner_pid")
+        val RECOVERY_BOOT_COUNT = intPreferencesKey("recovery.boot_count")
+        val RECOVERY_SET_AT = longPreferencesKey("recovery.set_at")
         val LAST_SEEN_BOOT_COUNT = intPreferencesKey("recovery.last_seen_boot_count")
     }
 }

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/InterruptionAssessor.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/InterruptionAssessor.kt
@@ -1,0 +1,202 @@
+package eu.darken.amply.fullcharge.core
+
+import eu.darken.amply.common.debug.logging.Logging
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import kotlinx.coroutines.CancellationException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Sequences interrupted-session detection around the service's session/recovery pickups. It decides
+ * — from persisted work provenance, the boot counter, and the pure [InterruptionDecisionEngine] —
+ * whether a process death actually cost the user a restore, records at most one dashboard event when
+ * it did, and otherwise silently re-adopts surviving work to the current process so a same-process
+ * retry never double-records.
+ *
+ * Every public method is best-effort: a non-cancellation failure is caught and logged, never
+ * propagated, so interruption bookkeeping can never strand the service's own cleanup. Cancellation
+ * still propagates.
+ */
+@Singleton
+class InterruptionAssessor @Inject constructor(
+    private val fullChargeStore: FullChargeStore,
+    private val interruptionStore: InterruptionStore,
+    private val exitSource: ExitSource,
+    private val identity: ProcessIdentity,
+    private val bootCountProvider: BootCountProvider,
+) {
+
+    /** A survived same-boot pickup that may warrant an event; consumed exactly once by a terminal handler. */
+    class PickupAssessment internal constructor(
+        internal val provenance: WorkProvenance,
+        internal val workId: String?,
+        internal val survived: Boolean,
+        internal val sameBoot: Boolean,
+    ) {
+        private var consumed = false
+
+        internal fun consume(): Boolean {
+            if (consumed) return false
+            consumed = true
+            return true
+        }
+    }
+
+    /**
+     * A recovery pickup: the stable [workId] of the recovering work (present even when no assessment
+     * is produced, so a convergence can resolve a prior event) plus the candidate [assessment].
+     */
+    class RecoveryPickup internal constructor(
+        internal val workId: String?,
+        internal val assessment: PickupAssessment?,
+    )
+
+    /**
+     * Assess a resumed persisted session. Returns a candidate assessment only when the session's work
+     * crossed a same-boot process death; for legacy/no-death/reboot pickups it silently adopts the
+     * session to the current process and returns null (no event).
+     */
+    suspend fun captureSessionPickup(record: ChargeSessionRecord): PickupAssessment? = runSafeOrNull {
+        val provenance = record.provenance
+        if (provenance == null || !isSurvivedSameBoot(provenance)) {
+            fullChargeStore.adoptSessionOwner(currentProvenance())
+            return@runSafeOrNull null
+        }
+        PickupAssessment(provenance, workId = record.workId, survived = true, sameBoot = true)
+    }
+
+    /** The session resumed unharmed (CONTINUE / MARK_CONNECTED): adopt, no event. */
+    suspend fun onSessionDecision(assessment: PickupAssessment?, decision: SessionDecision) = runSafe {
+        if (assessment == null || !assessment.consume()) return@runSafe
+        when (decision) {
+            SessionDecision.MARK_CONNECTED -> fullChargeStore.markConnectedAndAdopt(currentProvenance())
+            else -> fullChargeStore.adoptSessionOwner(currentProvenance())
+        }
+    }
+
+    /** A restore was due after the pickup and has finished; record the outcome. */
+    suspend fun onSessionRestoreFinished(assessment: PickupAssessment?, success: Boolean) = runSafe {
+        if (assessment == null || !assessment.consume()) return@runSafe
+        val outcome = if (success) InterruptionOutcome.RESTORED_LATE else InterruptionOutcome.STILL_PENDING
+        recordEvent(assessment, outcome)
+        // A failed restore leaves the session persisted with the dead process's provenance; adopt so a
+        // same-process retry never re-fires. A successful restore has already cleared the session.
+        if (fullChargeStore.currentSession() != null) fullChargeStore.adoptSessionOwner(currentProvenance())
+    }
+
+    /**
+     * Assess a recovery pickup. Recovery reaches here for both a pending target and a session-only
+     * restore, so provenance is read from the pending target first, then the session. Non-candidate
+     * pickups silently adopt any surviving recovery work — but the [RecoveryPickup] still carries the
+     * work id so a convergence can resolve a prior event even without an assessment.
+     */
+    suspend fun captureRecoveryPickup(): RecoveryPickup = runSafeOrNull {
+        val provenance = fullChargeStore.pendingRecoveryProvenance()
+            ?: fullChargeStore.currentSession()?.provenance
+        val workId = fullChargeStore.pendingRecoveryWorkId()
+            ?: fullChargeStore.currentSession()?.workId
+        if (provenance == null || !isSurvivedSameBoot(provenance)) {
+            adoptRecoveryWork()
+            return@runSafeOrNull RecoveryPickup(workId = workId, assessment = null)
+        }
+        RecoveryPickup(
+            workId = workId,
+            assessment = PickupAssessment(provenance, workId = workId, survived = true, sameBoot = true),
+        )
+    } ?: RecoveryPickup(workId = null, assessment = null)
+
+    /** The recovery flow finished; resolve a converged prior event, map its outcome, re-adopt retry work. */
+    suspend fun onRecoveryFinished(pickup: RecoveryPickup, result: BootRecoveryFlow.Result) = runSafe {
+        // A converged recovery restored the protective policy; resolve any prior still-pending event
+        // for this work FIRST — unconditionally, even when this pickup records nothing itself.
+        if (result.outcome == BootRecoveryFlow.Outcome.CONVERGED) {
+            pickup.workId?.let { interruptionStore.markRestored(it) }
+        }
+        val assessment = pickup.assessment
+        if (assessment != null && assessment.consume()) {
+            val outcome = InterruptionDecisionEngine.recoveryOutcome(
+                survived = assessment.survived,
+                sameBoot = assessment.sameBoot,
+                result = result,
+            )
+            if (outcome != null) recordEvent(assessment, outcome)
+        }
+        // Re-adopt a pending target still persisted for retry so a same-process retry never double-records.
+        fullChargeStore.adoptRecoveryOwner(currentProvenance())
+    }
+
+    /** A later restore for [workId] succeeded: upgrade a still-pending / unconfirmed event. */
+    suspend fun onRestoreSucceeded(workId: String?) = runSafe {
+        if (workId == null) return@runSafe
+        interruptionStore.markRestored(workId)
+    }
+
+    /** An explicit user policy write supersedes the situation the event warned about; clear it. */
+    suspend fun onExplicitPolicyWrite() = runSafe {
+        interruptionStore.clearPending()
+    }
+
+    private fun isSurvivedSameBoot(provenance: WorkProvenance): Boolean {
+        val survived = InterruptionDecisionEngine.survivedDeath(provenance.token, identity.token)
+        val sameBoot = InterruptionDecisionEngine.sameBoot(provenance.bootCount, bootCountProvider.current())
+        return survived && sameBoot
+    }
+
+    private suspend fun adoptRecoveryWork() {
+        val provenance = currentProvenance()
+        fullChargeStore.adoptRecoveryOwner(provenance)
+        fullChargeStore.adoptSessionOwner(provenance)
+    }
+
+    private suspend fun recordEvent(assessment: PickupAssessment, outcome: InterruptionOutcome) {
+        val reason = InterruptionDecisionEngine.classifyExit(
+            exits = exitSource.recentExits(EXIT_LOOKBACK),
+            ownerPid = assessment.provenance.pid,
+            notBeforeMillis = assessment.provenance.createdAtMillis,
+        )
+        interruptionStore.record(
+            InterruptionEvent(
+                occurredAtMillis = System.currentTimeMillis(),
+                reason = reason,
+                outcome = outcome,
+                // The stable work id (never the mutable owner token) correlates a later restore; a
+                // record carrying provenance always carries a work id, so the fallback is unreachable.
+                workId = assessment.workId ?: assessment.provenance.token,
+            ),
+        )
+    }
+
+    private fun currentProvenance() = WorkProvenance(
+        token = identity.token,
+        pid = identity.pid,
+        bootCount = bootCountProvider.current(),
+        createdAtMillis = System.currentTimeMillis(),
+    )
+
+    private suspend fun runSafe(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, Logging.Priority.WARN) { "Interruption bookkeeping failed: ${e.message}" }
+        }
+    }
+
+    private suspend fun <T> runSafeOrNull(block: suspend () -> T?): T? = try {
+        block()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, Logging.Priority.WARN) { "Interruption assessment failed: ${e.message}" }
+        null
+    }
+
+    private companion object {
+        val TAG = logTag("FullCharge", "InterruptionAssessor")
+
+        // How many historical process-exit records to scan when classifying the interruption reason.
+        const val EXIT_LOOKBACK = 16
+    }
+}

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/InterruptionDecision.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/InterruptionDecision.kt
@@ -1,0 +1,90 @@
+package eu.darken.amply.fullcharge.core
+
+/** A single historical process-exit record, distilled from `ApplicationExitInfo`. */
+data class ExitRecord(
+    val timestampMillis: Long,
+    val pid: Int,
+    val reason: Int,
+)
+
+/**
+ * Pure, JVM-testable decisions for interrupted-session detection. Everything here is evidence-based:
+ * a survived-death signal from a process-token mismatch, a same-boot guard from the boot counter, an
+ * effect gate from what work was actually due, and a cosmetic exit-reason classification that never
+ * overclaims a force-stop.
+ */
+object InterruptionDecisionEngine {
+
+    /** `ApplicationExitInfo.REASON_USER_REQUESTED` (10). */
+    const val REASON_USER_REQUESTED = 10
+
+    /** `ApplicationExitInfo.REASON_USER_STOPPED` (11). */
+    const val REASON_USER_STOPPED = 11
+
+    /** True when persisted work was created by a different, now-dead process. */
+    fun survivedDeath(storedToken: String?, currentToken: String): Boolean =
+        storedToken != null && storedToken != currentToken
+
+    /** True only when both boot counts are known and equal — otherwise a reboot cannot be excluded. */
+    fun sameBoot(storedBootCount: Int?, currentBootCount: Int?): Boolean =
+        storedBootCount != null && currentBootCount != null && storedBootCount == currentBootCount
+
+    /**
+     * A session pickup that crossed a same-boot death warrants an event only when a restore was
+     * actually due (a `RESTORE_*` decision). `CONTINUE` / `MARK_CONNECTED` mean the session resumed
+     * unharmed — no event.
+     */
+    fun shouldRecordForSession(survived: Boolean, sameBoot: Boolean, decision: SessionDecision): Boolean {
+        if (!survived || !sameBoot) return false
+        return when (decision) {
+            SessionDecision.RESTORE_FULL,
+            SessionDecision.RESTORE_DISCONNECTED,
+            SessionDecision.RESTORE_ARM_TIMEOUT,
+            SessionDecision.RESTORE_SAFETY_TIMEOUT -> true
+            SessionDecision.CONTINUE,
+            SessionDecision.MARK_CONNECTED -> false
+        }
+    }
+
+    /**
+     * Maps a completed [BootRecoveryFlow.Result] to an outcome, or null for "no event". Requires a
+     * survived same-boot death first; then only a flow that actually did (or attempted) work counts.
+     */
+    fun recoveryOutcome(
+        survived: Boolean,
+        sameBoot: Boolean,
+        result: BootRecoveryFlow.Result,
+    ): InterruptionOutcome? {
+        if (!survived || !sameBoot) return null
+        return when (result.outcome) {
+            BootRecoveryFlow.Outcome.CONVERGED ->
+                if (result.restoreAttempted || result.rewrites > 0) InterruptionOutcome.RESTORED_LATE else null
+            BootRecoveryFlow.Outcome.RESTORE_FAILED -> InterruptionOutcome.STILL_PENDING
+            BootRecoveryFlow.Outcome.GAVE_UP ->
+                if (result.retryRemaining) InterruptionOutcome.STILL_PENDING else InterruptionOutcome.UNCONFIRMED
+            BootRecoveryFlow.Outcome.NOTHING_TO_DO,
+            BootRecoveryFlow.Outcome.SUPERSEDED -> null
+        }
+    }
+
+    /**
+     * Cosmetic reason from the historical exit list: the latest record for [ownerPid] at or after
+     * [notBeforeMillis] decides. Codes 10/11 read as [InterruptionReason.USER_STOPPED]; anything else,
+     * a null owner PID, or no matching record reads as [InterruptionReason.OTHER].
+     */
+    fun classifyExit(
+        exits: List<ExitRecord>,
+        ownerPid: Int?,
+        notBeforeMillis: Long,
+    ): InterruptionReason {
+        if (ownerPid == null) return InterruptionReason.OTHER
+        val candidate = exits
+            .filter { it.pid == ownerPid && it.timestampMillis >= notBeforeMillis }
+            .maxByOrNull { it.timestampMillis }
+            ?: return InterruptionReason.OTHER
+        return when (candidate.reason) {
+            REASON_USER_REQUESTED, REASON_USER_STOPPED -> InterruptionReason.USER_STOPPED
+            else -> InterruptionReason.OTHER
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/InterruptionStore.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/InterruptionStore.kt
@@ -1,0 +1,113 @@
+package eu.darken.amply.fullcharge.core
+
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import eu.darken.amply.common.AppDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Why Amply's process most likely went away. Cosmetic only — never asserts a force-stop. */
+enum class InterruptionReason {
+    /** The exit reason matched a user-requested stop (ApplicationExitInfo USER_REQUESTED / USER_STOPPED). */
+    USER_STOPPED,
+
+    /** Anything else, no matching exit record, or the API is unavailable. */
+    OTHER,
+}
+
+enum class InterruptionOutcome {
+    /** The catch-up restore succeeded — the protective limit is back. */
+    RESTORED_LATE,
+
+    /** The restore failed and retry work remains persisted. */
+    STILL_PENDING,
+
+    /** Recovery gave up without hardware confirmation and cleared its retry state. */
+    UNCONFIRMED,
+}
+
+data class InterruptionEvent(
+    val occurredAtMillis: Long,
+    val reason: InterruptionReason,
+    val outcome: InterruptionOutcome,
+    /** Stable correlation id of the owed work (see [ChargeSessionRecord.workId]); survives adoption. */
+    val workId: String,
+)
+
+/**
+ * Single-slot persistence for the "Amply was interrupted while owing a restore" dashboard signal.
+ * At most one event is held at a time — a newer event overwrites the old. A malformed/unknown stored
+ * enum decodes to no event. Shares the single [AppDataStore] like the other feature facades.
+ */
+@Singleton
+open class InterruptionStore @Inject constructor(
+    private val dataStore: AppDataStore,
+) {
+    val event: Flow<InterruptionEvent?> = dataStore.store.data.map(::toEvent)
+
+    open suspend fun record(event: InterruptionEvent) {
+        dataStore.store.edit {
+            it[OCCURRED_AT] = event.occurredAtMillis
+            it[REASON] = event.reason.name
+            it[OUTCOME] = event.outcome.name
+            it[WORK_TOKEN] = event.workId
+        }
+    }
+
+    /**
+     * Upgrade a still-pending / unconfirmed event to [InterruptionOutcome.RESTORED_LATE] once a later
+     * restore for the *same* work token succeeds. No-op when there is no event, the token differs, or
+     * it is already RESTORED_LATE.
+     */
+    open suspend fun markRestored(workId: String) {
+        dataStore.store.edit { prefs ->
+            val current = toEvent(prefs) ?: return@edit
+            if (current.workId != workId) return@edit
+            if (current.outcome == InterruptionOutcome.RESTORED_LATE) return@edit
+            prefs[OUTCOME] = InterruptionOutcome.RESTORED_LATE.name
+        }
+    }
+
+    /** Clear the event only if it is not a successful (RESTORED_LATE) one — used on an explicit user write. */
+    open suspend fun clearPending() {
+        dataStore.store.edit { prefs ->
+            val current = toEvent(prefs) ?: return@edit
+            if (current.outcome == InterruptionOutcome.RESTORED_LATE) return@edit
+            prefs.clearKeys()
+        }
+    }
+
+    open suspend fun clear() {
+        dataStore.store.edit { it.clearKeys() }
+    }
+
+    private fun androidx.datastore.preferences.core.MutablePreferences.clearKeys() {
+        remove(OCCURRED_AT)
+        remove(REASON)
+        remove(OUTCOME)
+        remove(WORK_TOKEN)
+    }
+
+    private fun toEvent(prefs: Preferences): InterruptionEvent? {
+        val occurredAt = prefs[OCCURRED_AT] ?: return null
+        val reason = prefs[REASON]?.let { name ->
+            InterruptionReason.entries.firstOrNull { it.name == name }
+        } ?: return null
+        val outcome = prefs[OUTCOME]?.let { name ->
+            InterruptionOutcome.entries.firstOrNull { it.name == name }
+        } ?: return null
+        val workId = prefs[WORK_TOKEN] ?: return null
+        return InterruptionEvent(occurredAt, reason, outcome, workId)
+    }
+
+    private companion object {
+        val OCCURRED_AT = longPreferencesKey("interruption.v1.occurred_at")
+        val REASON = stringPreferencesKey("interruption.v1.reason")
+        val OUTCOME = stringPreferencesKey("interruption.v1.outcome")
+        val WORK_TOKEN = stringPreferencesKey("interruption.v1.work_token")
+    }
+}

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ProcessExitSource.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ProcessExitSource.kt
@@ -1,0 +1,44 @@
+package eu.darken.amply.fullcharge.core
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.amply.common.debug.logging.Logging
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** The historical process-exit records, abstracted so the assessor stays pure-JVM testable. */
+fun interface ExitSource {
+    fun recentExits(limit: Int): List<ExitRecord>
+}
+
+/**
+ * Thin wrapper over `ActivityManager.getHistoricalProcessExitReasons`, filtered to Amply's main
+ * process. Purely cosmetic input to the interruption reason — best-effort: below API 30 or on any
+ * failure it returns an empty list, so classification simply falls back to [InterruptionReason.OTHER].
+ */
+@Singleton
+class ProcessExitSource @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : ExitSource {
+    override fun recentExits(limit: Int): List<ExitRecord> {
+        if (Build.VERSION.SDK_INT < 30) return emptyList()
+        return try {
+            val am = context.getSystemService(ActivityManager::class.java)
+            val mainProcessName = context.packageName
+            am.getHistoricalProcessExitReasons(null, 0, limit)
+                .filter { it.processName == mainProcessName }
+                .map { ExitRecord(timestampMillis = it.timestamp, pid = it.pid, reason = it.reason) }
+        } catch (e: Exception) {
+            log(TAG, Logging.Priority.WARN) { "Could not read historical exit reasons: ${e.message}" }
+            emptyList()
+        }
+    }
+
+    private companion object {
+        val TAG = logTag("FullCharge", "ProcessExitSource")
+    }
+}

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ProcessIdentity.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ProcessIdentity.kt
@@ -1,0 +1,17 @@
+package eu.darken.amply.fullcharge.core
+
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Identity of the current OS process. A persisted work record stamps [token] + [pid]; at pickup a
+ * stored token that differs from the live [token] proves the work crossed a process death (crash,
+ * force-stop, system kill). The [pid] only ever serves to match the corresponding
+ * `ApplicationExitInfo` record — never as the survived-death signal itself (PIDs are reused).
+ */
+@Singleton
+class ProcessIdentity @Inject constructor() {
+    val token: String = UUID.randomUUID().toString()
+    val pid: Int = android.os.Process.myPid()
+}

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/SessionNotifications.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/SessionNotifications.kt
@@ -186,9 +186,11 @@ object SessionNotifications {
             .build()
     }
 
-    // TODO known gap: this notification (RECOVERY_ID) is not cancelled when a later restore succeeds;
-    // it lingers until swiped. Should cancel on successful restore. See "Known gaps" in
-    // .claude/rules/privileged-access.md.
+    /** Cancel the "charge limit needs attention" notification once a later restore/convergence succeeds. */
+    fun cancelRecovery(context: Context) {
+        NotificationManagerCompat.from(context).cancel(RECOVERY_ID)
+    }
+
     fun showRecovery(context: Context, bodyRes: Int = R.string.recovery_notification_body) {
         ensureChannels(context)
         if (Build.VERSION.SDK_INT >= 33 && ContextCompat.checkSelfPermission(

--- a/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
@@ -272,6 +272,7 @@ class MainActivity : ComponentActivity() {
                             onPinWidget = viewModel::requestPinWidget,
                             onAddTile = viewModel::requestAddTile,
                             onDismissQuickAccess = viewModel::dismissQuickAccess,
+                            onDismissInterruption = viewModel::dismissInterruption,
                             onNativeSettings = viewModel::openNativeSettings,
                             onOpenShizuku = viewModel::openShizuku,
                             onAllowShizuku = viewModel::requestShizukuPermission,

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -77,6 +77,9 @@ import eu.darken.amply.common.compose.AmplyToggleCard
 import eu.darken.amply.common.compose.PreviewWrapper
 import eu.darken.amply.common.compose.asComposable
 import eu.darken.amply.fullcharge.core.ChargeSessionRecord
+import eu.darken.amply.fullcharge.core.InterruptionEvent
+import eu.darken.amply.fullcharge.core.InterruptionOutcome
+import eu.darken.amply.fullcharge.core.InterruptionReason
 import eu.darken.amply.fullcharge.core.policyOrNull
 import eu.darken.amply.main.core.formatReport
 import eu.darken.amply.battery.core.BatteryReadout
@@ -113,6 +116,7 @@ fun DashboardScreen(
     onPinWidget: () -> Unit,
     onAddTile: () -> Unit,
     onDismissQuickAccess: () -> Unit,
+    onDismissInterruption: () -> Unit,
     onNativeSettings: () -> Unit,
     onOpenShizuku: () -> Unit,
     onAllowShizuku: () -> Unit,
@@ -203,6 +207,13 @@ fun DashboardScreen(
                         )
                     }
                 } else {
+                    // Interrupted-session warning sits right under the hero, but only on a device
+                    // whose support is positively resolved (a live adapter is selected). Silent
+                    // otherwise — a warning about a restore Amply cannot even perform would confuse.
+                    val interruption = state.interruption
+                    if (interruption != null && state.charging.controlEnabled) {
+                        item { InterruptionCard(interruption, onDismissInterruption) }
+                    }
                     // Shizuku-only adapters (OnePlus/ColorOS) can't use WSS at all, so the WSS/ADB
                     // setup guide would ask for an ineffective grant — the dedicated
                     // "Shizuku required" banner below covers their setup instead.
@@ -740,6 +751,46 @@ private fun ShizukuBanner(
     }
 }
 
+@Composable
+private fun InterruptionCard(
+    event: InterruptionEvent,
+    onDismiss: () -> Unit,
+) {
+    // Tertiary-container "attention" tone, matching the ShizukuBanner. Copy is deliberately neutral —
+    // the reason never asserts a force-stop, only that Amply was stopped/interrupted.
+    AmplyCard(tone = AmplyCardTone.TertiaryContainer) {
+        Text(
+            stringResource(
+                when (event.outcome) {
+                    InterruptionOutcome.RESTORED_LATE -> R.string.dashboard_interruption_title_restored
+                    InterruptionOutcome.STILL_PENDING -> R.string.dashboard_interruption_title_pending
+                    InterruptionOutcome.UNCONFIRMED -> R.string.dashboard_interruption_title_unconfirmed
+                },
+            ),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+        )
+        val reason = stringResource(
+            when (event.reason) {
+                InterruptionReason.USER_STOPPED -> R.string.dashboard_interruption_reason_user
+                InterruptionReason.OTHER -> R.string.dashboard_interruption_reason_other
+            },
+        )
+        val outcome = stringResource(
+            when (event.outcome) {
+                InterruptionOutcome.RESTORED_LATE -> R.string.dashboard_interruption_outcome_restored
+                InterruptionOutcome.STILL_PENDING -> R.string.dashboard_interruption_outcome_pending
+                InterruptionOutcome.UNCONFIRMED -> R.string.dashboard_interruption_outcome_unconfirmed
+            },
+        )
+        Text("$reason $outcome", style = MaterialTheme.typography.bodySmall)
+        Spacer(Modifier.height(8.dp))
+        TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) {
+            Text(stringResource(R.string.dashboard_interruption_dismiss_action))
+        }
+    }
+}
+
 private fun ChargeObservation.title(): CaString = when (this) {
     is ChargeObservation.Verified -> if (backend == BackendKind.BATTERY_HARDWARE) {
         caString { it.getString(R.string.dashboard_status_verified_active, policy.shortLabel().get(it)) }
@@ -802,6 +853,13 @@ private fun DashboardScreenPreview() = PreviewWrapper {
             quickFullChargeEnabled = true,
             // Presence check done, nothing discovered yet — renders the quick-access promotion.
             quickAccessChecked = true,
+            // A resolved interruption: the warning card sits under the hero until dismissed.
+            interruption = InterruptionEvent(
+                occurredAtMillis = 0L,
+                reason = InterruptionReason.USER_STOPPED,
+                outcome = InterruptionOutcome.RESTORED_LATE,
+                workId = "preview",
+            ),
             // Held at the 80% limit: paired with the policy so the reading reads as the effect.
             batteryReadout = BatteryReadout(
                 levelPercent = 80,
@@ -852,6 +910,7 @@ private fun DashboardScreenPreview() = PreviewWrapper {
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
+        onDismissInterruption = {},
         onNativeSettings = {},
         onOpenShizuku = {},
         onAllowShizuku = {},
@@ -945,6 +1004,7 @@ private fun DashboardScreenLiveChargePreview() = PreviewWrapper {
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
+        onDismissInterruption = {},
         onNativeSettings = {},
         onOpenShizuku = {},
         onAllowShizuku = {},
@@ -1020,6 +1080,7 @@ private fun DashboardScreenApplyingPreview() = PreviewWrapper {
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
+        onDismissInterruption = {},
         onNativeSettings = {},
         onOpenShizuku = {},
         onAllowShizuku = {},
@@ -1091,6 +1152,7 @@ private fun DashboardScreenSessionActivePreview() = PreviewWrapper {
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
+        onDismissInterruption = {},
         onNativeSettings = {},
         onOpenShizuku = {},
         onAllowShizuku = {},
@@ -1164,6 +1226,7 @@ private fun DashboardScreenSessionRecordedPreview() = PreviewWrapper {
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
+        onDismissInterruption = {},
         onNativeSettings = {},
         onOpenShizuku = {},
         onAllowShizuku = {},
@@ -1225,6 +1288,7 @@ private fun DashboardScreenWssOnlyPreview() = PreviewWrapper {
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
+        onDismissInterruption = {},
         onNativeSettings = {},
         onOpenShizuku = {},
         onAllowShizuku = {},
@@ -1293,6 +1357,7 @@ private fun DashboardScreenSamsungPreview() = PreviewWrapper {
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
+        onDismissInterruption = {},
         onNativeSettings = {},
         onOpenShizuku = {},
         onAllowShizuku = {},
@@ -1362,6 +1427,7 @@ private fun DashboardScreenOnePlusNeedsShizukuPreview() = PreviewWrapper {
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
+        onDismissInterruption = {},
         onNativeSettings = {},
         onOpenShizuku = {},
         onAllowShizuku = {},
@@ -1416,6 +1482,7 @@ private fun DashboardScreenUnsupportedPreview() = PreviewWrapper {
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
+        onDismissInterruption = {},
         onNativeSettings = {},
         onOpenShizuku = {},
         onAllowShizuku = {},

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
@@ -36,7 +36,10 @@ import eu.darken.amply.fullcharge.core.ChargeSessionManager
 import eu.darken.amply.fullcharge.core.ChargeSessionRecord
 import eu.darken.amply.fullcharge.core.ChargeSessionService
 import eu.darken.amply.fullcharge.core.FullChargeStore
+import eu.darken.amply.fullcharge.core.InterruptionEvent
+import eu.darken.amply.fullcharge.core.InterruptionStore
 import eu.darken.amply.fullcharge.core.ServiceDispatch
+import eu.darken.amply.fullcharge.core.SessionNotifications
 import eu.darken.amply.main.core.DeviceSupportReport
 import eu.darken.amply.main.core.DeviceSupportReporter
 import eu.darken.amply.main.core.OnboardingSettings
@@ -102,6 +105,8 @@ data class DashboardUiState(
     val notificationsBlocked: Boolean = false,
     /** Everything the stats card needs: capture switch, pipeline health, and the Room teaser data. */
     val stats: StatsDashboardState = StatsDashboardState(),
+    /** A pending "Amply was interrupted while owing a restore" warning, or null when there is none. */
+    val interruption: InterruptionEvent? = null,
 )
 
 @HiltViewModel
@@ -118,6 +123,7 @@ class DashboardViewModel @Inject constructor(
     private val statsPreferences: StatsPreferences,
     private val statsRepository: ChargeStatsRepository,
     private val captureServiceHealth: CaptureServiceHealth,
+    private val interruptionStore: InterruptionStore,
     private val watchers: Set<@JvmSuppressWildcards ChargeMonitorWatcher>,
 ) : ViewModel() {
     private val deviceReport = MutableStateFlow<DeviceSupportReport?>(null)
@@ -133,12 +139,22 @@ class DashboardViewModel @Inject constructor(
     ) { enabled, anyLevel -> enabled to anyLevel }
 
     // Grouped so the outer combine keeps one slot each: the live battery readout, the alarm config,
-    // and the notifications-blocked flag.
+    // the notifications-blocked flag, and the interrupted-session warning.
     private val unprivilegedExtras = combine(
         batteryReadoutSource.readouts(),
         chargeAlarmStore.config,
         notificationsBlocked,
-    ) { readout, alarm, blocked -> Triple(readout, alarm, blocked) }
+        interruptionStore.event,
+    ) { readout, alarm, blocked, interruption ->
+        UnprivilegedExtras(readout, alarm, blocked, interruption)
+    }
+
+    private data class UnprivilegedExtras(
+        val readout: BatteryReadout?,
+        val alarm: ChargeAlarmConfig,
+        val notificationsBlocked: Boolean,
+        val interruption: InterruptionEvent?,
+    )
 
     // Battery-statistics dashboard teaser. The session/count reads (which open the stats Room DB)
     // run only while capture is enabled — when it's off the card shows a promo, so a user who never
@@ -173,14 +189,15 @@ class DashboardViewModel @Inject constructor(
         tileRequestPending,
         unprivilegedExtras,
         statsDashboard,
-    ) { base, quickAccess, checked, tilePending, (readout, alarm, blocked), stats ->
+    ) { base, quickAccess, checked, tilePending, extras, stats ->
         base.copy(
             quickAccess = quickAccess,
             quickAccessChecked = checked,
             tileRequestPending = tilePending,
-            batteryReadout = readout,
-            alarm = alarm,
-            notificationsBlocked = blocked,
+            batteryReadout = extras.readout,
+            alarm = extras.alarm,
+            notificationsBlocked = extras.notificationsBlocked,
+            interruption = extras.interruption,
             stats = stats,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), DashboardUiState())
@@ -327,7 +344,13 @@ class DashboardViewModel @Inject constructor(
     fun applyPolicy(policy: ChargePolicy) = viewModelScope.launch {
         log(TAG, Logging.Priority.INFO) { "applyPolicy(${policy.stableId})" }
         if (fullChargeStore.currentSession() != null) sessionManager.cancelWithoutRestore()
-        repository.applyPersistent(policy)
+        val result = repository.applyPersistent(policy)
+        if (result.success) {
+            // An explicit policy choice supersedes any non-successful interruption warning and its
+            // lingering recovery notification.
+            interruptionStore.clearPending()
+            SessionNotifications.cancelRecovery(context)
+        }
         // The persistent policy is an any-level arming input; nudge a running gesture monitor so
         // arming and notification copy react now instead of on the next broadcast/30s poll.
         if (fullChargeStore.isQuickFullChargeEnabled()) {
@@ -445,6 +468,8 @@ class DashboardViewModel @Inject constructor(
     }
 
     fun dismissQuickAccess() = viewModelScope.launch { quickAccessStore.dismiss() }
+
+    fun dismissInterruption() = viewModelScope.launch { interruptionStore.clear() }
 
     fun requestPinWidget() {
         // The pin dialog is modal once shown, but rapid taps before it appears would queue

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -387,6 +387,17 @@
     <string name="dashboard_quickaccess_widget_manual">Widget pinning isn\'t available here. Long-press your home screen and add the Amply widget from the widget picker.</string>
     <string name="dashboard_quickaccess_tile_manual">Open Quick Settings, tap the edit button, and drag the Amply tile into place.</string>
 
+    <!-- Interrupted-session warning card -->
+    <string name="dashboard_interruption_title_restored">Charge limit restored after interruption</string>
+    <string name="dashboard_interruption_title_pending">Charge limit needs attention</string>
+    <string name="dashboard_interruption_title_unconfirmed">Charge limit restore unconfirmed</string>
+    <string name="dashboard_interruption_reason_user">Amply was stopped while it was watching a temporary full charge.</string>
+    <string name="dashboard_interruption_reason_other">Amply was interrupted while it was watching a temporary full charge.</string>
+    <string name="dashboard_interruption_outcome_restored">Your charge limit has been restored now.</string>
+    <string name="dashboard_interruption_outcome_pending">Your charge limit could not be restored yet — Amply keeps retrying. Check the current policy below.</string>
+    <string name="dashboard_interruption_outcome_unconfirmed">Your charge limit was written again, but the charging hardware has not confirmed it. Check the current policy below.</string>
+    <string name="dashboard_interruption_dismiss_action">Dismiss</string>
+
     <!-- Charge alarm (dashboard card + notification) -->
     <string name="dashboard_alarm_title">Charge alarm</string>
     <string name="dashboard_alarm_body_on">Amply will alert you to unplug when charging reaches your target. Works without any special setup.</string>

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/BootRecoveryFlowTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/BootRecoveryFlowTest.kt
@@ -22,7 +22,11 @@ class BootRecoveryFlowTest {
     fun `nothing to do without session or pending target`() = runTest {
         val hooks = FakeHooks(sessionTarget = null)
 
-        BootRecoveryFlow(hooks).run() shouldBe BootRecoveryFlow.Outcome.NOTHING_TO_DO
+        val result = BootRecoveryFlow(hooks).run()
+        result.outcome shouldBe BootRecoveryFlow.Outcome.NOTHING_TO_DO
+        result.restoreAttempted shouldBe false
+        result.rewrites shouldBe 0
+        result.retryRemaining shouldBe false
         hooks.restoreCalls shouldBe 0
     }
 
@@ -30,7 +34,10 @@ class BootRecoveryFlowTest {
     fun `restore failure notifies as write failure and skips convergence`() = runTest {
         val hooks = FakeHooks(restoreResult = false)
 
-        BootRecoveryFlow(hooks).run() shouldBe BootRecoveryFlow.Outcome.RESTORE_FAILED
+        val result = BootRecoveryFlow(hooks).run()
+        result.outcome shouldBe BootRecoveryFlow.Outcome.RESTORE_FAILED
+        result.restoreAttempted shouldBe true
+        result.rewrites shouldBe 0
         hooks.failures shouldContainExactlyInAnyOrder listOf(true)
         hooks.rewrites.shouldBeEmpty()
         hooks.pending shouldBe null
@@ -40,16 +47,41 @@ class BootRecoveryFlowTest {
     fun `hardware confirmation clears the pending target`() = runTest {
         val hooks = FakeHooks(observation = { hardwareLongLife })
 
-        BootRecoveryFlow(hooks).run() shouldBe BootRecoveryFlow.Outcome.CONVERGED
+        // Converged with the hardware already confirming: a real restore happened but no re-writes.
+        val result = BootRecoveryFlow(hooks).run()
+        result.outcome shouldBe BootRecoveryFlow.Outcome.CONVERGED
+        result.restoreAttempted shouldBe true
+        result.rewrites shouldBe 0
+        result.retryRemaining shouldBe false
         hooks.pending shouldBe null
         hooks.rewrites.shouldBeEmpty()
+    }
+
+    @Test
+    fun `converging a pending-only target without work reports no restore and no rewrites`() = runTest {
+        // A resumed pending target already confirmed by the hardware: no restore call, no re-writes,
+        // so an interruption assessor can tell nothing was actually done.
+        val hooks = FakeHooks(
+            sessionTarget = null,
+            pending = fixedLimit,
+            observation = { hardwareLongLife },
+        )
+
+        val result = BootRecoveryFlow(hooks).run()
+        result.outcome shouldBe BootRecoveryFlow.Outcome.CONVERGED
+        result.restoreAttempted shouldBe false
+        result.rewrites shouldBe 0
     }
 
     @Test
     fun `persistent divergence rewrites then gives up with a convergence notification`() = runTest {
         val hooks = FakeHooks()
 
-        BootRecoveryFlow(hooks).run() shouldBe BootRecoveryFlow.Outcome.GAVE_UP
+        // Convergence budget exhausted: the pending target is cleared, so no retry remains.
+        val result = BootRecoveryFlow(hooks).run()
+        result.outcome shouldBe BootRecoveryFlow.Outcome.GAVE_UP
+        result.rewrites shouldBe BootRecoveryEngine.MAX_REWRITES
+        result.retryRemaining shouldBe false
         hooks.rewrites shouldHaveSize BootRecoveryEngine.MAX_REWRITES
         hooks.failures shouldContainExactlyInAnyOrder listOf(false)
         hooks.pending shouldBe null
@@ -59,7 +91,11 @@ class BootRecoveryFlowTest {
     fun `rewrite failure notifies as write failure and preserves the pending target for retry`() = runTest {
         val hooks = FakeHooks(rewriteResult = false)
 
-        BootRecoveryFlow(hooks).run() shouldBe BootRecoveryFlow.Outcome.GAVE_UP
+        // A re-write failure keeps the pending target for a later retry.
+        val result = BootRecoveryFlow(hooks).run()
+        result.outcome shouldBe BootRecoveryFlow.Outcome.GAVE_UP
+        result.retryRemaining shouldBe true
+        result.rewrites shouldBe 1
         hooks.failures shouldContainExactlyInAnyOrder listOf(true)
         hooks.pending shouldBe fixedLimit
     }
@@ -68,7 +104,7 @@ class BootRecoveryFlowTest {
     fun `a newer policy choice supersedes recovery without re-writes`() = runTest {
         val hooks = FakeHooks(intended = { ChargePolicy.Adaptive })
 
-        BootRecoveryFlow(hooks).run() shouldBe BootRecoveryFlow.Outcome.SUPERSEDED
+        BootRecoveryFlow(hooks).run().outcome shouldBe BootRecoveryFlow.Outcome.SUPERSEDED
         hooks.rewrites.shouldBeEmpty()
         hooks.failures.shouldBeEmpty()
         hooks.pending shouldBe null
@@ -80,7 +116,10 @@ class BootRecoveryFlowTest {
             snapshot = BatterySnapshot(plugged = false, percent = 80, chargingState = 4),
         )
 
-        BootRecoveryFlow(hooks).run() shouldBe BootRecoveryFlow.Outcome.CONVERGED
+        val result = BootRecoveryFlow(hooks).run()
+        result.outcome shouldBe BootRecoveryFlow.Outcome.CONVERGED
+        result.restoreAttempted shouldBe true
+        result.rewrites shouldBe 1
         hooks.rewrites shouldHaveSize 1
         hooks.failures.shouldBeEmpty()
         hooks.pending shouldBe null
@@ -109,7 +148,7 @@ class BootRecoveryFlowTest {
                 observation = { ChargeObservation.Verified(ChargePolicy.Unrestricted, BackendKind.BATTERY_HARDWARE) },
             )
 
-            BootRecoveryFlow(hooks).run() shouldBe BootRecoveryFlow.Outcome.CONVERGED
+            BootRecoveryFlow(hooks).run().outcome shouldBe BootRecoveryFlow.Outcome.CONVERGED
             hooks.restoreCalls shouldBe 0
             hooks.staleSessionDrops shouldBe 1
             hooks.sessionTarget shouldBe null
@@ -129,7 +168,7 @@ class BootRecoveryFlowTest {
             observation = { ChargeObservation.Verified(ChargePolicy.Unrestricted, BackendKind.BATTERY_HARDWARE) },
         )
 
-        BootRecoveryFlow(hooks).run() shouldBe BootRecoveryFlow.Outcome.CONVERGED
+        BootRecoveryFlow(hooks).run().outcome shouldBe BootRecoveryFlow.Outcome.CONVERGED
         hooks.restoreCalls shouldBe 0
         hooks.staleSessionDrops shouldBe 1
         hooks.pending shouldBe null
@@ -146,7 +185,7 @@ class BootRecoveryFlowTest {
             intended = { if (intendedCalls++ == 0) ChargePolicy.Unrestricted else ChargePolicy.Adaptive },
         )
 
-        BootRecoveryFlow(hooks).run() shouldBe BootRecoveryFlow.Outcome.SUPERSEDED
+        BootRecoveryFlow(hooks).run().outcome shouldBe BootRecoveryFlow.Outcome.SUPERSEDED
         hooks.rewrites.shouldBeEmpty()
         hooks.pending shouldBe null
     }
@@ -159,7 +198,7 @@ class BootRecoveryFlowTest {
             observation = { hardwareLongLife },
         )
 
-        BootRecoveryFlow(hooks).run() shouldBe BootRecoveryFlow.Outcome.CONVERGED
+        BootRecoveryFlow(hooks).run().outcome shouldBe BootRecoveryFlow.Outcome.CONVERGED
         hooks.restoreCalls shouldBe 0
         hooks.staleSessionDrops shouldBe 0
         hooks.pending shouldBe null

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/FullChargeStoreTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/FullChargeStoreTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.amply.fullcharge.core
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.common.AppDataStore
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
@@ -58,5 +59,154 @@ class FullChargeStoreTest {
         store.setQuickFullChargeEnabled(true)
         store.setQuickFullChargeEnabled(false)
         store.isQuickFullChargeAnyLevel() shouldBe true
+    }
+
+    private val fixedLimit = ChargePolicy.FixedLimit(80)
+
+    @Test
+    fun `session provenance round-trips`() = runTest {
+        val provenance = WorkProvenance(token = "tok-a", pid = 42, bootCount = 7, createdAtMillis = 1_000L)
+        store.startSession(fixedLimit, startedAtMillis = 1_000L, provenance = provenance)
+
+        store.currentSession()?.provenance shouldBe provenance
+    }
+
+    @Test
+    fun `a legacy session record without provenance decodes to null`() = runTest {
+        store.startSession(fixedLimit, startedAtMillis = 1_000L, provenance = null)
+
+        store.currentSession()?.provenance shouldBe null
+    }
+
+    @Test
+    fun `clearing a session removes its provenance`() = runTest {
+        store.startSession(
+            fixedLimit,
+            startedAtMillis = 1_000L,
+            provenance = WorkProvenance("tok-a", 42, 7, 1_000L),
+        )
+        store.clearSession()
+
+        store.currentSession() shouldBe null
+    }
+
+    @Test
+    fun `recovery provenance round-trips including a null boot count`() = runTest {
+        val provenance = WorkProvenance(token = "tok-r", pid = 99, bootCount = null, createdAtMillis = 2_500L)
+        store.setPendingRecoveryTarget(ChargePolicy.Unrestricted, provenance = provenance)
+
+        store.pendingRecoveryProvenance() shouldBe provenance
+    }
+
+    @Test
+    fun `clearing the recovery target removes its provenance`() = runTest {
+        store.setPendingRecoveryTarget(
+            ChargePolicy.Unrestricted,
+            provenance = WorkProvenance("tok-r", 99, 3, 2_500L),
+        )
+        store.clearPendingRecoveryTarget()
+
+        store.pendingRecoveryTarget() shouldBe null
+        store.pendingRecoveryProvenance() shouldBe null
+    }
+
+    @Test
+    fun `adoptSessionOwner only stamps when a session is active`() = runTest {
+        // No session: adoption is a no-op and doesn't fabricate one.
+        store.adoptSessionOwner(WorkProvenance("tok-x", 1, 1, 1L))
+        store.currentSession() shouldBe null
+
+        store.startSession(fixedLimit, startedAtMillis = 1_000L, provenance = WorkProvenance("old", 1, 1, 1_000L))
+        val adopted = WorkProvenance(token = "new", pid = 2, bootCount = 1, createdAtMillis = 1_000L)
+        store.adoptSessionOwner(adopted)
+
+        store.currentSession()?.provenance shouldBe adopted
+    }
+
+    @Test
+    fun `adoptRecoveryOwner only stamps when a target is present`() = runTest {
+        store.adoptRecoveryOwner(WorkProvenance("tok-x", 1, 1, 1L))
+        store.pendingRecoveryProvenance() shouldBe null
+
+        store.setPendingRecoveryTarget(
+            ChargePolicy.Unrestricted,
+            provenance = WorkProvenance("old", 1, 1, 5L),
+        )
+        val adopted = WorkProvenance(token = "new", pid = 2, bootCount = 4, createdAtMillis = 9L)
+        store.adoptRecoveryOwner(adopted)
+
+        store.pendingRecoveryProvenance() shouldBe adopted
+    }
+
+    @Test
+    fun `markConnectedAndAdopt sets connected and owner in one edit`() = runTest {
+        store.startSession(fixedLimit, startedAtMillis = 1_000L, provenance = WorkProvenance("old", 1, 1, 1_000L))
+        val adopted = WorkProvenance(token = "new", pid = 2, bootCount = 1, createdAtMillis = 1_000L)
+
+        store.markConnectedAndAdopt(adopted)
+
+        val session = store.currentSession()
+        session?.connectedSeen shouldBe true
+        session?.provenance shouldBe adopted
+    }
+
+    @Test
+    fun `session work id is written at creation and cleared with the record`() = runTest {
+        store.startSession(fixedLimit, startedAtMillis = 1_000L, workId = "wid-1")
+        store.currentSession()?.workId shouldBe "wid-1"
+
+        store.clearSession()
+        store.currentSession() shouldBe null
+    }
+
+    @Test
+    fun `session work id survives owner adoption`() = runTest {
+        store.startSession(
+            fixedLimit,
+            startedAtMillis = 1_000L,
+            workId = "wid-1",
+            provenance = WorkProvenance("old", 1, 1, 1_000L),
+        )
+        store.adoptSessionOwner(WorkProvenance("new", 2, 1, 1_000L))
+
+        val session = store.currentSession()!!
+        session.workId shouldBe "wid-1"
+        session.provenance!!.token shouldBe "new"
+    }
+
+    @Test
+    fun `adoption stamps a fresh owner timestamp, not the session start`() = runTest {
+        store.startSession(
+            fixedLimit,
+            startedAtMillis = 1_000L,
+            provenance = WorkProvenance("old", 1, 1, 1_000L),
+        )
+        // Adopt with a creation time distinct from the session start; it must round-trip exactly.
+        val adopted = WorkProvenance(token = "new", pid = 2, bootCount = 1, createdAtMillis = 9_999L)
+        store.adoptSessionOwner(adopted)
+
+        store.currentSession()!!.provenance!!.createdAtMillis shouldBe 9_999L
+    }
+
+    @Test
+    fun `recovery work id is written at creation and cleared with the target`() = runTest {
+        store.setPendingRecoveryTarget(ChargePolicy.Unrestricted, workId = "wid-r")
+        store.pendingRecoveryWorkId() shouldBe "wid-r"
+
+        store.clearPendingRecoveryTarget()
+        store.pendingRecoveryWorkId() shouldBe null
+    }
+
+    @Test
+    fun `recovery work id survives owner adoption`() = runTest {
+        store.setPendingRecoveryTarget(
+            ChargePolicy.Unrestricted,
+            workId = "wid-r",
+            provenance = WorkProvenance("old", 1, 1, 5L),
+        )
+        store.adoptRecoveryOwner(WorkProvenance("new", 2, 1, 9L))
+
+        store.pendingRecoveryWorkId() shouldBe "wid-r"
+        store.pendingRecoveryProvenance()!!.token shouldBe "new"
     }
 }

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/InterruptionAssessorTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/InterruptionAssessorTest.kt
@@ -1,0 +1,328 @@
+package eu.darken.amply.fullcharge.core
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.common.AppDataStore
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+// Robolectric because ProcessIdentity reads android.os.Process.myPid(); the store deps run against
+// an in-memory DataStore and the exit/boot seams are plain fakes, so the sequencing stays testable.
+@RunWith(RobolectricTestRunner::class)
+class InterruptionAssessorTest {
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val identity = ProcessIdentity()
+    private val fixedLimit = ChargePolicy.FixedLimit(80)
+
+    private var bootCount: Int? = 5
+    private var exits: List<ExitRecord> = emptyList()
+
+    private lateinit var appDataStore: AppDataStore
+    private lateinit var fullChargeStore: FullChargeStore
+    private lateinit var interruptionStore: InterruptionStore
+    private lateinit var assessor: InterruptionAssessor
+
+    @Before
+    fun setup() {
+        appDataStore = AppDataStore(
+            PreferenceDataStoreFactory.create(scope = scope) { File(tmp.newFolder(), "t.preferences_pb") },
+        )
+        fullChargeStore = FullChargeStore(appDataStore)
+        interruptionStore = InterruptionStore(appDataStore)
+        assessor = InterruptionAssessor(
+            fullChargeStore = fullChargeStore,
+            interruptionStore = interruptionStore,
+            exitSource = ExitSource { exits },
+            identity = identity,
+            bootCountProvider = BootCountProvider { bootCount },
+        )
+    }
+
+    @After
+    fun teardown() {
+        scope.cancel()
+    }
+
+    private fun deadProvenance(pid: Int = 4321, createdAt: Long = 1_000L, boot: Int? = 5) =
+        WorkProvenance(token = "dead-process", pid = pid, bootCount = boot, createdAtMillis = createdAt)
+
+    @Test
+    fun `a legacy session record is adopted silently with no event`() = runTest {
+        fullChargeStore.startSession(fixedLimit, startedAtMillis = 1_000L, provenance = null)
+
+        assessor.captureSessionPickup(fullChargeStore.currentSession()!!) shouldBe null
+        fullChargeStore.currentSession()!!.provenance!!.token shouldBe identity.token
+        interruptionStore.event.first() shouldBe null
+    }
+
+    @Test
+    fun `a same-process session pickup is adopted with no assessment`() = runTest {
+        fullChargeStore.startSession(
+            fixedLimit,
+            startedAtMillis = 1_000L,
+            provenance = WorkProvenance(identity.token, identity.pid, 5, 1_000L),
+        )
+
+        assessor.captureSessionPickup(fullChargeStore.currentSession()!!) shouldBe null
+    }
+
+    @Test
+    fun `a session pickup across a reboot is adopted with no assessment`() = runTest {
+        bootCount = 6
+        fullChargeStore.startSession(fixedLimit, startedAtMillis = 1_000L, provenance = deadProvenance(boot = 5))
+
+        assessor.captureSessionPickup(fullChargeStore.currentSession()!!) shouldBe null
+        fullChargeStore.currentSession()!!.provenance!!.token shouldBe identity.token
+    }
+
+    @Test
+    fun `a session pickup across a same-boot death yields an assessment`() = runTest {
+        bootCount = 5
+        fullChargeStore.startSession(fixedLimit, startedAtMillis = 1_000L, provenance = deadProvenance(boot = 5))
+
+        assessor.captureSessionPickup(fullChargeStore.currentSession()!!).shouldNotBeNull()
+    }
+
+    @Test
+    fun `onSessionDecision CONTINUE adopts and records nothing`() = runTest {
+        bootCount = 5
+        fullChargeStore.startSession(fixedLimit, startedAtMillis = 1_000L, provenance = deadProvenance(boot = 5))
+        val assessment = assessor.captureSessionPickup(fullChargeStore.currentSession()!!)
+
+        assessor.onSessionDecision(assessment, SessionDecision.CONTINUE)
+
+        interruptionStore.event.first() shouldBe null
+        fullChargeStore.currentSession()!!.provenance!!.token shouldBe identity.token
+    }
+
+    @Test
+    fun `onSessionDecision MARK_CONNECTED flags connected and adopts`() = runTest {
+        bootCount = 5
+        fullChargeStore.startSession(fixedLimit, startedAtMillis = 1_000L, provenance = deadProvenance(boot = 5))
+        val assessment = assessor.captureSessionPickup(fullChargeStore.currentSession()!!)
+
+        assessor.onSessionDecision(assessment, SessionDecision.MARK_CONNECTED)
+
+        val session = fullChargeStore.currentSession()!!
+        session.connectedSeen shouldBe true
+        session.provenance!!.token shouldBe identity.token
+        interruptionStore.event.first() shouldBe null
+    }
+
+    @Test
+    fun `onSessionRestoreFinished success records a restored-late event with the classified reason`() = runTest {
+        bootCount = 5
+        exits = listOf(ExitRecord(timestampMillis = 2_000L, pid = 4321, reason = 10))
+        fullChargeStore.startSession(
+            fixedLimit,
+            startedAtMillis = 1_000L,
+            workId = "wid-1",
+            provenance = deadProvenance(boot = 5),
+        )
+        val assessment = assessor.captureSessionPickup(fullChargeStore.currentSession()!!)
+
+        assessor.onSessionRestoreFinished(assessment, success = true)
+
+        val event = interruptionStore.event.first()!!
+        event.outcome shouldBe InterruptionOutcome.RESTORED_LATE
+        // The stable work id — not the dead process's owner token — is the correlation handle.
+        event.workId shouldBe "wid-1"
+        event.reason shouldBe InterruptionReason.USER_STOPPED
+    }
+
+    @Test
+    fun `adoption does not break a later restore upgrading the event`() = runTest {
+        bootCount = 5
+        fullChargeStore.startSession(
+            fixedLimit,
+            startedAtMillis = 1_000L,
+            workId = "wid-1",
+            provenance = deadProvenance(boot = 5),
+        )
+        val assessment = assessor.captureSessionPickup(fullChargeStore.currentSession()!!)
+
+        // A failed restore records STILL_PENDING and adopts the session (owner token → this process),
+        // but the work id must survive so a later restore can still correlate.
+        assessor.onSessionRestoreFinished(assessment, success = false)
+        val session = fullChargeStore.currentSession()!!
+        session.provenance!!.token shouldBe identity.token
+        session.workId shouldBe "wid-1"
+
+        assessor.onRestoreSucceeded(session.workId)
+        interruptionStore.event.first()!!.outcome shouldBe InterruptionOutcome.RESTORED_LATE
+    }
+
+    @Test
+    fun `onSessionRestoreFinished failure records still-pending and OTHER without a matching exit`() = runTest {
+        bootCount = 5
+        fullChargeStore.startSession(fixedLimit, startedAtMillis = 1_000L, provenance = deadProvenance(boot = 5))
+        val assessment = assessor.captureSessionPickup(fullChargeStore.currentSession()!!)
+
+        assessor.onSessionRestoreFinished(assessment, success = false)
+
+        val event = interruptionStore.event.first()!!
+        event.outcome shouldBe InterruptionOutcome.STILL_PENDING
+        event.reason shouldBe InterruptionReason.OTHER
+    }
+
+    @Test
+    fun `an assessment is consumed once`() = runTest {
+        bootCount = 5
+        fullChargeStore.startSession(fixedLimit, startedAtMillis = 1_000L, provenance = deadProvenance(boot = 5))
+        val assessment = assessor.captureSessionPickup(fullChargeStore.currentSession()!!)
+
+        // First handler consumes it; the second must be ignored (no event recorded).
+        assessor.onSessionDecision(assessment, SessionDecision.CONTINUE)
+        assessor.onSessionRestoreFinished(assessment, success = true)
+
+        interruptionStore.event.first() shouldBe null
+    }
+
+    @Test
+    fun `a recovery pickup across a same-boot death maps the flow result to an outcome`() = runTest {
+        bootCount = 5
+        fullChargeStore.setPendingRecoveryTarget(
+            ChargePolicy.Unrestricted,
+            workId = "wid-r",
+            provenance = deadProvenance(boot = 5),
+        )
+        val pickup = assessor.captureRecoveryPickup()
+        pickup.assessment.shouldNotBeNull()
+
+        assessor.onRecoveryFinished(
+            pickup,
+            BootRecoveryFlow.Result(
+                outcome = BootRecoveryFlow.Outcome.GAVE_UP,
+                restoreAttempted = false,
+                rewrites = 0,
+                retryRemaining = false,
+            ),
+        )
+
+        interruptionStore.event.first()!!.outcome shouldBe InterruptionOutcome.UNCONFIRMED
+    }
+
+    @Test
+    fun `a recovery pickup without provenance is adopted with no assessment`() = runTest {
+        bootCount = 5
+        fullChargeStore.setPendingRecoveryTarget(ChargePolicy.Unrestricted, provenance = null)
+
+        assessor.captureRecoveryPickup().assessment shouldBe null
+        fullChargeStore.pendingRecoveryProvenance()!!.token shouldBe identity.token
+    }
+
+    @Test
+    fun `onRecoveryFinished records nothing when the flow did no work`() = runTest {
+        bootCount = 5
+        fullChargeStore.setPendingRecoveryTarget(
+            ChargePolicy.Unrestricted,
+            workId = "wid-r",
+            provenance = deadProvenance(boot = 5),
+        )
+        val pickup = assessor.captureRecoveryPickup()
+
+        assessor.onRecoveryFinished(
+            pickup,
+            BootRecoveryFlow.Result(
+                outcome = BootRecoveryFlow.Outcome.CONVERGED,
+                restoreAttempted = false,
+                rewrites = 0,
+                retryRemaining = false,
+            ),
+        )
+
+        interruptionStore.event.first() shouldBe null
+    }
+
+    @Test
+    fun `a converged recovery resolves a prior event even without an assessment`() = runTest {
+        bootCount = 5
+        // A prior still-pending event for this work.
+        interruptionStore.record(
+            InterruptionEvent(1_000L, InterruptionReason.OTHER, InterruptionOutcome.STILL_PENDING, "wid-r"),
+        )
+        // A same-process recovery pickup (no death) → no assessment, but it carries the work id.
+        fullChargeStore.setPendingRecoveryTarget(
+            ChargePolicy.Unrestricted,
+            workId = "wid-r",
+            provenance = WorkProvenance(identity.token, identity.pid, 5, 5L),
+        )
+        val pickup = assessor.captureRecoveryPickup()
+        pickup.assessment shouldBe null
+
+        assessor.onRecoveryFinished(
+            pickup,
+            BootRecoveryFlow.Result(
+                outcome = BootRecoveryFlow.Outcome.CONVERGED,
+                restoreAttempted = true,
+                rewrites = 0,
+                retryRemaining = false,
+            ),
+        )
+
+        interruptionStore.event.first()!!.outcome shouldBe InterruptionOutcome.RESTORED_LATE
+    }
+
+    @Test
+    fun `a throwing interruption store never propagates`() = runTest {
+        val throwing = object : InterruptionStore(appDataStore) {
+            override suspend fun record(event: InterruptionEvent) {
+                throw RuntimeException("boom")
+            }
+        }
+        val assessorWithThrowingStore = InterruptionAssessor(
+            fullChargeStore = fullChargeStore,
+            interruptionStore = throwing,
+            exitSource = ExitSource { exits },
+            identity = identity,
+            bootCountProvider = BootCountProvider { bootCount },
+        )
+        bootCount = 5
+        fullChargeStore.startSession(fixedLimit, startedAtMillis = 1_000L, provenance = deadProvenance(boot = 5))
+        val assessment = assessorWithThrowingStore.captureSessionPickup(fullChargeStore.currentSession()!!)
+
+        // Must not throw despite record() failing.
+        assessorWithThrowingStore.onSessionRestoreFinished(assessment, success = true)
+    }
+
+    @Test
+    fun `onRestoreSucceeded ignores a null token and upgrades a matching event`() = runTest {
+        interruptionStore.record(
+            InterruptionEvent(1_000L, InterruptionReason.OTHER, InterruptionOutcome.STILL_PENDING, "tok"),
+        )
+
+        assessor.onRestoreSucceeded(null)
+        interruptionStore.event.first()!!.outcome shouldBe InterruptionOutcome.STILL_PENDING
+
+        assessor.onRestoreSucceeded("tok")
+        interruptionStore.event.first()!!.outcome shouldBe InterruptionOutcome.RESTORED_LATE
+    }
+
+    @Test
+    fun `onExplicitPolicyWrite clears a pending event`() = runTest {
+        interruptionStore.record(
+            InterruptionEvent(1_000L, InterruptionReason.OTHER, InterruptionOutcome.STILL_PENDING, "tok"),
+        )
+
+        assessor.onExplicitPolicyWrite()
+
+        interruptionStore.event.first() shouldBe null
+    }
+}

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/InterruptionDecisionEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/InterruptionDecisionEngineTest.kt
@@ -1,0 +1,173 @@
+package eu.darken.amply.fullcharge.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class InterruptionDecisionEngineTest {
+
+    // --- survivedDeath -------------------------------------------------------
+
+    @Test
+    fun `survivedDeath is false when the stored token is null`() {
+        InterruptionDecisionEngine.survivedDeath(storedToken = null, currentToken = "a") shouldBe false
+    }
+
+    @Test
+    fun `survivedDeath is false when tokens match`() {
+        InterruptionDecisionEngine.survivedDeath(storedToken = "a", currentToken = "a") shouldBe false
+    }
+
+    @Test
+    fun `survivedDeath is true when a stored token differs`() {
+        InterruptionDecisionEngine.survivedDeath(storedToken = "old", currentToken = "new") shouldBe true
+    }
+
+    // --- sameBoot ------------------------------------------------------------
+
+    @Test
+    fun `sameBoot needs both counts present and equal`() {
+        InterruptionDecisionEngine.sameBoot(null, 5) shouldBe false
+        InterruptionDecisionEngine.sameBoot(5, null) shouldBe false
+        InterruptionDecisionEngine.sameBoot(null, null) shouldBe false
+        InterruptionDecisionEngine.sameBoot(5, 6) shouldBe false
+        InterruptionDecisionEngine.sameBoot(5, 5) shouldBe true
+    }
+
+    // --- shouldRecordForSession ---------------------------------------------
+
+    @Test
+    fun `session record requires a survived same-boot restore decision`() {
+        // Gates fail → never record, whatever the decision.
+        InterruptionDecisionEngine.shouldRecordForSession(false, true, SessionDecision.RESTORE_FULL) shouldBe false
+        InterruptionDecisionEngine.shouldRecordForSession(true, false, SessionDecision.RESTORE_FULL) shouldBe false
+
+        // Gates pass: only the RESTORE_* decisions record.
+        val restores = listOf(
+            SessionDecision.RESTORE_FULL,
+            SessionDecision.RESTORE_DISCONNECTED,
+            SessionDecision.RESTORE_ARM_TIMEOUT,
+            SessionDecision.RESTORE_SAFETY_TIMEOUT,
+        )
+        restores.forEach {
+            InterruptionDecisionEngine.shouldRecordForSession(true, true, it) shouldBe true
+        }
+        InterruptionDecisionEngine.shouldRecordForSession(true, true, SessionDecision.CONTINUE) shouldBe false
+        InterruptionDecisionEngine.shouldRecordForSession(true, true, SessionDecision.MARK_CONNECTED) shouldBe false
+    }
+
+    // --- recoveryOutcome -----------------------------------------------------
+
+    private fun result(
+        outcome: BootRecoveryFlow.Outcome,
+        restoreAttempted: Boolean = false,
+        rewrites: Int = 0,
+        retryRemaining: Boolean = false,
+    ) = BootRecoveryFlow.Result(outcome, restoreAttempted, rewrites, retryRemaining)
+
+    @Test
+    fun `recoveryOutcome is null when gates fail`() {
+        val r = result(BootRecoveryFlow.Outcome.CONVERGED, restoreAttempted = true)
+        InterruptionDecisionEngine.recoveryOutcome(false, true, r) shouldBe null
+        InterruptionDecisionEngine.recoveryOutcome(true, false, r) shouldBe null
+    }
+
+    @Test
+    fun `converged with restore or rewrites is restored-late, without work is null`() {
+        InterruptionDecisionEngine.recoveryOutcome(
+            true, true, result(BootRecoveryFlow.Outcome.CONVERGED, restoreAttempted = true),
+        ) shouldBe InterruptionOutcome.RESTORED_LATE
+        InterruptionDecisionEngine.recoveryOutcome(
+            true, true, result(BootRecoveryFlow.Outcome.CONVERGED, rewrites = 2),
+        ) shouldBe InterruptionOutcome.RESTORED_LATE
+        InterruptionDecisionEngine.recoveryOutcome(
+            true, true, result(BootRecoveryFlow.Outcome.CONVERGED),
+        ) shouldBe null
+    }
+
+    @Test
+    fun `restore failed maps to still-pending`() {
+        InterruptionDecisionEngine.recoveryOutcome(
+            true, true, result(BootRecoveryFlow.Outcome.RESTORE_FAILED, restoreAttempted = true),
+        ) shouldBe InterruptionOutcome.STILL_PENDING
+    }
+
+    @Test
+    fun `gave up splits on retry-remaining`() {
+        InterruptionDecisionEngine.recoveryOutcome(
+            true, true, result(BootRecoveryFlow.Outcome.GAVE_UP, rewrites = 1, retryRemaining = true),
+        ) shouldBe InterruptionOutcome.STILL_PENDING
+        InterruptionDecisionEngine.recoveryOutcome(
+            true, true, result(BootRecoveryFlow.Outcome.GAVE_UP, retryRemaining = false),
+        ) shouldBe InterruptionOutcome.UNCONFIRMED
+    }
+
+    @Test
+    fun `nothing-to-do and superseded map to null`() {
+        InterruptionDecisionEngine.recoveryOutcome(
+            true, true, result(BootRecoveryFlow.Outcome.NOTHING_TO_DO),
+        ) shouldBe null
+        InterruptionDecisionEngine.recoveryOutcome(
+            true, true, result(BootRecoveryFlow.Outcome.SUPERSEDED),
+        ) shouldBe null
+    }
+
+    // --- classifyExit --------------------------------------------------------
+
+    @Test
+    fun `classifyExit is OTHER with a null owner pid`() {
+        val exits = listOf(ExitRecord(timestampMillis = 100, pid = 5, reason = 10))
+        InterruptionDecisionEngine.classifyExit(exits, ownerPid = null, notBeforeMillis = 0) shouldBe
+            InterruptionReason.OTHER
+    }
+
+    @Test
+    fun `classifyExit is OTHER on an empty list`() {
+        InterruptionDecisionEngine.classifyExit(emptyList(), ownerPid = 5, notBeforeMillis = 0) shouldBe
+            InterruptionReason.OTHER
+    }
+
+    @Test
+    fun `classifyExit filters by owner pid`() {
+        val exits = listOf(ExitRecord(timestampMillis = 100, pid = 6, reason = 10))
+        InterruptionDecisionEngine.classifyExit(exits, ownerPid = 5, notBeforeMillis = 0) shouldBe
+            InterruptionReason.OTHER
+    }
+
+    @Test
+    fun `classifyExit ignores records before the window`() {
+        val exits = listOf(ExitRecord(timestampMillis = 50, pid = 5, reason = 10))
+        InterruptionDecisionEngine.classifyExit(exits, ownerPid = 5, notBeforeMillis = 100) shouldBe
+            InterruptionReason.OTHER
+    }
+
+    @Test
+    fun `classifyExit picks the latest candidate`() {
+        val exits = listOf(
+            ExitRecord(timestampMillis = 100, pid = 5, reason = 10),
+            ExitRecord(timestampMillis = 200, pid = 5, reason = 6),
+        )
+        // Latest (200) is a non-user reason, so OTHER despite an earlier user-stop record.
+        InterruptionDecisionEngine.classifyExit(exits, ownerPid = 5, notBeforeMillis = 0) shouldBe
+            InterruptionReason.OTHER
+    }
+
+    @Test
+    fun `classifyExit reads codes 10 and 11 as user-stopped`() {
+        listOf(10, 11).forEach { reason ->
+            val exits = listOf(ExitRecord(timestampMillis = 100, pid = 5, reason = reason))
+            InterruptionDecisionEngine.classifyExit(exits, ownerPid = 5, notBeforeMillis = 0) shouldBe
+                InterruptionReason.USER_STOPPED
+        }
+    }
+
+    @Test
+    fun `classifyExit reads every other known code and an unknown one as OTHER`() {
+        // ApplicationExitInfo reason codes 0..16 minus the two user-stop codes, plus a future code.
+        val otherCodes = (0..16).filter { it != 10 && it != 11 } + 99
+        otherCodes.forEach { reason ->
+            val exits = listOf(ExitRecord(timestampMillis = 100, pid = 5, reason = reason))
+            InterruptionDecisionEngine.classifyExit(exits, ownerPid = 5, notBeforeMillis = 0) shouldBe
+                InterruptionReason.OTHER
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/InterruptionStoreTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/InterruptionStoreTest.kt
@@ -1,0 +1,110 @@
+package eu.darken.amply.fullcharge.core
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import eu.darken.amply.common.AppDataStore
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class InterruptionStoreTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private val storeScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val appDataStore by lazy {
+        AppDataStore(
+            PreferenceDataStoreFactory.create(scope = storeScope) {
+                File(tempDir, "test.preferences_pb")
+            },
+        )
+    }
+    private val store by lazy { InterruptionStore(appDataStore) }
+
+    @AfterEach
+    fun teardown() {
+        storeScope.cancel()
+    }
+
+    private fun event(
+        outcome: InterruptionOutcome = InterruptionOutcome.STILL_PENDING,
+        reason: InterruptionReason = InterruptionReason.OTHER,
+        workId: String = "tok-1",
+        occurredAt: Long = 1_000L,
+    ) = InterruptionEvent(occurredAt, reason, outcome, workId)
+
+    @Test
+    fun `no event by default`() = runTest {
+        store.event.first() shouldBe null
+    }
+
+    @Test
+    fun `record round-trips`() = runTest {
+        val e = event(outcome = InterruptionOutcome.RESTORED_LATE, reason = InterruptionReason.USER_STOPPED)
+        store.record(e)
+        store.event.first() shouldBe e
+    }
+
+    @Test
+    fun `a newer event overwrites the old`() = runTest {
+        store.record(event(workId = "old"))
+        val newer = event(outcome = InterruptionOutcome.UNCONFIRMED, workId = "new", occurredAt = 2_000L)
+        store.record(newer)
+        store.event.first() shouldBe newer
+    }
+
+    @Test
+    fun `markRestored upgrades a matching still-pending event`() = runTest {
+        store.record(event(outcome = InterruptionOutcome.STILL_PENDING, workId = "tok-1"))
+        store.markRestored("tok-1")
+        store.event.first()?.outcome shouldBe InterruptionOutcome.RESTORED_LATE
+    }
+
+    @Test
+    fun `markRestored ignores a non-matching token`() = runTest {
+        store.record(event(outcome = InterruptionOutcome.STILL_PENDING, workId = "tok-1"))
+        store.markRestored("other")
+        store.event.first()?.outcome shouldBe InterruptionOutcome.STILL_PENDING
+    }
+
+    @Test
+    fun `markRestored on an absent event is a no-op`() = runTest {
+        store.markRestored("tok-1")
+        store.event.first() shouldBe null
+    }
+
+    @Test
+    fun `clearPending removes a pending event but keeps a restored-late one`() = runTest {
+        store.record(event(outcome = InterruptionOutcome.STILL_PENDING))
+        store.clearPending()
+        store.event.first() shouldBe null
+
+        val restored = event(outcome = InterruptionOutcome.RESTORED_LATE)
+        store.record(restored)
+        store.clearPending()
+        store.event.first() shouldBe restored
+    }
+
+    @Test
+    fun `clear removes any event`() = runTest {
+        store.record(event(outcome = InterruptionOutcome.RESTORED_LATE))
+        store.clear()
+        store.event.first() shouldBe null
+    }
+
+    @Test
+    fun `a malformed stored enum decodes to no event`() = runTest {
+        store.record(event())
+        appDataStore.store.edit { it[stringPreferencesKey("interruption.v1.outcome")] = "GARBAGE" }
+        store.event.first() shouldBe null
+    }
+}

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardInterruptionCardTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardInterruptionCardTest.kt
@@ -1,0 +1,136 @@
+package eu.darken.amply.main.ui.dashboard
+
+import android.app.Application
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.R
+import eu.darken.amply.charging.core.BackendKind
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.ChargingState
+import eu.darken.amply.common.ca.toCaString
+import eu.darken.amply.fullcharge.core.InterruptionEvent
+import eu.darken.amply.fullcharge.core.InterruptionOutcome
+import eu.darken.amply.fullcharge.core.InterruptionReason
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class DashboardInterruptionCardTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    private fun string(res: Int): String = context.getString(res)
+
+    private val event = InterruptionEvent(
+        occurredAtMillis = 0L,
+        reason = InterruptionReason.USER_STOPPED,
+        outcome = InterruptionOutcome.RESTORED_LATE,
+        workId = "tok",
+    )
+
+    private fun supportedState(interruption: InterruptionEvent?) = DashboardUiState(
+        onboardingComplete = true,
+        interruption = interruption,
+        charging = ChargingState(
+            controlEnabled = true,
+            observation = ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.SHIZUKU),
+        ),
+    )
+
+    private fun render(state: DashboardUiState, onDismissInterruption: () -> Unit = {}) {
+        compose.setContent {
+            DashboardScreen(
+                state = state,
+                adbCommand = "",
+                onRefresh = {},
+                onSettings = {},
+                onStartFull = {},
+                onRestore = {},
+                onApply = {},
+                onQuickFullChargeChange = {},
+                onOpenReconnectSettings = {},
+                onAlarmEnabledChange = {},
+                onAlarmTargetChange = {},
+                onFixNotifications = {},
+                onOpenBatteryDetail = {},
+                onOpenStats = {},
+                onOpenLiveSession = {},
+                onRetryCapture = {},
+                onPinWidget = {},
+                onAddTile = {},
+                onDismissQuickAccess = {},
+                onDismissInterruption = onDismissInterruption,
+                onNativeSettings = {},
+                onOpenShizuku = {},
+                onAllowShizuku = {},
+                onGrantWss = {},
+                onCopyAdb = {},
+                onCopyWebUsbLink = {},
+                onOpenContribution = {},
+                onPrepareSupportReport = {},
+                onCopySupportReport = {},
+                onOpenSupportIssue = {},
+                onEmailSupport = {},
+                onHelp = {},
+            )
+        }
+    }
+
+    @Test
+    fun `card shows on a supported device with an event`() {
+        render(supportedState(event))
+        compose.onNodeWithText(string(R.string.dashboard_interruption_title_restored)).assertExists()
+    }
+
+    @Test
+    fun `card is absent without an event`() {
+        render(supportedState(interruption = null))
+        compose.onNodeWithText(string(R.string.dashboard_interruption_title_restored)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `card is absent on an unsupported device`() {
+        render(
+            DashboardUiState(
+                onboardingComplete = true,
+                interruption = event,
+                charging = ChargingState(
+                    observation = ChargeObservation.Unsupported("Not supported".toCaString()),
+                ),
+            ),
+        )
+        compose.onNodeWithText(string(R.string.dashboard_interruption_title_restored)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `card is absent while support is unresolved`() {
+        // Default ChargingState: control not enabled yet (still detecting) — the card must stay hidden.
+        render(DashboardUiState(onboardingComplete = true, interruption = event))
+        compose.onNodeWithText(string(R.string.dashboard_interruption_title_restored)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `dismiss invokes the callback`() {
+        var dismissed = false
+        render(supportedState(event), onDismissInterruption = { dismissed = true })
+
+        compose.onNode(hasScrollAction())
+            .performScrollToNode(hasText(string(R.string.dashboard_interruption_dismiss_action)))
+        compose.onNodeWithText(string(R.string.dashboard_interruption_dismiss_action)).performClick()
+
+        compose.runOnIdle { dismissed shouldBe true }
+    }
+}

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenGestureTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenGestureTest.kt
@@ -75,6 +75,7 @@ class DashboardScreenGestureTest {
                 onPinWidget = {},
                 onAddTile = {},
                 onDismissQuickAccess = {},
+                onDismissInterruption = {},
                 onNativeSettings = {},
                 onOpenShizuku = {},
                 onAllowShizuku = {},


### PR DESCRIPTION
**What changed**

- If Amply is stopped while it is watching a one-time full charge — force-stopped, killed by the system, or crashed — the dashboard now explains what happened the next time you open the app, instead of leaving you to wonder whether your charge limit came back.
- The card states the outcome plainly: the limit was restored after the interruption, it could not be restored yet and Amply keeps retrying, or it was written again but the charging hardware has not confirmed it. A single Dismiss button clears it.
- The card only appears when the interruption actually cost you a restore. A stop that changed nothing, a reboot (Amply already recovers on boot), or a session that resumed unharmed stay silent.
- The wording never claims you force-stopped the app — Android reports several different situations the same way, so it only says Amply was stopped or interrupted.
- The "Charge limit needs attention" notification now disappears once a later restore succeeds, instead of lingering until swiped.

**Technical Context**

- **Detection is evidence-based, not guessed.** Persisted session and pending-recovery records now carry a provenance stamp — a random per-process token, the PID, the boot counter, and a timestamp — plus a stable work id. A stored token that differs from the live one proves the work crossed a process death; PIDs are deliberately *not* used for that (they are reused), only to match the corresponding `ApplicationExitInfo` record.
- **Reboots are excluded positively**, by requiring the stored boot counter to equal the current one, rather than by wall-clock/elapsed-time arithmetic (which is unreliable across clock corrections and near a reboot boundary). Unknown on either side means no event.
- **The effect gate** is what keeps the card from crying wolf: an event is only recorded when a restore was actually due at pickup (a `RESTORE_*` decision), or when the recovery flow really did work. `BootRecoveryFlow.run()` therefore returns a richer result (restore attempted, rewrite count, retry-work remaining) so "already configured, nothing written" does not masquerade as a late restore, and the two flavours of give-up map to different honest outcomes.
- **The work id is separate from the ownership token on purpose.** Surviving work is re-adopted to the current process so a same-process retry cannot double-record, but adoption rewrites the owner token — so a mutable token cannot correlate an event to a later restore. The work id is written once at creation, never touched by adoption, and is what upgrades or clears a warning (on a successful session restore, a recovery convergence, or an explicit policy write by the user).
- **Bookkeeping is best-effort and cannot hurt the safety path.** All of it runs through a coordinator that swallows and logs non-cancellation failures, and the service's recovery cleanup moved into `finally`, so a DataStore or exit-query hiccup can never strand the foreground service or a pending restore.
- **Testing.** The decision logic, the store, and the coordinator are pure/JVM-tested (about 79 new tests, 505 total across both flavours), plus a Robolectric test for card visibility and dismissal. An emulator run confirmed the no-false-positive path: a plain force-stop with no session never produces the card.
- **Still outstanding:** an end-to-end pass on a supported device (start a session, force-stop mid-charge, reopen) — emulators cannot run real sessions, so that stays a physical-device qualification step.
