### PR TITLE
Dashboard: Show current charge stats near the top while plugged in

### DIFF
--- a/app/src/main/java/eu/darken/amply/battery/core/BatteryReadout.kt
+++ b/app/src/main/java/eu/darken/amply/battery/core/BatteryReadout.kt
@@ -24,6 +24,14 @@ data class BatteryReadout(
     val chargeCounterMicroampHours: Int? = null,
     val cycleCount: Int? = null,
 ) {
+    /**
+     * External power is reported. A null (not reported) [plugged] collapses conservatively to false —
+     * nothing may claim a charger it can't observe. This is the single "on the charger" rule; it is
+     * deliberately independent of [status], because a device held at a charge limit reports
+     * `BATTERY_STATUS_NOT_CHARGING` while still connected.
+     */
+    val onCharger: Boolean get() = (plugged ?: 0) != 0
+
     companion object {
         val UNKNOWN = BatteryReadout()
     }

--- a/app/src/main/java/eu/darken/amply/common/compose/AmplyCard.kt
+++ b/app/src/main/java/eu/darken/amply/common/compose/AmplyCard.kt
@@ -310,8 +310,13 @@ fun AmplyCardHeader(
 
 /**
  * Navigation card: the whole card opens a destination ([onClick]) with an [onClickLabel] for
- * accessibility, a standard header, and a decorative RTL-aware trailing chevron. Must contain no
- * independent interactive controls — the surface owns the single tap.
+ * accessibility, a standard header, and a decorative RTL-aware trailing chevron.
+ *
+ * The surface owns the primary tap. Content may add at most a small trailing text action for a
+ * *secondary* destination or side effect (never a duplicate of [onClick]); anything richer — switches,
+ * multiple buttons, a whole control row — belongs in [AmplyToggleCard] or a plain [AmplyCard]. A
+ * nested action must not bubble to the surface: assert both routes separately in tests, as
+ * `StatsDashboardCard`'s "History" and "Retry" actions do.
  */
 @Composable
 fun AmplyNavigationCard(

--- a/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
@@ -106,9 +106,6 @@ class MainActivity : ComponentActivity() {
                     var destination by rememberSaveable { mutableStateOf(SettingsDestination.DASHBOARD) }
                     // Where a back-out of the contribution wizard returns to (set on each entry).
                     var wizardOrigin by rememberSaveable { mutableStateOf(SettingsDestination.DASHBOARD) }
-                    // Battery statistics is reachable from both the dashboard card and the settings hub;
-                    // remember which so back returns there.
-                    var statsOrigin by rememberSaveable { mutableStateOf(SettingsDestination.SETTINGS) }
                     // Where the session-detail screen returns to: the stats list when opened from it, or
                     // the dashboard when deep-linked from the live "on the charger" card.
                     var detailOrigin by rememberSaveable { mutableStateOf(SettingsDestination.STATS) }
@@ -207,17 +204,18 @@ class MainActivity : ComponentActivity() {
                         when (destination) {
                             // The wizard clears its raw session and returns to whichever surface opened it.
                             SettingsDestination.DIAGNOSTICS -> leaveWizard()
-                            // These are entered from the dashboard, not the settings hub.
+                            // These are entered from the dashboard, not the settings hub — the stats list
+                            // included, since the dashboard card is its only entry point.
                             SettingsDestination.SETTINGS,
                             SettingsDestination.RECONNECT_GESTURE,
-                            SettingsDestination.BATTERY_DETAIL -> destination = SettingsDestination.DASHBOARD
-                            // The session detail returns to the stats list; the list returns to wherever
-                            // it was opened from (dashboard card or settings hub).
+                            SettingsDestination.BATTERY_DETAIL,
+                            SettingsDestination.STATS -> destination = SettingsDestination.DASHBOARD
+                            // The session detail returns to the stats list, or to the dashboard when it was
+                            // deep-linked from the live card.
                             SettingsDestination.STATS_SESSION_DETAIL -> {
                                 statsViewModel.closeSession()
                                 destination = detailOrigin
                             }
-                            SettingsDestination.STATS -> destination = statsOrigin
                             else -> destination = SettingsDestination.SETTINGS
                         }
                     }
@@ -256,10 +254,7 @@ class MainActivity : ComponentActivity() {
                             onAlarmTargetChange = viewModel::setChargeAlarmTarget,
                             onFixNotifications = viewModel::openNotificationSettings,
                             onOpenBatteryDetail = { destination = SettingsDestination.BATTERY_DETAIL },
-                            onOpenStats = {
-                                statsOrigin = SettingsDestination.DASHBOARD
-                                destination = SettingsDestination.STATS
-                            },
+                            onOpenStats = { destination = SettingsDestination.STATS },
                             onOpenLiveSession = { id ->
                                 // Deep-link straight to the in-progress session's detail; back returns
                                 // to the dashboard the card lives on.
@@ -289,10 +284,6 @@ class MainActivity : ComponentActivity() {
                         SettingsDestination.SETTINGS -> SettingsScreen(
                             onBack = { destination = SettingsDestination.DASHBOARD },
                             onGeneral = { destination = SettingsDestination.GENERAL },
-                            onStats = {
-                                statsOrigin = SettingsDestination.SETTINGS
-                                destination = SettingsDestination.STATS
-                            },
                             // Offered whenever this device is one we want contribution data for (unsupported/lab),
                             // regardless of whether Shizuku is installed yet — the wizard nudges the install.
                             showDiagnostics = state.charging.contributionWanted,
@@ -367,7 +358,9 @@ class MainActivity : ComponentActivity() {
                             val statsState by statsViewModel.state.collectAsState()
                             StatsScreen(
                                 state = statsState,
-                                onBack = { destination = statsOrigin },
+                                // Only the dashboard's stats card opens this screen, so back always
+                                // returns there.
+                                onBack = { destination = SettingsDestination.DASHBOARD },
                                 onCaptureEnabledChange = { enabled ->
                                     if (enabled) {
                                         runWithNotifications(NotificationAction.ENABLE_STATS)

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
@@ -155,24 +156,52 @@ fun DashboardScreen(
             // Derived once and shared by the status + full-charge cards so they can never disagree
             // about whether the one-time charge is actually in effect.
             val sessionPresentation = SessionPresentation.from(state.session, state.charging.observation)
-            // The single stats card sits in one fixed slot (shared tail below); only its content
-            // adapts. "On the charger" is decided by the raw battery readout, never the recorder's
-            // DB row — see StatsCardPresentation for the truth rules.
+            // There is one stats card; only its content adapts. "On the charger" is decided by the raw
+            // battery readout, never the recorder's DB row — see StatsCardPresentation for the truth
+            // rules.
             val statsPresentation = StatsCardPresentation.from(state.stats, state.batteryReadout)
+            // Its slot is a separate, purely plug-driven decision: on the charger it is promoted to the
+            // second card (below the interruption warning and the setup guide, which are rarer and
+            // actionable), otherwise it stays in the shared tail. Deliberately independent of the
+            // content state — a promo/loading/unavailable card is promoted too, so the slot never
+            // changes underneath the user as the stats DB answers.
+            val statsPromoted = state.batteryReadout?.onCharger == true
             val unsupported = state.charging.observation is ChargeObservation.Unsupported
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(start = sidePadding, end = sidePadding, top = 8.dp, bottom = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                item { StatusCard(state, sessionPresentation, onOpenBatteryDetail) }
+                // Every card carries a stable key. Without one a LazyColumn identifies items by index, so
+                // the stats card changing slot would renumber everything after it and throw away their
+                // remembered state — e.g. the alarm card's in-flight slider drag would snap back if the
+                // charger were plugged in mid-gesture. Keys are unique per render: the pairs that appear
+                // in both the supported and unsupported branches are mutually exclusive.
+                //
+                // One construction site for the stats card — only its slot varies (see statsPromoted),
+                // so the supported/unsupported branches below can't drift apart.
+                val statsItem: LazyListScope.() -> Unit = {
+                    item(key = "dashboard.stats") {
+                        StatsDashboardCard(
+                            presentation = statsPresentation,
+                            onOpenStats = onOpenStats,
+                            onOpenLiveSession = onOpenLiveSession,
+                            onRetryCapture = onRetryCapture,
+                        )
+                    }
+                }
+
+                item(key = "dashboard.hero") { StatusCard(state, sessionPresentation, onOpenBatteryDetail) }
 
                 if (unsupported) {
+                    // Promoted slot: no interruption card or setup guide exists on this branch, so on
+                    // the charger the stats card follows the hero directly.
+                    if (statsPromoted) statsItem()
                     // Unsupported devices cannot use the Pixel policy/charge controls; showing them
                     // greyed-out (and a "Pixel settings" action) only confuses non-Pixel users. Offer
                     // a contribution path instead, and keep only the restore card if a session lingers.
                     if (state.session != null) {
-                        item {
+                        item(key = "dashboard.fullcharge") {
                             FullChargeCard(
                                 presentation = sessionPresentation,
                                 canControl = state.charging.controlEnabled &&
@@ -186,7 +215,7 @@ fun DashboardScreen(
                     // after it was enabled), keep the card so the user can turn it — and its foreground
                     // service — off. The card renders as disable-only when control isn't available.
                     if (state.quickFullChargeEnabled) {
-                        item {
+                        item(key = "dashboard.reconnect") {
                             QuickFullChargeCard(
                                 enabled = true,
                                 anyLevel = state.quickFullChargeAnyLevel,
@@ -198,7 +227,7 @@ fun DashboardScreen(
                         }
                     }
                     // Point unsupported devices at their OEM's own charge-protection setting.
-                    item {
+                    item(key = "dashboard.oemguide") {
                         OemGuideCard(
                             manufacturer = state.charging.device.manufacturer
                                 .ifBlank { stringResource(R.string.dashboard_manufacturer_fallback) },
@@ -212,13 +241,13 @@ fun DashboardScreen(
                     // otherwise — a warning about a restore Amply cannot even perform would confuse.
                     val interruption = state.interruption
                     if (interruption != null && state.charging.controlEnabled) {
-                        item { InterruptionCard(interruption, onDismissInterruption) }
+                        item(key = "dashboard.interruption") { InterruptionCard(interruption, onDismissInterruption) }
                     }
                     // Shizuku-only adapters (OnePlus/ColorOS) can't use WSS at all, so the WSS/ADB
                     // setup guide would ask for an ineffective grant — the dedicated
                     // "Shizuku required" banner below covers their setup instead.
                     if (!state.charging.writeRequiresShizuku && state.charging.access?.direct?.ready != true) {
-                        item {
+                        item(key = "dashboard.setupguide") {
                             AccessSetupGuide(
                                 state = state,
                                 adbCommand = adbCommand,
@@ -231,7 +260,11 @@ fun DashboardScreen(
                         }
                     }
 
-                    item {
+                    // Promoted slot: below the interruption warning and the setup guide above, so a
+                    // restore that is still owed and an unfinished setup keep the top of the list.
+                    if (statsPromoted) statsItem()
+
+                    item(key = "dashboard.fullcharge") {
                         FullChargeCard(
                             presentation = sessionPresentation,
                             canControl = state.charging.canApply,
@@ -239,11 +272,11 @@ fun DashboardScreen(
                             onRestore = onRestore,
                         )
                     }
-                    item { PolicyCard(state, onApply, onNativeSettings) }
+                    item(key = "dashboard.policy") { PolicyCard(state, onApply, onNativeSettings) }
                     // Hidden where the adapter lacks the gesture's hardware signal (non-Pixel) —
                     // unless it is still switched on and needs a way to be turned off.
                     if (state.charging.reconnectSupported || state.quickFullChargeEnabled) {
-                        item {
+                        item(key = "dashboard.reconnect") {
                             QuickFullChargeCard(
                                 enabled = state.quickFullChargeEnabled,
                                 anyLevel = state.quickFullChargeAnyLevel,
@@ -255,9 +288,10 @@ fun DashboardScreen(
                     }
                 }
 
-                // Shared tail: the alarm and the single stats card render on every device class —
-                // one lexical slot each, so the supported/unsupported branches can't drift apart.
-                item {
+                // Shared tail: the alarm renders on every device class, and the stats card joins it here
+                // whenever it wasn't promoted above — one lexical slot each, so the supported and
+                // unsupported branches can't drift apart.
+                item(key = "dashboard.alarm") {
                     ChargeAlarmCard(
                         config = state.alarm,
                         notificationsBlocked = state.notificationsBlocked,
@@ -266,18 +300,11 @@ fun DashboardScreen(
                         onFixNotifications = onFixNotifications,
                     )
                 }
-                item {
-                    StatsDashboardCard(
-                        presentation = statsPresentation,
-                        onOpenStats = onOpenStats,
-                        onOpenLiveSession = onOpenLiveSession,
-                        onRetryCapture = onRetryCapture,
-                    )
-                }
+                if (!statsPromoted) statsItem()
 
                 if (unsupported) {
                     if (state.charging.contributionWanted) {
-                        item {
+                        item(key = "dashboard.unsupported") {
                             UnsupportedDeviceCard(
                                 manufacturer = state.charging.device.manufacturer
                                     .ifBlank { stringResource(R.string.dashboard_manufacturer_fallback) },
@@ -302,7 +329,7 @@ fun DashboardScreen(
                             quickAccess = state.quickAccess,
                         )
                     ) {
-                        item {
+                        item(key = "dashboard.quickaccess") {
                             QuickAccessCard(
                                 widgetAdded = state.quickAccess.widgetAdded,
                                 tileAdded = state.quickAccess.tileAdded,
@@ -320,7 +347,7 @@ fun DashboardScreen(
                         // disabled until it is connected.
                         state.charging.controlEnabled &&
                             state.charging.writeRequiresShizuku &&
-                            access?.shizuku?.ready != true -> item {
+                            access?.shizuku?.ready != true -> item(key = "dashboard.shizukubanner") {
                             ShizukuBanner(
                                 running = access?.shizuku?.available == true,
                                 requiredForControl = true,
@@ -332,7 +359,7 @@ fun DashboardScreen(
                         // (computer) path: durable control is present but Shizuku isn't, so exact
                         // readback/diagnostics are missing. Sync-readback adapters verify through
                         // any backend, so the readback pitch would be wrong there.
-                        access?.direct?.ready == true && !access.canVerify && !state.charging.syncVerification -> item {
+                        access?.direct?.ready == true && !access.canVerify && !state.charging.syncVerification -> item(key = "dashboard.shizukubanner") {
                             ShizukuBanner(
                                 running = access.shizuku.available,
                                 requiredForControl = false,
@@ -926,7 +953,8 @@ private fun DashboardScreenPreview() = PreviewWrapper {
     )
 }
 
-// On the charger with capture enabled: the stats card in its fixed slot renders the live session.
+// On the charger with capture enabled: the stats card is promoted to the second slot and renders the
+// live session (the unplugged preview above shows the same card in its tail slot).
 @AmplyPreview
 @Composable
 private fun DashboardScreenLiveChargePreview() = PreviewWrapper {

--- a/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.icons.twotone.Book
 import androidx.compose.material.icons.twotone.BugReport
 import androidx.compose.material.icons.twotone.Favorite
 import androidx.compose.material.icons.twotone.History
-import androidx.compose.material.icons.automirrored.twotone.ShowChart
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material.icons.twotone.SupportAgent
 import androidx.compose.material3.Icon
@@ -34,7 +33,6 @@ import eu.darken.amply.common.settings.SettingsNavigationItem
 fun SettingsScreen(
     onBack: () -> Unit,
     onGeneral: () -> Unit,
-    onStats: () -> Unit,
     showDiagnostics: Boolean,
     diagnosticsReady: Boolean,
     onDiagnostics: () -> Unit,
@@ -77,15 +75,8 @@ fun SettingsScreen(
                 )
             }
             item { SettingsDivider() }
-            item {
-                SettingsNavigationItem(
-                    title = stringResource(R.string.settings_stats_title),
-                    subtitle = stringResource(R.string.settings_stats_subtitle),
-                    icon = Icons.AutoMirrored.TwoTone.ShowChart,
-                    onClick = onStats,
-                )
-            }
-            item { SettingsDivider() }
+            // Battery statistics deliberately has no entry here — the dashboard's stats card is the
+            // single way in, so the capture switch lives next to the data it produces.
             if (showDiagnostics) {
                 item { SettingsCategoryHeader(stringResource(R.string.settings_category_advanced)) }
                 item {
@@ -159,7 +150,6 @@ private fun SettingsScreenPreview() = PreviewWrapper {
     SettingsScreen(
         onBack = {},
         onGeneral = {},
-        onStats = {},
         showDiagnostics = true,
         diagnosticsReady = true,
         onDiagnostics = {},

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsCardPresentation.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsCardPresentation.kt
@@ -24,11 +24,12 @@ data class StatsDashboardState(
 )
 
 /**
- * What the single dashboard stats card shows. The card sits in one fixed slot; only its content
- * adapts through these states.
+ * What the single dashboard stats card shows. There is exactly one card; its content adapts through
+ * these states. Where it sits is a separate, purely plug-driven decision made by the dashboard (see
+ * `DashboardScreen`) — content state and slot must not be conflated.
  *
  * Truth rules:
- * - "On the charger" is decided by the RAW battery readout ([BatteryReadout.plugged]), never by the
+ * - "On the charger" is decided by the RAW battery readout ([BatteryReadout.onCharger]), never by the
  *   recorder's DB row: a stale open row must not claim [Live] while unplugged, and a missing row
  *   must not hide that the phone is on the charger ([ConnectedWithoutSession]).
  * - A null `plugged` (not reported) collapses conservatively to not-connected — the card never
@@ -73,7 +74,7 @@ sealed interface StatsCardPresentation {
             !stats.enabled -> Promo
             stats.unavailable -> Unavailable
             stats.loading -> Loading
-            readout != null && (readout.plugged ?: 0) != 0 -> when (val live = stats.live) {
+            readout != null && readout.onCharger -> when (val live = stats.live) {
                 null -> ConnectedWithoutSession(battery = readout, startFailed = stats.startFailed)
                 else -> Live(session = live, battery = readout)
             }

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsDashboardCard.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsDashboardCard.kt
@@ -41,13 +41,16 @@ import kotlinx.coroutines.delay
 const val STATS_CARD_TEST_TAG = "dashboard.stats.card"
 
 /**
- * The single dashboard stats card. It sits in one fixed slot; only its content adapts through
- * [StatsCardPresentation] — promo when capture is off, the in-progress session while on the
- * charger, an honest "no session yet / couldn't start" while connected without a recorder row,
- * and the last-session teaser otherwise. Session identity, start, and the compact curve come from
- * the live Room row; the current level / power / temperature come from the same fresh battery
- * readout the hero uses, so the two never disagree. Tapping opens the statistics screen, or the
- * in-progress session's detail while live.
+ * The single dashboard stats card. Its content adapts through [StatsCardPresentation] — promo when
+ * capture is off, the in-progress session while on the charger, an honest "no session yet / couldn't
+ * start" while connected without a recorder row, and the last-session teaser otherwise. Session
+ * identity, start, and the compact curve come from the live Room row; the current level / power /
+ * temperature come from the same fresh battery readout the hero uses, so the two never disagree.
+ * (Where the card sits on the dashboard is decided separately — see `DashboardScreen`.)
+ *
+ * Tapping opens the statistics screen, or the in-progress session's detail while live — which is why
+ * the live state also carries an explicit "History" action: it is the only state whose surface tap
+ * leads somewhere else. Both that and the retry action must not bubble to the card's own navigation.
  */
 @Composable
 fun StatsDashboardCard(
@@ -78,7 +81,7 @@ fun StatsDashboardCard(
             StatsCardPresentation.Promo -> BodyText(stringResource(R.string.dashboard_stats_promo))
             StatsCardPresentation.Loading -> BodyText(stringResource(R.string.dashboard_stats_loading))
             StatsCardPresentation.Unavailable -> BodyText(stringResource(R.string.dashboard_stats_unavailable))
-            is StatsCardPresentation.Live -> LiveBody(presentation, nowElapsedRealtimeMillis)
+            is StatsCardPresentation.Live -> LiveBody(presentation, nowElapsedRealtimeMillis, onOpenStats)
             is StatsCardPresentation.ConnectedWithoutSession -> ConnectedBody(presentation, onRetryCapture)
             is StatsCardPresentation.Idle -> IdleBody(presentation)
         }
@@ -96,6 +99,7 @@ private fun BodyText(text: String) = Text(
 private fun ColumnScope.LiveBody(
     live: StatsCardPresentation.Live,
     nowElapsedRealtimeMillis: Long,
+    onOpenStats: () -> Unit,
 ) {
     // Fresh battery readouts normally drive recomposition (~3s), but identical consecutive readouts
     // are conflated upstream — the minute tick keeps "charging for" moving even without new data.
@@ -137,6 +141,15 @@ private fun ColumnScope.LiveBody(
     // degenerate line, so keep the card compact and text-only until then.
     if (elapsedMillis >= CHART_MIN_ELAPSED_MILLIS && live.session.curve.size >= 2) {
         StatsCurveChart(curve = live.session.curve, chartHeight = 84.dp, showAxes = false)
+    }
+
+    // While live the card's own tap deep-links into this session, so the past-sessions list needs its
+    // own way in. Kept a plain text action (like Retry) rather than a second card.
+    TextButton(
+        onClick = onOpenStats,
+        modifier = Modifier.align(Alignment.End),
+    ) {
+        Text(stringResource(R.string.dashboard_stats_history_action))
     }
 
     // Small bottom-right caption noting a mid-charge start (so the start%/elapsed aren't read as a

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -481,8 +481,6 @@
     <string name="widget_label_tap">Tap to set a limit</string>
 
     <!-- Battery statistics -->
-    <string name="settings_stats_title">Battery statistics</string>
-    <string name="settings_stats_subtitle">Detailed charge history, speed, and temperature</string>
     <string name="dashboard_stats_title">Battery statistics</string>
     <string name="dashboard_stats_view_action">View</string>
     <string name="dashboard_stats_promo">Record every charge to see charging speed, power, and temperature curves — plus a history of past sessions</string>
@@ -495,6 +493,7 @@
     <string name="dashboard_stats_live_starting">Charger detected — recording is starting…</string>
     <string name="dashboard_stats_live_start_failed">Charger detected — recording couldn\'t start</string>
     <string name="dashboard_stats_retry_action">Retry</string>
+    <string name="dashboard_stats_history_action">History</string>
     <plurals name="dashboard_stats_session_count">
         <item quantity="one">%1$d recorded session</item>
         <item quantity="other">%1$d recorded sessions</item>

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenGestureTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenGestureTest.kt
@@ -2,7 +2,11 @@ package eu.darken.amply.main.ui.dashboard
 
 import android.app.Application
 import android.os.BatteryManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
@@ -10,6 +14,7 @@ import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -19,9 +24,16 @@ import androidx.compose.ui.test.performScrollToNode
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.charging.core.BackendKind
 import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.ChargingState
+import eu.darken.amply.charging.core.access.AccessSnapshot
+import eu.darken.amply.charging.core.access.BackendStatus
 import eu.darken.amply.common.ca.toCaString
+import eu.darken.amply.fullcharge.core.InterruptionEvent
+import eu.darken.amply.fullcharge.core.InterruptionOutcome
+import eu.darken.amply.fullcharge.core.InterruptionReason
 import eu.darken.amply.stats.core.StatsLiveSession
 import eu.darken.amply.stats.ui.STATS_CARD_TEST_TAG
 import eu.darken.amply.stats.ui.StatsDashboardState
@@ -30,6 +42,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
 @RunWith(RobolectricTestRunner::class)
@@ -55,39 +68,10 @@ class DashboardScreenGestureTest {
         onOpenReconnectSettings: () -> Unit = {},
     ) {
         compose.setContent {
-            DashboardScreen(
+            DashboardScreenForTest(
                 state = state,
-                adbCommand = "",
-                onRefresh = {},
-                onSettings = {},
-                onStartFull = {},
-                onRestore = {},
-                onApply = {},
-                onQuickFullChargeChange = {},
-                onOpenReconnectSettings = onOpenReconnectSettings,
-                onAlarmEnabledChange = {},
-                onAlarmTargetChange = {},
-                onFixNotifications = {},
                 onOpenBatteryDetail = onOpenBatteryDetail,
-                onOpenStats = {},
-                onOpenLiveSession = {},
-                onRetryCapture = {},
-                onPinWidget = {},
-                onAddTile = {},
-                onDismissQuickAccess = {},
-                onDismissInterruption = {},
-                onNativeSettings = {},
-                onOpenShizuku = {},
-                onAllowShizuku = {},
-                onGrantWss = {},
-                onCopyAdb = {},
-                onCopyWebUsbLink = {},
-                onOpenContribution = {},
-                onPrepareSupportReport = {},
-                onCopySupportReport = {},
-                onOpenSupportIssue = {},
-                onEmailSupport = {},
-                onHelp = {},
+                onOpenReconnectSettings = onOpenReconnectSettings,
             )
         }
     }
@@ -149,27 +133,126 @@ class DashboardScreenGestureTest {
     private fun scrollToStatsCard() =
         compose.onNode(hasScrollAction()).performScrollToNode(hasTestTag(STATS_CARD_TEST_TAG))
 
+    // Access already granted, so the (large) setup guide doesn't sit between the hero and the promoted
+    // stats card — otherwise the promotion assertions would fail on layout, not on order.
+    private fun readyAccess() = AccessSnapshot(
+        direct = BackendStatus(available = true, granted = true, detail = "granted".toCaString()),
+        shizuku = BackendStatus(available = true, granted = true, detail = "connected".toCaString()),
+    )
+
+    private fun supportedCharging() = ChargingState(
+        controlEnabled = true,
+        access = readyAccess(),
+        observation = ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.SHIZUKU),
+    )
+
+    private fun pluggedReadout(status: Int? = null) = BatteryReadout(
+        levelPercent = 78,
+        status = status,
+        plugged = BatteryManager.BATTERY_PLUGGED_AC,
+    )
+
+    private fun topOf(matcher: SemanticsMatcher) = compose.onNode(matcher).getUnclippedBoundsInRoot().top
+
+    private fun statsCardTop() = compose.onNodeWithTag(STATS_CARD_TEST_TAG).getUnclippedBoundsInRoot().top
+
     @Test
     fun `live charge shows in the stats card while plugged in`() {
         render(
             state = DashboardUiState(
                 onboardingComplete = true,
+                charging = supportedCharging(),
                 stats = StatsDashboardState(enabled = true, live = liveSession()),
-                batteryReadout = BatteryReadout(
-                    levelPercent = 78,
-                    plugged = BatteryManager.BATTERY_PLUGGED_AC,
-                ),
+                batteryReadout = pluggedReadout(),
             ),
         )
-        // Before scrolling the initial viewport shows the hero region: a regression re-inserting
-        // the old under-hero live card would surface here (post-scroll it would be disposed by the
-        // LazyColumn and invisible to the count below).
-        compose.onNodeWithText(string(R.string.dashboard_stats_live_title)).assertDoesNotExist()
-        scrollToStatsCard()
+        // Promoted to the second slot, so it is on screen without scrolling.
+        compose.onNodeWithTag(STATS_CARD_TEST_TAG).assertIsDisplayed()
         compose.onNodeWithText(string(R.string.dashboard_stats_live_title)).assertExists()
         // One surface: while live-titled there is no second "Battery statistics" card anywhere.
         compose.onAllNodesWithText(string(R.string.dashboard_stats_title)).assertCountEquals(0)
         compose.onAllNodesWithText(string(R.string.dashboard_stats_live_title)).assertCountEquals(1)
+    }
+
+    // Ordering assertions need every compared card composed at once, which a LazyColumn only guarantees
+    // inside the viewport — on the default screen a failure would mean "scrolled out", not "wrong
+    // order". The tall qualifier renders the whole list; "reachable without scrolling" is asserted
+    // separately, at the real screen height, where the fold actually means something.
+    @Test
+    @Config(qualifiers = "+h2400dp")
+    fun `plugged in promotes the stats card out of the tail and above the charge controls`() {
+        render(
+            state = DashboardUiState(
+                onboardingComplete = true,
+                charging = supportedCharging(),
+                stats = StatsDashboardState(enabled = true, live = liveSession()),
+                batteryReadout = pluggedReadout(),
+            ),
+        )
+        val statsTop = statsCardTop()
+        // Second, not first: the hero keeps the top slot.
+        (topOf(heroCard()) < statsTop) shouldBe true
+        (statsTop < topOf(hasText(string(R.string.dashboard_fullcharge_idle_title)))) shouldBe true
+        // ...and it really left the tail.
+        (statsTop < topOf(hasText(string(R.string.dashboard_alarm_title)))) shouldBe true
+    }
+
+    @Test
+    fun `holding at a limit still counts as on the charger`() {
+        render(
+            state = DashboardUiState(
+                onboardingComplete = true,
+                charging = supportedCharging(),
+                stats = StatsDashboardState(enabled = true, live = liveSession()),
+                // A device parked at its limit reports NOT_CHARGING while still plugged: promotion
+                // follows the plug, never the charge status.
+                batteryReadout = pluggedReadout(status = BatteryManager.BATTERY_STATUS_NOT_CHARGING),
+            ),
+        )
+        compose.onNodeWithTag(STATS_CARD_TEST_TAG).assertIsDisplayed()
+    }
+
+    @Test
+    fun `capture off is promoted too while plugged in`() {
+        render(
+            state = DashboardUiState(
+                onboardingComplete = true,
+                charging = supportedCharging(),
+                // Promo (capture disabled) and the loading/unavailable states share the slot with the
+                // live card, so it never moves under the user as the stats DB answers.
+                stats = StatsDashboardState(enabled = false),
+                batteryReadout = pluggedReadout(),
+            ),
+        )
+        compose.onNodeWithText(string(R.string.dashboard_stats_promo)).assertIsDisplayed()
+    }
+
+    @Test
+    @Config(qualifiers = "+h2400dp")
+    fun `the setup guide and interruption warning stay above the promoted card`() {
+        render(
+            state = DashboardUiState(
+                onboardingComplete = true,
+                // No access yet → the setup guide renders; plus a restore that is still owed.
+                charging = ChargingState(
+                    controlEnabled = true,
+                    observation = ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.SHIZUKU),
+                ),
+                interruption = InterruptionEvent(
+                    occurredAtMillis = 0L,
+                    reason = InterruptionReason.USER_STOPPED,
+                    outcome = InterruptionOutcome.RESTORED_LATE,
+                    workId = "tok",
+                ),
+                stats = StatsDashboardState(enabled = true, live = liveSession()),
+                batteryReadout = pluggedReadout(),
+            ),
+        )
+        val interruptionTop = topOf(hasText(string(R.string.dashboard_interruption_title_restored)))
+        val guideTop = topOf(hasText(string(R.string.setup_access_setup_title)))
+        val statsTop = statsCardTop()
+        (interruptionTop < guideTop) shouldBe true
+        (guideTop < statsTop) shouldBe true
     }
 
     @Test
@@ -190,46 +273,87 @@ class DashboardScreenGestureTest {
     }
 
     @Test
-    fun `plugged in without a recorder row shows the starting state`() {
+    fun `plugged in without a recorder row shows the starting state and is promoted`() {
         render(
             state = DashboardUiState(
                 onboardingComplete = true,
+                charging = supportedCharging(),
                 stats = StatsDashboardState(enabled = true),
-                batteryReadout = BatteryReadout(
-                    levelPercent = 78,
-                    plugged = BatteryManager.BATTERY_PLUGGED_AC,
-                ),
+                batteryReadout = pluggedReadout(),
             ),
         )
-        scrollToStatsCard()
-        compose.onNodeWithText(string(R.string.dashboard_stats_live_title)).assertExists()
+        compose.onNodeWithText(string(R.string.dashboard_stats_live_title)).assertIsDisplayed()
         compose.onNodeWithText(string(R.string.dashboard_stats_live_starting)).assertExists()
     }
 
     @Test
-    fun `stats card sits in its fixed slot below the alarm card`() {
+    fun `a failed capture start is promoted with its retry action`() {
         render(
             state = DashboardUiState(
                 onboardingComplete = true,
-                stats = StatsDashboardState(enabled = true, live = liveSession()),
-                batteryReadout = BatteryReadout(
-                    levelPercent = 78,
-                    plugged = BatteryManager.BATTERY_PLUGGED_AC,
-                ),
+                charging = supportedCharging(),
+                stats = StatsDashboardState(enabled = true, startFailed = true),
+                batteryReadout = pluggedReadout(),
             ),
         )
-        // Going live must not teleport the card: it stays in the shared tail, directly after the
-        // alarm card, instead of jumping under the hero.
-        scrollToStatsCard()
-        val alarmTop = compose.onNodeWithText(string(R.string.dashboard_alarm_title))
-            .getUnclippedBoundsInRoot().top
-        val statsTop = compose.onNodeWithTag(STATS_CARD_TEST_TAG)
-            .getUnclippedBoundsInRoot().top
-        (alarmTop < statsTop) shouldBe true
+        compose.onNodeWithText(string(R.string.dashboard_stats_live_start_failed)).assertIsDisplayed()
+        compose.onNodeWithText(string(R.string.dashboard_stats_retry_action)).assertIsDisplayed()
+    }
+
+    // The interesting case is the card actually moving inside a live composition (plugging in), not two
+    // separate renders: that is what the LazyColumn keys have to survive, and it must never leave two
+    // stats cards behind.
+    @Test
+    @Config(qualifiers = "+h2400dp")
+    fun `plugging in and out moves the single stats card between its slots`() {
+        val plugged = mutableStateOf(false)
+        compose.setContent {
+            DashboardScreenForTest(
+                state = DashboardUiState(
+                    onboardingComplete = true,
+                    charging = supportedCharging(),
+                    stats = StatsDashboardState(enabled = true, live = liveSession()),
+                    batteryReadout = BatteryReadout(
+                        levelPercent = 78,
+                        plugged = if (plugged.value) BatteryManager.BATTERY_PLUGGED_AC else 0,
+                    ),
+                ),
+            )
+        }
+        val alarm = hasText(string(R.string.dashboard_alarm_title))
+
+        compose.onAllNodesWithTag(STATS_CARD_TEST_TAG).assertCountEquals(1)
+        (topOf(alarm) < statsCardTop()) shouldBe true
+
+        compose.runOnIdle { plugged.value = true }
+        compose.onAllNodesWithTag(STATS_CARD_TEST_TAG).assertCountEquals(1)
+        (statsCardTop() < topOf(alarm)) shouldBe true
+
+        compose.runOnIdle { plugged.value = false }
+        compose.onAllNodesWithTag(STATS_CARD_TEST_TAG).assertCountEquals(1)
+        (topOf(alarm) < statsCardTop()) shouldBe true
     }
 
     @Test
-    fun `unsupported devices show the live charge in the same slot`() {
+    fun `unplugged keeps the stats card in its tail slot below the alarm card`() {
+        render(
+            state = DashboardUiState(
+                onboardingComplete = true,
+                charging = supportedCharging(),
+                stats = StatsDashboardState(enabled = true, live = liveSession()),
+                batteryReadout = BatteryReadout(levelPercent = 78, plugged = 0),
+            ),
+        )
+        // Off the charger the card is a teaser, not a live readout: it stays in the shared tail,
+        // directly after the (adjacent, so reliably co-composed) alarm card.
+        scrollToStatsCard()
+        val alarmTop = topOf(hasText(string(R.string.dashboard_alarm_title)))
+        (alarmTop < statsCardTop()) shouldBe true
+    }
+
+    @Test
+    @Config(qualifiers = "+h2400dp")
+    fun `unsupported devices promote the live charge too`() {
         render(
             state = DashboardUiState(
                 onboardingComplete = true,
@@ -237,14 +361,16 @@ class DashboardScreenGestureTest {
                     observation = ChargeObservation.Unsupported("Not a supported device".toCaString()),
                 ),
                 stats = StatsDashboardState(enabled = true, live = liveSession()),
-                batteryReadout = BatteryReadout(
-                    levelPercent = 78,
-                    plugged = BatteryManager.BATTERY_PLUGGED_AC,
-                ),
+                batteryReadout = pluggedReadout(),
             ),
         )
-        scrollToStatsCard()
+        // The unsupported branch has no interruption card or setup guide, so the card follows the hero
+        // directly — ahead of the OEM guide and the alarm card that end this branch.
         compose.onNodeWithText(string(R.string.dashboard_stats_live_title)).assertExists()
+        val statsTop = statsCardTop()
+        (topOf(heroCard()) < statsTop) shouldBe true
+        (statsTop < topOf(hasText(string(R.string.setup_oem_guide_title)))) shouldBe true
+        (statsTop < topOf(hasText(string(R.string.dashboard_alarm_title)))) shouldBe true
     }
 
     @Test
@@ -259,4 +385,49 @@ class DashboardScreenGestureTest {
         )
         compose.onNode(heroCard()).assertExists()
     }
+}
+
+// The screen takes ~30 callbacks; funnel every fixture through one renderer so a test only describes the
+// state it cares about. Kept composable (rather than inlined into setContent) so a test can drive state
+// changes through a live composition.
+@Composable
+private fun DashboardScreenForTest(
+    state: DashboardUiState,
+    onOpenBatteryDetail: () -> Unit = {},
+    onOpenReconnectSettings: () -> Unit = {},
+) {
+    DashboardScreen(
+        state = state,
+        adbCommand = "",
+        onRefresh = {},
+        onSettings = {},
+        onStartFull = {},
+        onRestore = {},
+        onApply = {},
+        onQuickFullChargeChange = {},
+        onOpenReconnectSettings = onOpenReconnectSettings,
+        onAlarmEnabledChange = {},
+        onAlarmTargetChange = {},
+        onFixNotifications = {},
+        onOpenBatteryDetail = onOpenBatteryDetail,
+        onOpenStats = {},
+        onOpenLiveSession = {},
+        onRetryCapture = {},
+        onPinWidget = {},
+        onAddTile = {},
+        onDismissQuickAccess = {},
+        onDismissInterruption = {},
+        onNativeSettings = {},
+        onOpenShizuku = {},
+        onAllowShizuku = {},
+        onGrantWss = {},
+        onCopyAdb = {},
+        onCopyWebUsbLink = {},
+        onOpenContribution = {},
+        onPrepareSupportReport = {},
+        onCopySupportReport = {},
+        onOpenSupportIssue = {},
+        onEmailSupport = {},
+        onHelp = {},
+    )
 }

--- a/app/src/test/java/eu/darken/amply/stats/ui/StatsCardPresentationTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/ui/StatsCardPresentationTest.kt
@@ -59,7 +59,7 @@ class StatsCardPresentationTest {
     )
 
     @Test
-    fun `disabled always promotes - even plugged with an open row`() {
+    fun `disabled always yields the promo card - even plugged with an open row`() {
         StatsCardPresentation.from(stats(enabled = false, live = liveSession), plugged) shouldBe
             StatsCardPresentation.Promo
         StatsCardPresentation.from(stats(enabled = false, last = lastSession), unplugged) shouldBe

--- a/app/src/test/java/eu/darken/amply/stats/ui/StatsDashboardCardTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/ui/StatsDashboardCardTest.kt
@@ -108,6 +108,38 @@ class StatsDashboardCardTest {
     }
 
     @Test
+    fun `live body offers history without triggering the session deep link`() {
+        var opened = false
+        var openedId: Long? = null
+        render(
+            StatsCardPresentation.Live(session = liveSession, battery = pluggedBattery),
+            onOpenStats = { opened = true },
+            onOpenLiveSession = { openedId = it },
+        )
+        // The card's own tap goes to this session, so the past-sessions list needs its own action —
+        // which must not bubble to that navigation.
+        compose.onNodeWithText(string(R.string.dashboard_stats_history_action)).performClick()
+        compose.runOnIdle {
+            opened shouldBe true
+            openedId shouldBe null
+        }
+    }
+
+    // Everywhere but Live the card's own tap already opens the list, so a second affordance would be a
+    // duplicate — asserted per state because setContent can only run once per test.
+    @Test
+    fun `idle carries no history action`() {
+        render(StatsCardPresentation.Idle(lastSession = lastSession, sessionCount = 3))
+        compose.onNodeWithText(string(R.string.dashboard_stats_history_action)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `connected-without-session carries no history action`() {
+        render(StatsCardPresentation.ConnectedWithoutSession(battery = pluggedBattery, startFailed = false))
+        compose.onNodeWithText(string(R.string.dashboard_stats_history_action)).assertDoesNotExist()
+    }
+
+    @Test
     fun `connected-without-session shows the starting note and opens the stats list`() {
         var opened = false
         render(


### PR DESCRIPTION
## What changed

- While a charger is connected, the battery-statistics card now sits right below the status card at the top of the dashboard instead of at the bottom, so the running charge is visible without scrolling. Unplug and it moves back down.
- "Connected" means exactly that: a phone parked at its charge limit — which reports itself as *not charging* — still counts, and the card also takes the top spot before recording has produced anything yet, so it never jumps around while it loads.
- A restore that is still owed, and the one-time setup guide, keep their place above it. Both are rarer and need action.
- Battery statistics no longer have their own entry in Settings. The dashboard card is the way in, so the recording switch sits next to the data it produces.
- While a charge is being recorded the card opens that charge, so it now carries a **History** action for the list of past sessions.

## Technical Context

**Placement is plug-driven, not content-driven.** `statsPromoted` reads only the raw battery readout via the new `BatteryReadout.onCharger` (`plugged != 0`, null → false), the same rule `StatsCardPresentation.from` uses — deliberately not `status`, because a device holding at its limit reports `BATTERY_STATUS_NOT_CHARGING` while still connected. It is also independent of the card's own state, so `Promo`/`Loading`/`Unavailable` are promoted too and the slot cannot shift under the user as the stats DB answers. This partially reverses the fixed-slot decision from #17; the single *construction* site stays (one lexical `StatsDashboardCard(...)`, so the supported and unsupported branches cannot drift), only the placement is conditional.

**Every dashboard item gained a stable `LazyColumn` key.** Without keys a lazy list identifies items by index, so the stats card changing slot renumbers everything after it and discards their remembered state — plugging in mid-drag would have snapped the charge-alarm slider back to its persisted value. Keys are unique per render; the pairs that appear in both branches (full charge, reconnect, Shizuku banner) are mutually exclusive.

**Navigation.** With the settings row gone there is one entry point, so `statsOrigin` is deleted and both back paths — the top-bar action *and* the `BackHandler` branch — return to the dashboard. `detailOrigin` stays: the session detail is still reached from the dashboard card (live deep-link) and from the list.

**Card contract.** `AmplyNavigationCard`'s KDoc claimed it must contain no interactive controls, which its own tested "Retry" button already contradicted. It now states the real contract: the surface owns the primary tap plus at most one small trailing text action that must not bubble — asserted for both History and Retry.

**Review guidance for the tests.** Bounds-ordering assertions run under `@Config(qualifiers = "+h2400dp")` so every compared card is composed; on the default screen a `LazyColumn` may not have composed the far card and a failure would mean "scrolled out", not "wrong order". Above-the-fold assertions deliberately stay at the real screen height, where the fold means something. A plug → unplug transition test drives the move through one live composition and asserts exactly one stats card after each step.

Not covered by automated tests: system-back from the statistics screen and its session detail (needs instrumentation) — on the manual list below. Play Store screenshots need no regeneration; their fixtures leave the battery readout unset, so those shots keep the tail placement.

## Manual verification

Not yet run on hardware — planned pass: promoted placement plus tap-through to the live session; **History** → list; unplug → back to the tail; both back paths out of the statistics screen; `adb shell dumpsys battery set ac 1` then `set status 4` to confirm the plugged-but-not-charging case.
