### PR TITLE
Stats: Keep the current charging session across app restarts

### DIFF
--- a/app/src/main/java/eu/darken/amply/stats/core/BootIdSource.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/BootIdSource.kt
@@ -9,9 +9,14 @@ import javax.inject.Singleton
 /**
  * Reads the device boot count, used to tell a same-boot process restart (resume the open session)
  * from a reboot (seal it — elapsed-time continuity can't survive a power-off). The value can only
- * change across a reboot, which restarts this process, so it is read once and cached. A device that
- * doesn't report [Settings.Global.BOOT_COUNT] yields a constant sentinel; reboots then look like
- * same-boot restarts, which degrades to a partial/interrupted seal rather than anything unsafe.
+ * change across a reboot, which restarts this process, so it is read once and cached.
+ *
+ * A device that doesn't report [Settings.Global.BOOT_COUNT] yields the [UNAVAILABLE] sentinel, which
+ * two different boots would compare *equal* on. So the sentinel is not merely a degraded id — it is
+ * explicitly disqualifying: [StatsSessionEngine.evaluateResume] refuses to resume an open session
+ * when either side is [UNAVAILABLE], because a resume across an unnoticed reboot would splice two
+ * boots' [android.os.SystemClock.elapsedRealtime] readings into one bogus duration. Such a device
+ * always falls back to sealing, which is lossy but never wrong.
  */
 @Singleton
 class BootIdSource @Inject constructor(
@@ -22,10 +27,11 @@ class BootIdSource @Inject constructor(
     fun current(): Long = cached
 
     private fun read(): Long = runCatching {
-        Settings.Global.getInt(context.contentResolver, Settings.Global.BOOT_COUNT, UNAVAILABLE).toLong()
-    }.getOrDefault(UNAVAILABLE.toLong())
+        Settings.Global.getInt(context.contentResolver, Settings.Global.BOOT_COUNT, UNAVAILABLE.toInt()).toLong()
+    }.getOrDefault(UNAVAILABLE)
 
-    private companion object {
-        const val UNAVAILABLE = -1
+    companion object {
+        /** Boot identity could not be determined — never usable to prove two observations share a boot. */
+        const val UNAVAILABLE = -1L
     }
 }

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRecorder.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRecorder.kt
@@ -1,6 +1,7 @@
 package eu.darken.amply.stats.core
 
 import android.os.BatteryManager
+import android.os.SystemClock
 import androidx.room.withTransaction
 import dagger.Lazy
 import eu.darken.amply.battery.core.BatteryReadout
@@ -10,10 +11,11 @@ import eu.darken.amply.common.debug.logging.log
 import eu.darken.amply.common.debug.logging.logTag
 import eu.darken.amply.stats.core.db.BatterySampleEntity
 import eu.darken.amply.stats.core.db.ChargeSessionEntity
+import eu.darken.amply.stats.core.db.StatsDao
 import eu.darken.amply.stats.core.db.StatsDatabase
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.first
@@ -41,8 +43,9 @@ class ChargeStatsRecorder @Inject constructor(
     private val preferences: StatsPreferences,
     private val bootIdSource: BootIdSource,
     private val batteryReader: BatteryReader,
+    @StatsDispatcher dispatcher: CoroutineDispatcher,
 ) {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private val commands = Channel<Command>(Channel.UNLIMITED)
 
     // Mutated only by the single consumer coroutine below — no locking needed.
@@ -54,8 +57,8 @@ class ChargeStatsRecorder @Inject constructor(
 
     init {
         scope.launch {
-            // Runs before any command: seals sessions left open by an unclean shutdown, and seeds the
-            // capturing flag from the durable preference.
+            // Runs before any command: reconciles sessions left open by an unclean shutdown, and seeds
+            // the capturing flag from the durable preference.
             startupRepair()
             for (command in commands) {
                 try {
@@ -92,10 +95,12 @@ class ChargeStatsRecorder @Inject constructor(
         try {
             capturing = preferences.isCaptureEnabledNow()
             // Only touch the DB when we might have data — avoids creating an empty stats.db for users
-            // who never enabled statistics. A dangling open row can only exist after prior recording,
-            // which always stamps lastCapture.
-            if (preferences.lastCaptureWallMillis.first() == null) return
-            sealDanglingSessions()
+            // who never enabled statistics. The lastCapture stamp alone is not a sound existence test:
+            // it is written after the row is committed, so a process death in between leaves an open
+            // row with no stamp. Capture being enabled is therefore also sufficient — such a user gets
+            // a stats.db on the next tick anyway, so opening it here costs nothing.
+            if (!capturing && preferences.lastCaptureWallMillis.first() == null) return
+            reconcileDanglingSessions()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -243,22 +248,68 @@ class ChargeStatsRecorder @Inject constructor(
     }
 
     /**
-     * Seal every session left open by an unclean shutdown (process kill / reboot). Never resumes:
-     * losing the monitor mid-charge breaks curve/elapsed continuity, so the session is closed
-     * honestly and the next plug opens a fresh one. This also sidesteps having to trust the boot
-     * count — a resumed session would risk a negative post-reboot duration.
+     * Reconcile sessions left open by an unclean shutdown (process kill / reboot). The newest row is
+     * offered to [StatsSessionEngine.evaluateResume] against the battery state observed right now; if
+     * the same plug event is still underway it is reattached, keeping the true plug-in time and one
+     * history row per physical charge. Everything else is sealed as before.
+     *
+     * The probe happens here rather than on the first watcher tick on purpose. A held-open row would
+     * be rendered as a live session by the dashboard for as long as no tick arrives — which also
+     * suppresses the "couldn't start capture" retry when the foreground service fails to start — and
+     * would need leak guards on the disable/clear paths. Resolving synchronously costs one sticky
+     * broadcast read and leaves [onSample] untouched.
      */
-    private suspend fun sealDanglingSessions() {
+    private suspend fun reconcileDanglingSessions() {
         val dao = database.get().statsDao()
         val open = dao.openSessions()
         if (open.isEmpty()) return
         val currentBoot = bootIdSource.current()
-        open.forEach { row ->
-            val sealed = sealFromLastKnown(row, currentBoot)
-            // Drop a dangling row that never captured anything (same rule as a live seal).
-            if (StatsSessionEngine.isDiscardable(sealed)) dao.deleteSession(sealed.id) else dao.updateSession(sealed)
-        }
+        // Capture is off, so no tick is coming to advance a resumed row — seal everything, as before.
+        // Ordered by id (monotonic), matching the row `openSessionFlow` shows as live; `openSessions`
+        // orders by elapsed-realtime, which disagrees across a reboot.
+        val candidate = if (capturing) open.maxByOrNull { it.id } else null
+        val resumed = candidate?.let { resumeOrNull(it, currentBoot) }
+        open.filter { it.id != resumed?.id }.forEach { row -> sealDangling(dao, row, currentBoot) }
         open.maxOfOrNull { it.runningLastWallMillis ?: it.startedAtWallMillis }?.let { purgeOldSamples(it) }
+    }
+
+    /**
+     * Reattach [row] if the charge it recorded is still running, else null. In-memory state is
+     * installed only *after* the durable write returns: command failures are logged and swallowed
+     * (see the loop above), and a remembered-but-unwritten session would let a later tick open a
+     * second row against a row the database still has open.
+     */
+    private suspend fun resumeOrNull(row: ChargeSessionEntity, currentBoot: Long): ChargeSessionEntity? {
+        val readout = batteryReader.read()
+        val probe = ResumeProbe(
+            elapsedRealtimeMillis = SystemClock.elapsedRealtime(),
+            bootId = currentBoot,
+            plugged = (readout.plugged ?: 0) != 0,
+            percent = readout.levelPercent,
+        )
+        return when (val decision = StatsSessionEngine.evaluateResume(row, probe)) {
+            is ResumeDecision.Reject -> {
+                log(TAG) { "Not resuming session ${row.id}: ${decision.reason}" }
+                null
+            }
+
+            is ResumeDecision.Resume -> {
+                database.get().statsDao().updateSession(decision.session)
+                openSession = decision.session
+                // Continue the existing cadence instead of restarting it, so the resumed session
+                // doesn't force an extra curve point on top of the one it already has.
+                lastRecordedElapsed = decision.session.runningLastElapsedRealtimeMillis
+                lastRecordedPercent = decision.session.runningLastPercent
+                log(TAG, Logging.Priority.INFO) { "Resumed charge session ${decision.session.id}" }
+                decision.session
+            }
+        }
+    }
+
+    private suspend fun sealDangling(dao: StatsDao, row: ChargeSessionEntity, currentBoot: Long) {
+        val sealed = sealFromLastKnown(row, currentBoot)
+        // Drop a dangling row that never captured anything (same rule as a live seal).
+        if (StatsSessionEngine.isDiscardable(sealed)) dao.deleteSession(sealed.id) else dao.updateSession(sealed)
     }
 
     private fun sealFromLastKnown(row: ChargeSessionEntity, currentBoot: Long): ChargeSessionEntity {

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
@@ -35,14 +35,17 @@ class ChargeStatsRepository @Inject constructor(
      * The in-progress charge session of the current boot, or null when nothing is open, as a live flow
      * for the dashboard card. The curve is a bounded recent window (decimated) so a session that stays
      * open for days at an OEM charge limit never triggers an unbounded reload on every appended sample.
-     * `distinctUntilChangedBy(id)` keeps the inner sample flow subscribed across the per-tick session-row
-     * updates (the open row's start fields are immutable, so only a change of session identity matters),
-     * avoiding a redundant curve re-query on every fold.
+     * `distinctUntilChangedBy` keeps the inner sample flow subscribed across the per-tick session-row
+     * updates, avoiding a redundant curve re-query on every fold. It keys on identity **plus every row
+     * field this flow actually renders**: `partial` flips when a session is resumed after a process
+     * restart, and since the row is captured inside `flatMapLatest`, an id-only key would pin the stale
+     * copy for the lifetime of the subscription. The remaining projected fields (the start columns) are
+     * immutable once the row exists.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     fun currentSession(): Flow<StatsLiveSession?> =
         database.get().statsDao().openSessionFlow(bootIdSource.current())
-            .distinctUntilChangedBy { it?.id }
+            .distinctUntilChangedBy { row -> row?.let { it.id to it.partial } }
             .flatMapLatest { row ->
                 if (row == null) {
                     flowOf(null)

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsModule.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsModule.kt
@@ -2,10 +2,14 @@ package eu.darken.amply.stats.core
 
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.amply.monitor.core.ChargeMonitorWatcher
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Qualifier
 
 /**
  * Contributes [ChargeStatsWatcher] into the shared [Set] of [ChargeMonitorWatcher]s the
@@ -18,4 +22,20 @@ abstract class StatsModule {
     @Binds
     @IntoSet
     abstract fun bindStatsWatcher(impl: ChargeStatsWatcher): ChargeMonitorWatcher
+
+    companion object {
+        @Provides
+        @StatsDispatcher
+        fun statsDispatcher(): CoroutineDispatcher = Dispatchers.IO
+    }
 }
+
+/**
+ * The dispatcher [ChargeStatsRecorder] runs its serialized command loop on. Injected rather than
+ * hardcoded purely so tests can substitute a deterministic scheduler; production is always
+ * [Dispatchers.IO]. Qualified (and scoped to the stats feature) so this doesn't become an
+ * unqualified app-wide `CoroutineDispatcher` binding.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class StatsDispatcher

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsSealReason.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsSealReason.kt
@@ -9,7 +9,12 @@ enum class StatsSealReason {
     /** Charger removed — the normal, complete end of a session. */
     UNPLUGGED,
 
-    /** Reopened an open session after a process restart within the same boot; curve has a gap. */
+    /**
+     * Found open after a process restart and *not* resumable — the charge it recorded could not be
+     * shown to still be running (unplugged since, level dropped, unknown boot). A restart that is
+     * consistent with the same plug event reattaches the row instead of sealing it, so this reason
+     * means the evidence failed, not merely that the process died.
+     */
     INTERRUPTED,
 
     /** Open session found after a reboot; elapsed-time continuity across power-off can't be trusted. */

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsSessionEngine.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsSessionEngine.kt
@@ -19,6 +19,49 @@ sealed interface StatsTransition {
 }
 
 /**
+ * Current battery state observed at process start, used to reconcile a session left open by a
+ * process death. Deliberately *not* a [StatsSample]: that type's contract is "built from the exact
+ * intent the charge-session service evaluated", while this comes from an independent sticky read
+ * before any service tick exists.
+ */
+data class ResumeProbe(
+    val elapsedRealtimeMillis: Long,
+    val bootId: Long,
+    val plugged: Boolean,
+    val percent: Int?,
+)
+
+/** Outcome of reconciling a dangling open session against a [ResumeProbe]. */
+sealed interface ResumeDecision {
+
+    /** Reattach [session] — the same plug event is still in progress, as far as can be told. */
+    data class Resume(val session: ChargeSessionEntity) : ResumeDecision
+
+    /** Seal the row instead; [reason] is for diagnostics only. */
+    data class Reject(val reason: Reason) : ResumeDecision
+
+    enum class Reason {
+        /** Row is already sealed — nothing to reconcile. */
+        CLOSED,
+
+        /** No external power now, so whatever charge was underway has ended. */
+        UNPLUGGED,
+
+        /** Boot identity is unknown on either side, so a same-boot claim can't be made. */
+        BOOT_UNKNOWN,
+
+        /** A reboot happened; elapsed-realtime readings from two boots can't be compared. */
+        BOOT_MISMATCH,
+
+        /** Probe predates the row's last sample — the clock base can't be the one we recorded against. */
+        TIME_WENT_BACKWARDS,
+
+        /** Charge level fell while we weren't looking, so the device discharged in the gap. */
+        LEVEL_DROPPED,
+    }
+}
+
+/**
  * Pure charge-session segmentation and online aggregation. Holds no state itself: the open session
  * is a [ChargeSessionEntity] the recorder loads from (and persists to) Room, so every decision
  * survives process death and is JVM-unit-testable without Android or a database.
@@ -68,6 +111,51 @@ object StatsSessionEngine {
             sealed.endPercent == sealed.startPercent
         return zeroDuration && noLevelGain && sealed.runningSampleCount <= 1
     }
+
+    /**
+     * Reconcile a session left open by a process death against the battery state observed at the next
+     * process start. Resuming keeps the real plug-in time and one history row for one physical charge;
+     * the alternative (always sealing) restarts the session at process-launch time, which reads as a
+     * wrong "Since …" and splits one charge into two rows.
+     *
+     * Continuity here is **inferred, not observed** — nothing survived the gap to witness it. A replug
+     * at an equal-or-higher level is indistinguishable from an uninterrupted plug, and a level *drop*
+     * while plugged is possible (heavy load, weak charger, thermal throttling, an OEM hold). So these
+     * guards are best-effort and deliberately biased toward merging: an occasional merged plug cycle
+     * beats fragmenting real sessions. Two things keep that bias honest, both applied on [Resume]:
+     * the row is flagged [ChargeSessionEntity.partial], and the last power/temperature readings are
+     * dropped so [fold] credits **nothing** for the unobserved gap (see the null handling in
+     * [creditInterval]). A wrong merge therefore costs an over-long duration — never invented
+     * power/temperature averages.
+     */
+    fun evaluateResume(row: ChargeSessionEntity, probe: ResumeProbe): ResumeDecision {
+        val lastObserved = row.runningLastElapsedRealtimeMillis ?: row.startedElapsedRealtimeMillis
+        val reason = when {
+            row.endedAtWallMillis != null -> ResumeDecision.Reason.CLOSED
+            !probe.plugged -> ResumeDecision.Reason.UNPLUGGED
+            // Checked before equality: the sentinel compares equal to itself across *different* boots.
+            probe.bootId == BootIdSource.UNAVAILABLE ||
+                row.bootId == BootIdSource.UNAVAILABLE -> ResumeDecision.Reason.BOOT_UNKNOWN
+            probe.bootId != row.bootId -> ResumeDecision.Reason.BOOT_MISMATCH
+            probe.elapsedRealtimeMillis < lastObserved -> ResumeDecision.Reason.TIME_WENT_BACKWARDS
+            droppedLevel(row.runningLastPercent, probe.percent) -> ResumeDecision.Reason.LEVEL_DROPPED
+            else -> null
+        }
+        if (reason != null) return ResumeDecision.Reject(reason)
+        return ResumeDecision.Resume(
+            row.copy(
+                // The curve has a hole and the continuity is inferred — never present this as a clean
+                // plug→unplug history.
+                partial = true,
+                runningLastPowerMilliwatts = null,
+                runningLastTemperatureTenthsC = null,
+            ),
+        )
+    }
+
+    /** True only when both readings exist and the level fell — a missing reading is not evidence. */
+    private fun droppedLevel(lastPercent: Int?, probePercent: Int?): Boolean =
+        lastPercent != null && probePercent != null && probePercent < lastPercent
 
     fun open(sample: StatsSample, partial: Boolean): ChargeSessionEntity = ChargeSessionEntity(
         startedAtWallMillis = sample.wallMillis,

--- a/app/src/main/java/eu/darken/amply/stats/core/db/ChargeSessionEntity.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/db/ChargeSessionEntity.kt
@@ -40,8 +40,10 @@ data class ChargeSessionEntity(
 
     /**
      * True when the session does not represent a clean plug→unplug: capture was enabled mid-charge,
-     * started already at 100%, or the session was sealed by process recovery / reboot. The UI labels
-     * these as partial rather than presenting them as complete histories.
+     * started already at 100%, the session was sealed by process recovery / reboot, or it was resumed
+     * after a process restart (start time and totals are real, but the curve has a gap and continuity
+     * across that gap is inferred rather than observed). The UI labels these as partial rather than
+     * presenting them as complete histories.
      */
     val partial: Boolean = false,
 

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsCardPresentation.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsCardPresentation.kt
@@ -33,8 +33,11 @@ data class StatsDashboardState(
  *   must not hide that the phone is on the charger ([ConnectedWithoutSession]).
  * - A null `plugged` (not reported) collapses conservatively to not-connected — the card never
  *   claims a charger it can't observe.
- * - Previous-boot rows are already excluded by the recorder's boot-scoped query; a same-boot row
- *   surviving process death can briefly present as [Live] until the recorder's first tick seals it.
+ * - Previous-boot rows are already excluded by the recorder's boot-scoped query.
+ * - A row is not enough to claim [Live]: capture must also be running. When the last service-start
+ *   attempt failed, no ticks are arriving, so an open row (including one the recorder resumed after a
+ *   process restart, which stays open indefinitely by design) would otherwise render as a live
+ *   session frozen at its last values — and hide the retry action that could fix it.
  */
 sealed interface StatsCardPresentation {
 
@@ -54,8 +57,9 @@ sealed interface StatsCardPresentation {
     ) : StatsCardPresentation
 
     /**
-     * Capture on and the charger is connected, but no recorder row exists yet — install-while-
-     * plugged, service-start latency, or a failed start ([startFailed]).
+     * Capture on and the charger is connected, but there is no session to show live — no recorder row
+     * yet (install-while-plugged, service-start latency), or capture isn't running because the last
+     * start attempt failed ([startFailed]), in which case any open row is frozen and not shown.
      */
     data class ConnectedWithoutSession(
         val battery: BatteryReadout,
@@ -75,7 +79,11 @@ sealed interface StatsCardPresentation {
             stats.loading -> Loading
             readout != null && (readout.plugged ?: 0) != 0 -> when (val live = stats.live) {
                 null -> ConnectedWithoutSession(battery = readout, startFailed = stats.startFailed)
-                else -> Live(session = live, battery = readout)
+                // A failed start means no ticks: show the retry rather than a frozen "live" session.
+                else -> when {
+                    stats.startFailed -> ConnectedWithoutSession(battery = readout, startFailed = true)
+                    else -> Live(session = live, battery = readout)
+                }
             }
             else -> Idle(lastSession = stats.lastSession, sessionCount = stats.sessionCount)
         }

--- a/app/src/test/java/eu/darken/amply/stats/core/ChargeStatsRecorderTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/ChargeStatsRecorderTest.kt
@@ -1,0 +1,299 @@
+package eu.darken.amply.stats.core
+
+import android.content.Context
+import android.content.Intent
+import android.os.BatteryManager
+import android.provider.Settings
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.battery.core.BatteryReader
+import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.stats.core.db.ChargeSessionEntity
+import eu.darken.amply.stats.core.db.StatsDatabase
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * Startup reconciliation of a session left open by a process death, against an in-memory Room
+ * instance: does the recorder reattach the row (keeping the real plug-in time and one history entry),
+ * or seal it? The decision itself is unit-tested in [StatsSessionEngineTest]; what is covered here is
+ * the orchestration around it — probing live battery state, choosing among multiple open rows, and
+ * the capture-disabled short circuit.
+ *
+ * Robolectric (JUnit 4) per the project's convention for anything needing the Android framework. The
+ * recorder's own command loop is injected with a dispatcher, but its database work still crosses
+ * Room's executors, so assertions await an observable database state under a generous timeout rather
+ * than assuming a synchronous handoff.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ChargeStatsRecorderTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var context: Context
+    private lateinit var database: StatsDatabase
+    private lateinit var preferences: StatsPreferences
+    private lateinit var dataStoreScope: CoroutineScope
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        database = Room.inMemoryDatabaseBuilder(context, StatsDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        // Own temp file per test, matching the project's other DataStore tests. A DataStore over the
+        // app's real path would be shared with every other Robolectric class in the same JVM.
+        dataStoreScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        preferences = StatsPreferences(
+            AppDataStore(
+                PreferenceDataStoreFactory.create(scope = dataStoreScope) {
+                    File(tempFolder.root, "stats-${System.nanoTime()}.preferences_pb")
+                },
+            ),
+        )
+    }
+
+    @After
+    fun teardown() {
+        dataStoreScope.cancel()
+        database.close()
+    }
+
+    /**
+     * Construct the recorder, which runs its startup reconciliation immediately. Everything the
+     * reconciliation reads (capture flag, last-capture stamp, boot count, sticky battery state) must
+     * already be seeded.
+     */
+    private fun startRecorder() = ChargeStatsRecorder(
+        database = { database },
+        preferences = preferences,
+        bootIdSource = BootIdSource(context),
+        batteryReader = BatteryReader(context),
+        dispatcher = Dispatchers.Unconfined,
+    )
+
+    private suspend fun enableCapture(enabled: Boolean = true, stamped: Boolean = true) {
+        preferences.setCaptureEnabled(enabled)
+        // With capture off, the last-capture stamp is what tells the recorder there may be data worth
+        // reconciling; without either it refuses to touch the DB at all.
+        if (stamped) preferences.setLastCaptureWallMillis(WALL_START)
+    }
+
+    private fun setBootCount(count: Int) {
+        Settings.Global.putInt(context.contentResolver, Settings.Global.BOOT_COUNT, count)
+    }
+
+    private fun setBattery(plugged: Boolean, percent: Int) {
+        val intent = Intent(Intent.ACTION_BATTERY_CHANGED).apply {
+            putExtra(BatteryManager.EXTRA_PLUGGED, if (plugged) BatteryManager.BATTERY_PLUGGED_AC else 0)
+            putExtra(BatteryManager.EXTRA_LEVEL, percent)
+            putExtra(BatteryManager.EXTRA_SCALE, 100)
+            putExtra(
+                BatteryManager.EXTRA_STATUS,
+                if (plugged) BatteryManager.BATTERY_STATUS_CHARGING else BatteryManager.BATTERY_STATUS_DISCHARGING,
+            )
+        }
+        @Suppress("DEPRECATION")
+        context.sendStickyBroadcast(intent)
+    }
+
+    private suspend fun insertOpenSession(
+        bootId: Long = BOOT_ID,
+        lastPercent: Int? = 50,
+        startWall: Long = WALL_START,
+    ): Long = database.statsDao().insertSession(
+        ChargeSessionEntity(
+            startedAtWallMillis = startWall,
+            startedElapsedRealtimeMillis = 0,
+            bootId = bootId,
+            startPercent = 40,
+            runningSampleCount = 1,
+            runningLastPercent = lastPercent,
+            runningLastElapsedRealtimeMillis = 0,
+            runningLastWallMillis = startWall,
+            runningLastPowerMilliwatts = 9_000,
+        ),
+    )
+
+    private suspend fun await(condition: suspend () -> Boolean) {
+        withTimeout(AWAIT_TIMEOUT_MILLIS) {
+            while (!condition()) delay(20)
+        }
+    }
+
+    private suspend fun awaitSealed(id: Long) = await { database.statsDao().sessionById(id)?.endedAtWallMillis != null }
+
+    private suspend fun awaitResumed(id: Long) = await { database.statsDao().sessionById(id)?.partial == true }
+
+    @Test
+    fun `a restart while still plugged resumes the open session instead of restarting it`(): Unit = runBlocking {
+        enableCapture()
+        setBootCount(BOOT_ID.toInt())
+        setBattery(plugged = true, percent = 55)
+        val id = insertOpenSession()
+
+        startRecorder()
+        awaitResumed(id)
+
+        val row = database.statsDao().sessionById(id).shouldNotBeNull()
+        // The whole point: the card's "Since …" keeps the real plug-in time rather than jumping to
+        // the process launch time.
+        row.startedAtWallMillis shouldBe WALL_START
+        row.startPercent shouldBe 40
+        row.endedAtWallMillis shouldBe null
+        // Continuity across the gap is inferred, so the row is flagged...
+        row.partial shouldBe true
+        // ...and the pre-death readings are dropped so the unwitnessed gap is never credited.
+        row.runningLastPowerMilliwatts shouldBe null
+        // One physical charge stays one history row.
+        database.statsDao().openSessions().size shouldBe 1
+    }
+
+    @Test
+    fun `a restart after the charger was pulled seals the session`(): Unit = runBlocking {
+        enableCapture()
+        setBootCount(BOOT_ID.toInt())
+        setBattery(plugged = false, percent = 55)
+        val id = insertOpenSession()
+
+        startRecorder()
+        awaitSealed(id)
+
+        database.statsDao().sessionById(id)?.endReason shouldBe StatsSealReason.INTERRUPTED.name
+    }
+
+    @Test
+    fun `a level that dropped during the gap seals the session`(): Unit = runBlocking {
+        enableCapture()
+        setBootCount(BOOT_ID.toInt())
+        // Plugged again now, but below the last level we recorded — the device discharged in between,
+        // so this is a different plug event.
+        setBattery(plugged = true, percent = 41)
+        val id = insertOpenSession(lastPercent = 50)
+
+        startRecorder()
+        awaitSealed(id)
+    }
+
+    @Test
+    fun `a reboot seals the session rather than splicing two boots' clocks`(): Unit = runBlocking {
+        enableCapture()
+        setBootCount(9)
+        setBattery(plugged = true, percent = 55)
+        val id = insertOpenSession(bootId = 8)
+
+        startRecorder()
+        awaitSealed(id)
+
+        database.statsDao().sessionById(id)?.endReason shouldBe StatsSealReason.REBOOT.name
+    }
+
+    @Test
+    fun `an unreported boot count never resumes, because the sentinel equals itself across boots`(): Unit = runBlocking {
+        enableCapture()
+        // BOOT_COUNT deliberately unset → BootIdSource.UNAVAILABLE on both the row and the probe.
+        setBattery(plugged = true, percent = 55)
+        val id = insertOpenSession(bootId = BootIdSource.UNAVAILABLE)
+
+        startRecorder()
+        awaitSealed(id)
+    }
+
+    @Test
+    fun `an open row with no last-capture stamp is still reconciled`(): Unit = runBlocking {
+        // The stamp is written *after* the session row is committed, so a process death in between
+        // leaves an open row with no stamp. Gating reconciliation on the stamp alone would strand that
+        // row open forever and let the next tick open a second one alongside it.
+        enableCapture(stamped = false)
+        setBootCount(BOOT_ID.toInt())
+        setBattery(plugged = true, percent = 55)
+        val id = insertOpenSession()
+
+        startRecorder()
+        awaitResumed(id)
+
+        database.statsDao().openSessions().map { it.id } shouldBe listOf(id)
+    }
+
+    @Test
+    fun `capture disabled at startup seals without resuming`(): Unit = runBlocking {
+        // Reachable for real: the capture preference is written before the recorder's disable command
+        // is enqueued, so a crash in between leaves durable-off with a row still open. No tick will
+        // ever arrive to advance a resumed row.
+        enableCapture(enabled = false)
+        setBootCount(BOOT_ID.toInt())
+        setBattery(plugged = true, percent = 55)
+        val id = insertOpenSession()
+
+        startRecorder()
+        awaitSealed(id)
+    }
+
+    @Test
+    fun `with several open rows only the newest is resumed and the rest are sealed`(): Unit = runBlocking {
+        enableCapture()
+        setBootCount(BOOT_ID.toInt())
+        setBattery(plugged = true, percent = 55)
+        val older = insertOpenSession(startWall = WALL_START)
+        val newer = insertOpenSession(startWall = WALL_START + 60_000)
+
+        startRecorder()
+        awaitResumed(newer)
+        awaitSealed(older)
+
+        database.statsDao().openSessions().map { it.id } shouldBe listOf(newer)
+    }
+
+    @Test
+    fun `the first tick after a resume appends to the same row`(): Unit = runBlocking {
+        enableCapture()
+        setBootCount(BOOT_ID.toInt())
+        setBattery(plugged = true, percent = 55)
+        val id = insertOpenSession()
+
+        val recorder = startRecorder()
+        awaitResumed(id)
+
+        recorder.offer(
+            RawStatsTick(
+                plugged = true,
+                percent = 56,
+                batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+                sessionActive = false,
+                batteryIntent = null,
+                observedElapsedRealtimeMillis = 60_000,
+                wallMillis = WALL_START + 60_000,
+            ),
+        )
+        await { database.statsDao().sessionById(id)?.runningLastPercent == 56 }
+
+        // Appended, not reopened: still one session, and it is still the original row.
+        database.statsDao().openSessions().map { it.id } shouldBe listOf(id)
+        database.statsDao().sessionById(id)?.startedAtWallMillis shouldBe WALL_START
+    }
+
+    private companion object {
+        const val BOOT_ID = 7L
+        const val WALL_START = 1_000L
+        const val AWAIT_TIMEOUT_MILLIS = 10_000L
+    }
+}

--- a/app/src/test/java/eu/darken/amply/stats/core/ChargeStatsRepositoryLiveTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/ChargeStatsRepositoryLiveTest.kt
@@ -1,6 +1,8 @@
 package eu.darken.amply.stats.core
 
 import android.content.Context
+import android.provider.Settings
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.battery.core.BatteryReader
@@ -10,7 +12,10 @@ import eu.darken.amply.stats.core.db.ChargeSessionEntity
 import eu.darken.amply.stats.core.db.StatsDatabase
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.first
@@ -20,10 +25,13 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.io.File
 
 /**
  * The live-detail read paths against an in-memory Room instance: [ChargeStatsRepository.curveFlow]
@@ -35,8 +43,12 @@ import org.robolectric.annotation.Config
 @Config(sdk = [34])
 class ChargeStatsRepositoryLiveTest {
 
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
     private lateinit var database: StatsDatabase
     private lateinit var repository: ChargeStatsRepository
+    private lateinit var dataStoreScope: CoroutineScope
 
     @Before
     fun setup() {
@@ -44,12 +56,22 @@ class ChargeStatsRepositoryLiveTest {
         database = Room.inMemoryDatabaseBuilder(context, StatsDatabase::class.java)
             .allowMainThreadQueries()
             .build()
+        // Own temp file per test, matching the project's other DataStore tests. A DataStore over the
+        // app's real path would be shared with every other Robolectric class in the same JVM.
+        dataStoreScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         val bootIdSource = BootIdSource(context)
         val recorder = ChargeStatsRecorder(
             database = { database },
-            preferences = StatsPreferences(AppDataStore(context)),
+            preferences = StatsPreferences(
+                AppDataStore(
+                    PreferenceDataStoreFactory.create(scope = dataStoreScope) {
+                        File(tempFolder.root, "stats-${System.nanoTime()}.preferences_pb")
+                    },
+                ),
+            ),
             bootIdSource = bootIdSource,
             batteryReader = BatteryReader(context),
+            dispatcher = Dispatchers.IO,
         )
         repository = ChargeStatsRepository(
             database = { database },
@@ -60,6 +82,7 @@ class ChargeStatsRepositoryLiveTest {
 
     @After
     fun teardown() {
+        dataStoreScope.cancel()
         database.close()
     }
 
@@ -117,5 +140,38 @@ class ChargeStatsRepositoryLiveTest {
 
         database.statsDao().deleteSession(id)
         repository.session(id).first().shouldBeNull()
+    }
+
+    @Test
+    fun `current session flow reports a partial flip on the same row`() = runBlocking {
+        // Resuming a session after a process restart flips `partial` in place. Keying the flow on the
+        // row id alone would suppress that forever for an already-subscribed collector, because the
+        // row is captured inside flatMapLatest — the dashboard would keep rendering the stale copy.
+        Settings.Global.putInt(
+            ApplicationProvider.getApplicationContext<Context>().contentResolver,
+            Settings.Global.BOOT_COUNT,
+            7,
+        )
+        val id = insertOpenSession()
+        database.statsDao().insertSample(sample(id, elapsed = 1_000L, percent = 40))
+
+        val emissions = Channel<Boolean?>(Channel.UNLIMITED)
+        val collector = launch(Dispatchers.IO) {
+            repository.currentSession().collect { emissions.send(it?.partial) }
+        }
+        try {
+            withTimeout(10_000L) {
+                while (emissions.receive() != false) {
+                    // Await the initial non-partial state before flipping it.
+                }
+                val row = database.statsDao().sessionById(id)!!
+                database.statsDao().updateSession(row.copy(partial = true))
+                while (emissions.receive() != true) {
+                    // Await the flip on the SAME subscription.
+                }
+            }
+        } finally {
+            collector.cancelAndJoin()
+        }
     }
 }

--- a/app/src/test/java/eu/darken/amply/stats/core/StatsSessionEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/StatsSessionEngineTest.kt
@@ -248,4 +248,134 @@ class StatsSessionEngineTest {
         s = StatsSessionEngine.fold(s, sample(elapsed = 3_600_000, power = 1000))
         s.runningPowerWeightedDurationMillis shouldBe StatsSessionEngine.MAX_WEIGHT_GAP_MILLIS
     }
+
+    // --- evaluateResume: reconciling a session left open by a process death ---
+
+    /** An open row as it would be found at process start: opened at t=0, last seen at t=30s at 50%. */
+    private fun openRow(
+        bootId: Long = 1,
+        lastElapsed: Long? = 30_000,
+        lastPercent: Int? = 50,
+        partial: Boolean = false,
+        ended: Long? = null,
+    ) = StatsSessionEngine.open(sample(elapsed = 0, percent = 40, power = 1000, temp = 250), partial = partial)
+        .copy(
+            id = 7,
+            bootId = bootId,
+            endedAtWallMillis = ended,
+            runningLastElapsedRealtimeMillis = lastElapsed,
+            runningLastPercent = lastPercent,
+        )
+
+    private fun probe(
+        elapsed: Long = 60_000,
+        bootId: Long = 1,
+        plugged: Boolean = true,
+        percent: Int? = 55,
+    ) = ResumeProbe(
+        elapsedRealtimeMillis = elapsed,
+        bootId = bootId,
+        plugged = plugged,
+        percent = percent,
+    )
+
+    private fun rejectReason(decision: ResumeDecision) = (decision as ResumeDecision.Reject).reason
+
+    private fun resumed(decision: ResumeDecision) = (decision as ResumeDecision.Resume).session
+
+    @Test
+    fun `still plugged on the same boot at an equal or higher level resumes`() {
+        listOf(50, 55, 100).forEach { level ->
+            val decision = StatsSessionEngine.evaluateResume(openRow(), probe(percent = level))
+            resumed(decision).id shouldBe 7
+        }
+    }
+
+    @Test
+    fun `a resumed session keeps its start, so the card still shows the real plug-in time`() {
+        val row = openRow()
+        val session = resumed(StatsSessionEngine.evaluateResume(row, probe()))
+        session.startedAtWallMillis shouldBe row.startedAtWallMillis
+        session.startedElapsedRealtimeMillis shouldBe row.startedElapsedRealtimeMillis
+        session.startPercent shouldBe row.startPercent
+        session.runningSampleCount shouldBe row.runningSampleCount
+        session.runningPowerWeightedSum shouldBe row.runningPowerWeightedSum
+    }
+
+    @Test
+    fun `a resumed session is always partial - the gap is inferred, not observed`() {
+        resumed(StatsSessionEngine.evaluateResume(openRow(), probe())).partial shouldBe true
+    }
+
+    @Test
+    fun `resuming drops the last readings so the unobserved gap is never credited`() {
+        val row = openRow()
+        val session = resumed(StatsSessionEngine.evaluateResume(row, probe()))
+        session.runningLastPowerMilliwatts shouldBe null
+        session.runningLastTemperatureTenthsC shouldBe null
+
+        // Folding the first post-restart sample credits nothing for the dead-process gap...
+        val tick = sample(elapsed = 60_000, power = 2000, temp = 300)
+        val folded = StatsSessionEngine.fold(session, tick)
+        folded.runningPowerWeightedDurationMillis shouldBe 0
+        folded.runningTemperatureWeightedDurationMillis shouldBe 0
+
+        // ...whereas folding the row as-found would invent 30s of pre-death power/temperature across
+        // a window nothing observed. That is the difference the null-out buys.
+        val naive = StatsSessionEngine.fold(row, tick)
+        naive.runningPowerWeightedDurationMillis shouldBe 30_000
+        naive.runningPowerWeightedSum shouldBe 1000.0 * 30_000
+    }
+
+    @Test
+    fun `an unplugged probe refuses - the charge that was running has ended`() {
+        rejectReason(StatsSessionEngine.evaluateResume(openRow(), probe(plugged = false))) shouldBe
+            ResumeDecision.Reason.UNPLUGGED
+    }
+
+    @Test
+    fun `a different boot refuses`() {
+        rejectReason(StatsSessionEngine.evaluateResume(openRow(bootId = 1), probe(bootId = 2))) shouldBe
+            ResumeDecision.Reason.BOOT_MISMATCH
+    }
+
+    @Test
+    fun `an unknown boot id refuses even though the sentinel compares equal to itself`() {
+        val unknown = BootIdSource.UNAVAILABLE
+        // Both sides carry the sentinel, so an equality check alone would wave a real reboot through
+        // and splice two boots' elapsed-realtime readings into one bogus duration.
+        rejectReason(StatsSessionEngine.evaluateResume(openRow(bootId = unknown), probe(bootId = unknown))) shouldBe
+            ResumeDecision.Reason.BOOT_UNKNOWN
+    }
+
+    @Test
+    fun `a probe older than the last recorded sample refuses`() {
+        rejectReason(StatsSessionEngine.evaluateResume(openRow(lastElapsed = 30_000), probe(elapsed = 10_000))) shouldBe
+            ResumeDecision.Reason.TIME_WENT_BACKWARDS
+    }
+
+    @Test
+    fun `a dropped level refuses - the device discharged while we were gone`() {
+        rejectReason(StatsSessionEngine.evaluateResume(openRow(lastPercent = 50), probe(percent = 49))) shouldBe
+            ResumeDecision.Reason.LEVEL_DROPPED
+    }
+
+    @Test
+    fun `an absent level on either side is not treated as a drop`() {
+        resumed(StatsSessionEngine.evaluateResume(openRow(lastPercent = null), probe(percent = 10))).id shouldBe 7
+        resumed(StatsSessionEngine.evaluateResume(openRow(lastPercent = 90), probe(percent = null))).id shouldBe 7
+    }
+
+    @Test
+    fun `an already-sealed row is never resumed`() {
+        rejectReason(StatsSessionEngine.evaluateResume(openRow(ended = 99_000), probe())) shouldBe
+            ResumeDecision.Reason.CLOSED
+    }
+
+    @Test
+    fun `a row with no recorded sample falls back to its start time for the ordering check`() {
+        rejectReason(StatsSessionEngine.evaluateResume(openRow(lastElapsed = null), probe(elapsed = -1))) shouldBe
+            ResumeDecision.Reason.TIME_WENT_BACKWARDS
+        resumed(StatsSessionEngine.evaluateResume(openRow(lastElapsed = null), probe(elapsed = 0))).id shouldBe 7
+    }
 }

--- a/app/src/test/java/eu/darken/amply/stats/ui/StatsCardPresentationTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/ui/StatsCardPresentationTest.kt
@@ -93,6 +93,15 @@ class StatsCardPresentationTest {
     }
 
     @Test
+    fun `a failed start never claims live, even with an open row`() {
+        // A row the recorder resumed after a process restart stays open indefinitely by design. If the
+        // service then can't start, no ticks arrive and that row is frozen — showing it as live would
+        // present stale numbers as current AND hide the retry that could fix it.
+        StatsCardPresentation.from(stats(live = liveSession, startFailed = true), plugged) shouldBe
+            StatsCardPresentation.ConnectedWithoutSession(battery = plugged, startFailed = true)
+    }
+
+    @Test
     fun `stale open row never claims live while unplugged`() {
         StatsCardPresentation.from(stats(live = liveSession, last = lastSession, count = 3), unplugged) shouldBe
             StatsCardPresentation.Idle(lastSession = lastSession, sessionCount = 3)


### PR DESCRIPTION
## What changed

If Amply's process was killed while your phone was still on the charger — a force stop, an app
update, or an aggressive OEM task killer — the "current charging session" card lost track of when
the charge actually began. On reopening the app, it showed "Since &lt;the moment you reopened it&gt;"
and the elapsed time started from zero, and the charge was split into two entries in the history.

The session now survives that. When the app comes back and the evidence says the same charge is
still running, it picks up the existing session: the real plug-in time, the starting percentage, and
one history entry for one charge.

Where it can't tell, it doesn't guess. If the charger was pulled in the meantime, or the battery
level dropped, or the phone rebooted, the old session is closed and a new one starts — the same as
before.

One honest limitation: if you unplug and replug at the same battery level while the app isn't
running, nothing observed the gap, so the two charges are counted as one. Sessions restored this way
are marked as partial, because the recorded curve has a hole in it.

## Technical Context

**Root cause.** Startup repair sealed every open session row unconditionally, with an explicit
"never resumes" rationale. The next battery tick then had no open session and opened a fresh one
stamped with the current wall time — hence the wrong "Since" and the duplicate row.

There is no platform source for the plug-in timestamp (`ACTION_BATTERY_CHANGED` carries none, the
`BatteryManager` properties are all instantaneous, no portable sysfs node). `dumpsys batterystats`
history has `+plugged` entries, but it needs `DUMP`, its format is device- and version-dependent, and
it is reset by the platform — and routing it through the Shizuku service would mean widening a typed
boundary that today only does settings get/put. Not worth it: the data was already in `stats.db`.

**Why the probe runs in startup repair.** The decision needs current battery state, which the first
watcher tick would also provide — but a row held open while waiting for that tick renders as a live
session, and the card prefers `Live` over the "couldn't start capture" retry. A failed foreground
start would then show a frozen card with no way out. Resolving synchronously costs one sticky
broadcast read and leaves the sampling path untouched.

**Why a wrong merge is cheap.** Resuming nulls the last power/temperature readings, so the interval
crediting skips the unobserved gap entirely instead of extrapolating up to 10 minutes of pre-death
values across it. The cost of a false merge is bounded to an over-long duration, never fabricated
averages.

**Also fixed here, all reachable before this change:**

- The boot-count sentinel (`-1`, for devices that don't report `BOOT_COUNT`) compares equal across
  two *different* boots. Left as a plain id it would have allowed a resume across a reboot, splicing
  two boots' `elapsedRealtime` readings into one nonsensical duration. It is now explicitly
  disqualifying.
- The live-session flow keyed `distinctUntilChangedBy` on the row id alone while capturing the row
  inside `flatMapLatest`, so a field change on the same row was suppressed for the lifetime of the
  subscription — the resumed-session flag would never have reached the card.
- The stats card preferred a live session whenever a row existed, ignoring a failed capture start.
  Since resumed rows stay open by design, that would have meant a permanently frozen card.
- The last-capture stamp is written *after* the session row is committed, so a process death between
  the two left an open row that startup repair skipped entirely — stranding it and letting the next
  tick open a second row alongside it.

**Review guidance.** The decision itself is a pure function (`evaluateResume`) with a sealed
result, unit-tested against each rejection reason; the orchestration around it is covered by a new
Robolectric test over in-memory Room. `ChargeStatsRecorder` gains an injected dispatcher — the first
in this codebase, deliberately qualified and scoped to the stats feature rather than introduced as an
app-wide binding — purely so that test can drive its command loop.

Unrelated but worth knowing: every stats test class was building a DataStore over the app's real file
path, so adding a class made pre-existing tests fail in a full-suite run. They now use per-test
temp-file DataStores, matching what the other DataStore tests already did.

## Testing

585 unit tests across both flavors, `lintVitalFossRelease`, and both debug assembles are green.

Device pass on a Pixel 8 (Android API 37), driving plug state with `dumpsys battery`:

| Scenario | Result |
|---|---|
| Resume across a force stop | Start time preserved, single row, no duplicate |
| Charger pulled during the gap | Rejected, session sealed |
| Battery level dropped during the gap | Rejected, session sealed |
| Real reboot | Rejected on boot mismatch, sealed as a reboot |

Two paths were not exercised on device — capture being disabled at startup, and a refused foreground
start — because neither race can be staged through adb. Both are covered by unit tests.
