### PR TITLE
Dedupe DataStore reads by porting SD Maid SE's DataStoreValue DSL

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,6 +47,8 @@ Under `app/src/main/java/eu/darken/amply/`:
 - `main/ui` — activity, onboarding, dashboard, settings, setup guide, `tile`, `widget`
 - `diagnostics/core` + `diagnostics/ui` — privileged settings comparison and its guided UI
 - `common` — shared DataStore owner (`AppDataStore`) and cross-feature primitives
+- `common/datastore` — the `createValue()` settings DSL every preference facade is built on (`DataStoreValue`)
+- `common/serialization` — the single `Json` plus `ChargePolicySerializer`, for JSON-backed setting records
 - `common/theming` — brand, Material You, mode, contrast preferences
 - `common/settings` — reusable hierarchical settings rows/sections
 - `common/debug/logging` — opt-in debug sessions and logging backends

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -27,7 +27,10 @@ eu.darken.amply
     └── debug/logging        Logging fan-out + backends (Logcat, File)
 ```
 
-Feature-specific preference facades live with their owning feature but share the one `AppDataStore` instance.
+Feature-specific preference facades live with their owning feature but share the one `AppDataStore` instance. They
+declare their settings with the `createValue()` DSL (`common/datastore`) rather than touching `store.data` — with a
+single shared store, every write reaches every collector, so the deduplication has to live in the primitive. See
+`code-style.md`.
 
 ## Data Flow
 

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -106,7 +106,29 @@ Debug logs stay **local**: the file logger records only after explicit consent, 
 
 - Reactive with Kotlin Flow / StateFlow.
 - **Preferences DataStore** via the single `AppDataStore` (`common/AppDataStore.kt`) — `preferencesDataStore(name = "amply")`.
-  This is the raw AndroidX Preferences API (read/write `Preferences.Key`s through `store.data` / `store.edit`); there
-  is no custom `createValue()` typed-setting DSL. Feature preference facades wrap `AppDataStore` but all share the one
-  process-safe instance — do not create a second `DataStore`.
+  Feature preference facades wrap `AppDataStore` but all share the one process-safe instance — do not create a second
+  `DataStore`.
+- **Never read `store.data` directly in a facade.** Declare settings with the `createValue()` DSL in
+  `common/datastore/` (ported from SD Maid SE). Because there is exactly one shared store, Preferences DataStore hands
+  the *entire* snapshot to *every* collector on *any* write — an unrelated key's write would otherwise re-emit every
+  setting in the app, restarting downstream `flatMapLatest` chains and rebuilding whole UI states. `DataStoreValue`
+  dedupes on the **raw stored value, before the reader runs**, so the guard cannot be forgotten per-facade and never
+  depends on a domain type's `equals`. (This is not hypothetical: an undeduplicated `captureEnabled` made the
+  dashboard's charging card flash its loading state on every stats-recorder tick.)
+
+  ```kotlin
+  val captureEnabled = dataStore.createValue("stats.capture_enabled", false)   // scalar
+  val session = dataStore.createValue<ChargeSessionRecord?>("session.v2", null, json, fallbackToDefault = true)
+  ```
+
+  Read with `.value()` / collect `.flow`; write with `.value(x)` or `.update { }` (read-modify-write in one
+  transaction). Settings consumed **as a unit** — a session and its provenance, the alarm config — are one
+  `@Serializable` record under one key, so a partially-written state cannot exist. Independent scalars stay separate,
+  so a hot-path write doesn't wake unrelated collectors.
+- **Persisted records are a stored wire format.** Give every persisted property and enum constant an explicit
+  `@SerialName` and a default, and never reuse a key name for a different type (Preferences keys compare by name).
+  `fallbackToDefault` is chosen **per record**: fine where the decode is already all-or-nothing (an unreadable session
+  is no session) or cosmetic, but a record whose fields degrade *independently* — `ChargingPreferences` — must
+  validate field by field, or one bad field silently resets a user's real protective baseline to the default.
+  `StoredRecordFormatTest` pins the JSON.
 - Debug builds attach extra logging; the file logger requires explicit user consent before recording.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
     id("projectConfig")
     id("com.android.application")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("org.jetbrains.kotlin.plugin.serialization")
     id("com.google.devtools.ksp")
     id("com.google.dagger.hilt.android")
     id("com.android.compose.screenshot")
@@ -193,6 +194,7 @@ tasks.withType<KotlinCompile>().configureEach {
         jvmTarget.set(JvmTarget.JVM_17)
         freeCompilerArgs.addAll(
             "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+            "-opt-in=kotlinx.serialization.ExperimentalSerializationApi",
             "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
             "-Xannotation-default-target=param-property",
         )

--- a/app/src/main/java/eu/darken/amply/alarm/core/ChargeAlarmStore.kt
+++ b/app/src/main/java/eu/darken/amply/alarm/core/ChargeAlarmStore.kt
@@ -1,21 +1,23 @@
 package eu.darken.amply.alarm.core
 
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.intPreferencesKey
 import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.datastore.createValue
+import eu.darken.amply.common.datastore.value
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.math.roundToInt
 
-/** User-facing charge-alarm configuration, derived from a single DataStore snapshot. */
+/** User-facing charge-alarm configuration, persisted as one record. */
+@Serializable
 data class ChargeAlarmConfig(
-    val enabled: Boolean = false,
-    val targetPercent: Int = DEFAULT_TARGET_PERCENT,
+    @SerialName("enabled") val enabled: Boolean = false,
+    @SerialName("targetPercent") val targetPercent: Int = DEFAULT_TARGET_PERCENT,
 ) {
     companion object {
         const val DEFAULT_TARGET_PERCENT = 80
@@ -27,43 +29,56 @@ data class ChargeAlarmConfig(
 
 /**
  * DataStore facade for the charge alarm, sharing the single [AppDataStore]. Exposes the config as
- * one flow (mapped from a single snapshot, so `enabled` and `targetPercent` never transiently
- * disagree) plus the durable "fired this plug cycle" latch that makes the alarm fire at most once
+ * one record — `enabled` and `targetPercent` live under a single key, so they can never transiently
+ * disagree — plus the durable "fired this plug cycle" latch that makes the alarm fire at most once
  * per charge even across process death.
+ *
+ * The latch is a separate value on purpose: it is written by the watcher on a completely different
+ * cadence than the user's config, and folding it into the record would wake every config collector
+ * each time the alarm fires or resets.
  */
 @Singleton
 class ChargeAlarmStore @Inject constructor(
-    private val dataStore: AppDataStore,
+    dataStore: AppDataStore,
+    json: Json,
 ) {
-    val config: Flow<ChargeAlarmConfig> = dataStore.store.data.map(::toConfig)
+    private val configValue = dataStore.createValue(
+        key = "alarm.config.v2",
+        defaultValue = ChargeAlarmConfig(),
+        json = json,
+        fallbackToDefault = true,
+    )
 
-    suspend fun configNow(): ChargeAlarmConfig = config.first()
+    private val firedCycleValue = dataStore.createValue("alarm.fired_cycle.v2", false)
+
+    /**
+     * Normalized on the way out — the setter snaps too, but a hand-edited or future-written record
+     * could still carry an off-step target and the UI's stepper assumes a valid tick.
+     *
+     * Deduped *again* after normalizing, because snapping is many-to-one: a stored 83 and a
+     * subsequent explicit 85 are two distinct raw records that both normalize to 85, so the upstream
+     * raw-value dedupe cannot catch the duplicate.
+     */
+    val config: Flow<ChargeAlarmConfig> = configValue.flow.map(::normalize).distinctUntilChanged()
+
+    suspend fun configNow(): ChargeAlarmConfig = normalize(configValue.value())
 
     suspend fun setEnabled(enabled: Boolean) {
-        dataStore.store.edit { it[ENABLED] = enabled }
+        configValue.update { it.copy(enabled = enabled) }
     }
 
     suspend fun setTargetPercent(percent: Int) {
-        dataStore.store.edit { it[TARGET_PERCENT] = normalizeTarget(percent) }
+        configValue.update { it.copy(targetPercent = normalizeTarget(percent)) }
     }
 
     /** Whether the alarm has already fired (or been suppressed) for the current plug cycle. */
-    suspend fun firedCycle(): Boolean = dataStore.store.data.first()[FIRED_CYCLE] ?: false
+    suspend fun firedCycle(): Boolean = firedCycleValue.value()
 
     suspend fun setFiredCycle(fired: Boolean) {
-        dataStore.store.edit { it[FIRED_CYCLE] = fired }
+        firedCycleValue.value(fired)
     }
 
-    private fun toConfig(prefs: Preferences) = ChargeAlarmConfig(
-        enabled = prefs[ENABLED] ?: false,
-        targetPercent = normalizeTarget(prefs[TARGET_PERCENT] ?: ChargeAlarmConfig.DEFAULT_TARGET_PERCENT),
-    )
-
-    private companion object {
-        val ENABLED = booleanPreferencesKey("alarm.enabled")
-        val TARGET_PERCENT = intPreferencesKey("alarm.target_percent")
-        val FIRED_CYCLE = booleanPreferencesKey("alarm.fired_cycle")
-    }
+    private fun normalize(raw: ChargeAlarmConfig) = raw.copy(targetPercent = normalizeTarget(raw.targetPercent))
 }
 
 /** Snap to the nearest [ChargeAlarmConfig.TARGET_STEP] and clamp to the allowed range. */

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingPreferences.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingPreferences.kt
@@ -1,31 +1,90 @@
 package eu.darken.amply.charging.core
 
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.datastore.createValue
+import eu.darken.amply.common.datastore.value
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * The stored form of Amply's policy bookkeeping.
+ *
+ * Policies are held as **raw [ChargePolicy.stableId] strings**, not as decoded `ChargePolicy`s,
+ * because these four facts degrade *independently*: an unreadable `lastRequested` must still leave a
+ * perfectly good `protective` baseline intact. Losing that baseline is not cosmetic — it is the
+ * limit Amply restores the battery to, so a wholesale fallback would quietly downgrade a user's
+ * Adaptive or 90 % choice to the 80 % default, and the next write would persist the downgrade.
+ *
+ * Which is why decoding goes through [decodePolicyState] field by field instead of
+ * `decodeFromString`: a typed whole-record decode fails on the *first* bad field and takes the other
+ * three with it, so `{"lastRequestedAt":"bad", "protective":"fixed:90"}` would lose a valid 90 %.
+ */
+@Serializable
+internal data class PolicyState(
+    @SerialName("lastRequested") val lastRequested: String? = null,
+    @SerialName("lastRequestedAt") val lastRequestedAt: Long = 0L,
+    @SerialName("protective") val protective: String? = null,
+    @SerialName("lastPersistent") val lastPersistent: String? = null,
+)
+
+/**
+ * Reads each field on its own terms. A field that is absent, the wrong JSON type, or an unreadable
+ * policy id yields only *that* field's default; only unparseable JSON loses the whole record.
+ */
+internal fun decodePolicyState(raw: String?, json: Json): PolicyState {
+    if (raw == null) return PolicyState()
+    val obj = runCatching { json.parseToJsonElement(raw) as? JsonObject }.getOrNull() ?: return PolicyState()
+    return PolicyState(
+        lastRequested = obj.stringOrNull("lastRequested"),
+        lastRequestedAt = obj.longOrDefault("lastRequestedAt"),
+        protective = obj.stringOrNull("protective"),
+        lastPersistent = obj.stringOrNull("lastPersistent"),
+    )
+}
+
+private fun JsonObject.primitiveOrNull(name: String): JsonPrimitive? =
+    (this[name] as? JsonPrimitive)?.takeUnless { it is JsonNull }
+
+private fun JsonObject.stringOrNull(name: String): String? = primitiveOrNull(name)?.takeIf { it.isString }?.content
+
+private fun JsonObject.longOrDefault(name: String, default: Long = 0L): Long =
+    primitiveOrNull(name)?.takeUnless { it.isString }?.content?.toLongOrNull() ?: default
+
 @Singleton
 class ChargingPreferences @Inject constructor(
-    private val dataStore: AppDataStore,
+    dataStore: AppDataStore,
+    json: Json,
 ) {
-    val lastRequested: Flow<ChargePolicy?> = dataStore.store.data.map {
-        ChargePolicy.fromStableId(it[LAST_REQUESTED])
-    }
+    private val policyState = dataStore.createValue(
+        key = stringPreferencesKey("policy.v2"),
+        reader = { raw -> decodePolicyState(raw as? String, json) },
+        writer = { state -> json.encodeToString(PolicyState.serializer(), state) },
+    )
+
+    // Each projection dedupes on its own: they all ride one record now, so without this a
+    // lastRequestedAt-only write would re-emit every one of them.
+    val lastRequested: Flow<ChargePolicy?> = policyState.flow
+        .map { ChargePolicy.fromStableId(it.lastRequested) }
+        .distinctUntilChanged()
 
     /** Wall-clock time of the last request; paired atomically with [lastRequested]. 0 = never requested. */
-    val lastRequestedAt: Flow<Long> = dataStore.store.data.map { it[LAST_REQUESTED_AT] ?: 0L }
+    val lastRequestedAt: Flow<Long> = policyState.flow
+        .map { it.lastRequestedAt }
+        .distinctUntilChanged()
 
-    val protectivePolicy: Flow<ChargePolicy> = dataStore.store.data.map {
-        ChargePolicy.fromStableId(it[PROTECTIVE_POLICY])?.takeUnless { policy ->
-            policy == ChargePolicy.Unrestricted
-        } ?: ChargePolicy.FixedLimit(80)
-    }
+    val protectivePolicy: Flow<ChargePolicy> = policyState.flow
+        .map { it.protectivePolicy() }
+        .distinctUntilChanged()
 
     /**
      * The last policy Amply successfully applied as a *persistent* configuration — including
@@ -33,37 +92,43 @@ class ChargingPreferences @Inject constructor(
      * update this, so it answers "what did the user configure through Amply" without a session's
      * transient Unrestricted write polluting the answer. Null until Amply's first persistent write.
      */
-    val lastPersistentPolicy: Flow<ChargePolicy?> = dataStore.store.data.map {
-        ChargePolicy.fromStableId(it[LAST_PERSISTENT_POLICY])
-    }
+    val lastPersistentPolicy: Flow<ChargePolicy?> = policyState.flow
+        .map { ChargePolicy.fromStableId(it.lastPersistent) }
+        .distinctUntilChanged()
 
     suspend fun recordRequested(
         policy: ChargePolicy,
         persistent: Boolean,
         nowMillis: Long = System.currentTimeMillis(),
     ) {
-        dataStore.store.edit {
-            it[LAST_REQUESTED] = policy.stableId
-            it[LAST_REQUESTED_AT] = nowMillis
-            if (persistent) {
-                it[LAST_PERSISTENT_POLICY] = policy.stableId
-                if (policy != ChargePolicy.Unrestricted) it[PROTECTIVE_POLICY] = policy.stableId
-            }
+        policyState.update { current ->
+            current.copy(
+                lastRequested = policy.stableId,
+                lastRequestedAt = nowMillis,
+                lastPersistent = if (persistent) policy.stableId else current.lastPersistent,
+                protective = if (persistent && policy != ChargePolicy.Unrestricted) {
+                    policy.stableId
+                } else {
+                    current.protective
+                },
+            )
         }
     }
 
-    suspend fun lastRequestedNow(): ChargePolicy? = lastRequested.first()
+    suspend fun lastRequestedNow(): ChargePolicy? = ChargePolicy.fromStableId(policyState.value().lastRequested)
 
-    suspend fun lastRequestedAtNow(): Long = lastRequestedAt.first()
+    suspend fun lastRequestedAtNow(): Long = policyState.value().lastRequestedAt
 
-    suspend fun protectivePolicyNow(): ChargePolicy = protectivePolicy.first()
+    suspend fun protectivePolicyNow(): ChargePolicy = policyState.value().protectivePolicy()
 
-    suspend fun lastPersistentPolicyNow(): ChargePolicy? = lastPersistentPolicy.first()
-
-    private companion object {
-        val LAST_REQUESTED = stringPreferencesKey("policy.last_requested")
-        val LAST_REQUESTED_AT = longPreferencesKey("policy.last_requested_at")
-        val PROTECTIVE_POLICY = stringPreferencesKey("policy.protective")
-        val LAST_PERSISTENT_POLICY = stringPreferencesKey("policy.last_persistent")
-    }
+    suspend fun lastPersistentPolicyNow(): ChargePolicy? =
+        ChargePolicy.fromStableId(policyState.value().lastPersistent)
 }
+
+/**
+ * Unrestricted is never a protective baseline, and neither is an unreadable value — both fall back to
+ * the 80 % limit rather than leaving the battery uncapped.
+ */
+private fun PolicyState.protectivePolicy(): ChargePolicy =
+    ChargePolicy.fromStableId(protective)?.takeUnless { it == ChargePolicy.Unrestricted }
+        ?: ChargePolicy.FixedLimit(80)

--- a/app/src/main/java/eu/darken/amply/charging/core/access/AutoWssGrantCoordinator.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/access/AutoWssGrantCoordinator.kt
@@ -49,7 +49,7 @@ class AutoWssGrantCoordinator @Inject constructor(
         if (!started.compareAndSet(false, true)) return
         scope.launch {
             observeAutoWssGrant(
-                inputs = autoWssGrantInputs(repository.state, onboardingSettings.isComplete),
+                inputs = autoWssGrantInputs(repository.state, onboardingSettings.isComplete.flow),
                 grantScope = scope,
             ) {
                 // The repository single-flights this call, so a concurrent manual tap or an overlapping

--- a/app/src/main/java/eu/darken/amply/common/datastore/DataStoreValue.kt
+++ b/app/src/main/java/eu/darken/amply/common/datastore/DataStoreValue.kt
@@ -1,0 +1,122 @@
+package eu.darken.amply.common.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import eu.darken.amply.common.AppDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+/**
+ * One persisted setting, backed by a single [Preferences.Key].
+ *
+ * Amply keeps **one** process-wide [AppDataStore], and Preferences DataStore hands the *entire*
+ * snapshot to every collector whenever any key changes. Without a guard, an unrelated write — the
+ * stats recorder stamping its last-capture timestamp every ~20s, say — re-emits every setting in the
+ * app, restarting downstream `flatMapLatest` chains and rebuilding whole UI states. That is a real
+ * user-visible defect, not just waste: it made the dashboard's charging card flash its loading state
+ * on every recorder tick.
+ *
+ * So the dedupe lives *here*, in the primitive, rather than at each call site — a facade cannot
+ * forget it. It runs on the **raw stored value, before [reader]**, which matters twice over: the
+ * comparison never depends on a domain type's `equals` (a type with identity equality would silently
+ * never dedupe), and no decoding work happens for a duplicate emission.
+ *
+ * Ported from SD Maid SE's `DataStoreValue`.
+ */
+class DataStoreValue<T : Any?>(
+    private val dataStore: DataStore<Preferences>,
+    private val key: Preferences.Key<*>,
+    val reader: (Any?) -> T,
+    val writer: (T) -> Any?,
+) {
+    val keyName: String
+        get() = key.name
+
+    val flow: Flow<T> = dataStore.data
+        .map { prefs -> prefs[this.key] }
+        .distinctUntilChanged()
+        .map { raw -> reader(raw) }
+
+    data class Updated<T>(
+        val old: T,
+        val new: T,
+    )
+
+    /**
+     * Read-modify-write in a single transaction, returning both sides. Returning `null` from [update]
+     * clears the key.
+     */
+    @Suppress("UNCHECKED_CAST")
+    suspend fun update(update: (T) -> T?): Updated<T> {
+        val values = arrayOfNulls<Any?>(2)
+
+        dataStore.updateData { prefs ->
+            val before = reader(prefs[this.key]).also { values[0] = it }
+            val after: T? = update(before).also { values[1] = it ?: reader(null) }
+
+            prefs.toMutablePreferences().apply {
+                set(this@DataStoreValue.key as Preferences.Key<Any?>, after?.let { writer(it) })
+            }.toPreferences()
+        }
+
+        return Updated(old = values[0] as T, new = values[1] as T)
+    }
+}
+
+fun <T : Any?> AppDataStore.createValue(
+    key: Preferences.Key<*>,
+    reader: (rawValue: Any?) -> T,
+    writer: (value: T) -> Any?,
+) = DataStoreValue(
+    dataStore = store,
+    key = key,
+    reader = reader,
+    writer = writer,
+)
+
+@Suppress("UNCHECKED_CAST")
+inline fun <reified T> basicKey(key: String): Preferences.Key<T> = when (T::class) {
+    Boolean::class -> booleanPreferencesKey(key) as Preferences.Key<T>
+    String::class -> stringPreferencesKey(key) as Preferences.Key<T>
+    Int::class -> intPreferencesKey(key) as Preferences.Key<T>
+    Long::class -> longPreferencesKey(key) as Preferences.Key<T>
+    Float::class -> floatPreferencesKey(key) as Preferences.Key<T>
+    else -> throw NotImplementedError("Unsupported type: ${T::class}")
+}
+
+/**
+ * Reads the raw value, falling back to [defaultValue] when the key is absent **or holds the wrong
+ * type**. A wrong-typed value can only come from a key name that was reused for a different type;
+ * decoding to the default beats throwing, which would kill the collector's flow for good.
+ */
+inline fun <reified T> basicReader(defaultValue: T): (rawValue: Any?) -> T = { rawValue ->
+    (rawValue as? T) ?: defaultValue
+}
+
+inline fun <reified T> basicWriter(): (T) -> Any? = { value ->
+    when (value) {
+        is Boolean, is String, is Int, is Long, is Float -> value
+        null -> null
+        else -> throw NotImplementedError("Unsupported type: ${value::class}")
+    }
+}
+
+inline fun <reified T : Any?> AppDataStore.createValue(
+    key: String,
+    defaultValue: T = null as T,
+) = createValue(
+    key = basicKey<T>(key),
+    reader = basicReader(defaultValue),
+    writer = basicWriter(),
+)
+
+suspend fun <T : Any?> DataStoreValue<T>.value(): T = flow.first()
+
+suspend fun <T : Any?> DataStoreValue<T>.value(value: T) = update { value }

--- a/app/src/main/java/eu/darken/amply/common/datastore/DataStoreValueKotlinx.kt
+++ b/app/src/main/java/eu/darken/amply/common/datastore/DataStoreValueKotlinx.kt
@@ -1,0 +1,72 @@
+package eu.darken.amply.common.datastore
+
+import androidx.datastore.preferences.core.stringPreferencesKey
+import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.debug.logging.Logging
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import kotlin.reflect.typeOf
+
+/**
+ * JSON-backed [DataStoreValue] reader. Used for settings that are read and written as a *unit* — a
+ * charge session and its provenance, the interruption event — so one key holds the whole record and
+ * a partially-written state cannot exist.
+ *
+ * [fallbackToDefault] decides what a corrupt record means, and the choice is per-record, not global:
+ * where the current decode is already all-or-nothing (an unparseable session is no session) falling
+ * back is right, but a record whose fields degrade *independently* must validate field by field
+ * instead — otherwise one bad field silently resets the others to defaults.
+ *
+ * Ported from SD Maid SE's `DataStoreValueKotlinx`.
+ */
+inline fun <reified T> kotlinxReader(
+    json: Json,
+    defaultValue: T,
+    fallbackToDefault: Boolean = false,
+): (Any?) -> T {
+    @Suppress("UNCHECKED_CAST")
+    val serializer = json.serializersModule.serializer(typeOf<T>()) as KSerializer<T>
+    return { rawValue ->
+        // `as?`, not `as`: a key name reused for a non-String type would otherwise throw a
+        // ClassCastException that the catch below does not cover, permanently killing the flow.
+        val stored = rawValue as? String
+        if (stored == null) {
+            defaultValue
+        } else if (fallbackToDefault) {
+            try {
+                json.decodeFromString(serializer, stored) ?: defaultValue
+            } catch (e: SerializationException) {
+                log(KOTLINX_TAG, Logging.Priority.ERROR) { "Failed to parse JSON, using default: ${e.message}" }
+                defaultValue
+            } catch (e: IllegalArgumentException) {
+                log(KOTLINX_TAG, Logging.Priority.ERROR) { "Failed to read JSON, using default: ${e.message}" }
+                defaultValue
+            }
+        } else {
+            json.decodeFromString(serializer, stored)
+        }
+    }
+}
+
+inline fun <reified T> kotlinxWriter(json: Json): (T) -> Any? {
+    @Suppress("UNCHECKED_CAST")
+    val serializer = json.serializersModule.serializer(typeOf<T>()) as KSerializer<T>
+    return { newValue: T -> newValue?.let { json.encodeToString(serializer, it) } }
+}
+
+inline fun <reified T : Any?> AppDataStore.createValue(
+    key: String,
+    defaultValue: T = null as T,
+    json: Json,
+    fallbackToDefault: Boolean = false,
+) = createValue(
+    key = stringPreferencesKey(key),
+    reader = kotlinxReader(json, defaultValue, fallbackToDefault),
+    writer = kotlinxWriter(json),
+)
+
+val KOTLINX_TAG = logTag("DataStore", "Value", "Kotlinx")

--- a/app/src/main/java/eu/darken/amply/common/serialization/ChargePolicySerializer.kt
+++ b/app/src/main/java/eu/darken/amply/common/serialization/ChargePolicySerializer.kt
@@ -1,0 +1,37 @@
+package eu.darken.amply.common.serialization
+
+import eu.darken.amply.charging.core.ChargePolicy
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Persists a [ChargePolicy] as its [ChargePolicy.stableId] string.
+ *
+ * Deliberately reuses the existing stable-id contract rather than introducing a second encoding:
+ * the same strings already travel through service intents, the widget and the tile, so a policy has
+ * exactly one wire representation across the whole app. It also keeps the sealed hierarchy free to
+ * change shape — only [ChargePolicy.fromStableId] defines what is readable.
+ *
+ * An unknown id throws [SerializationException]; the calling record decides whether that means "no
+ * record" (whole-record fallback) or "this one field is unusable" (per-field validation).
+ */
+object ChargePolicySerializer : KSerializer<ChargePolicy> {
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("eu.darken.amply.ChargePolicy", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: ChargePolicy) {
+        encoder.encodeString(value.stableId)
+    }
+
+    override fun deserialize(decoder: Decoder): ChargePolicy {
+        val raw = decoder.decodeString()
+        return ChargePolicy.fromStableId(raw)
+            ?: throw SerializationException("Unknown ChargePolicy stableId: $raw")
+    }
+}

--- a/app/src/main/java/eu/darken/amply/common/serialization/SerializationModule.kt
+++ b/app/src/main/java/eu/darken/amply/common/serialization/SerializationModule.kt
@@ -1,0 +1,30 @@
+package eu.darken.amply.common.serialization
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import javax.inject.Singleton
+
+/**
+ * The single [Json] used for everything Amply persists. There is exactly one, so it needs no
+ * qualifier.
+ *
+ * `ignoreUnknownKeys` lets an older build read a record a newer one wrote. It does **not** cover
+ * renames, which is why every persisted property and enum constant carries an explicit `@SerialName`
+ * — these records are a stored wire format, and a Kotlin-side rename must never silently reset a
+ * user's charge-session or restore state to defaults.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object SerializationModule {
+
+    @Provides
+    @Singleton
+    fun json(): Json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+    }
+}

--- a/app/src/main/java/eu/darken/amply/common/theming/ThemeModels.kt
+++ b/app/src/main/java/eu/darken/amply/common/theming/ThemeModels.kt
@@ -2,27 +2,54 @@ package eu.darken.amply.common.theming
 
 import androidx.annotation.StringRes
 import eu.darken.amply.R
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+/**
+ * Persisted as one JSON record, so the three choices are always read as a consistent set.
+ *
+ * The `@SerialName`s are the stored format — renaming a Kotlin constant must not silently reset a
+ * user's theme to the defaults.
+ */
+@Serializable
 data class ThemeState(
-    val mode: ThemeMode = ThemeMode.SYSTEM,
-    val style: ThemeStyle = ThemeStyle.DEFAULT,
-    val color: ThemeColor = ThemeColor.GREEN,
+    @SerialName("mode") val mode: ThemeMode = ThemeMode.SYSTEM,
+    @SerialName("style") val style: ThemeStyle = ThemeStyle.DEFAULT,
+    @SerialName("color") val color: ThemeColor = ThemeColor.GREEN,
 )
 
+@Serializable
 enum class ThemeMode(@get:StringRes val label: Int) {
+    @SerialName("SYSTEM")
     SYSTEM(R.string.theme_mode_system),
+
+    @SerialName("DARK")
     DARK(R.string.theme_mode_dark),
+
+    @SerialName("LIGHT")
     LIGHT(R.string.theme_mode_light),
 }
 
+@Serializable
 enum class ThemeStyle(@get:StringRes val label: Int) {
+    @SerialName("DEFAULT")
     DEFAULT(R.string.theme_style_default),
+
+    @SerialName("MATERIAL_YOU")
     MATERIAL_YOU(R.string.theme_style_material_you),
+
+    @SerialName("MEDIUM_CONTRAST")
     MEDIUM_CONTRAST(R.string.theme_style_medium_contrast),
+
+    @SerialName("HIGH_CONTRAST")
     HIGH_CONTRAST(R.string.theme_style_high_contrast),
 }
 
+@Serializable
 enum class ThemeColor(@get:StringRes val label: Int) {
+    @SerialName("GREEN")
     GREEN(R.string.theme_color_green),
+
+    @SerialName("BLUE")
     BLUE(R.string.theme_color_blue),
 }

--- a/app/src/main/java/eu/darken/amply/common/theming/ThemeSettings.kt
+++ b/app/src/main/java/eu/darken/amply/common/theming/ThemeSettings.kt
@@ -1,35 +1,34 @@
 package eu.darken.amply.common.theming
 
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringPreferencesKey
 import eu.darken.amply.common.AppDataStore
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import eu.darken.amply.common.datastore.createValue
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class ThemeSettings @Inject constructor(
-    private val dataStore: AppDataStore,
+    dataStore: AppDataStore,
+    json: Json,
 ) {
-    val state: Flow<ThemeState> = dataStore.store.data.map { prefs ->
-        ThemeState(
-            mode = prefs[MODE].toEnumOrDefault(ThemeMode.SYSTEM),
-            style = prefs[STYLE].toEnumOrDefault(ThemeStyle.DEFAULT),
-            color = prefs[COLOR].toEnumOrDefault(ThemeColor.GREEN),
-        )
+    // One record rather than three keys: the three choices are always consumed together, and a
+    // corrupt record falling back to the default theme is purely cosmetic.
+    val state = dataStore.createValue(
+        key = "core.ui.theme.v2",
+        defaultValue = ThemeState(),
+        json = json,
+        fallbackToDefault = true,
+    )
+
+    suspend fun setMode(value: ThemeMode) {
+        state.update { it.copy(mode = value) }
     }
 
-    suspend fun setMode(value: ThemeMode) = dataStore.store.edit { it[MODE] = value.name }
-    suspend fun setStyle(value: ThemeStyle) = dataStore.store.edit { it[STYLE] = value.name }
-    suspend fun setColor(value: ThemeColor) = dataStore.store.edit { it[COLOR] = value.name }
+    suspend fun setStyle(value: ThemeStyle) {
+        state.update { it.copy(style = value) }
+    }
 
-    private inline fun <reified T : Enum<T>> String?.toEnumOrDefault(default: T): T =
-        enumValues<T>().firstOrNull { it.name == this } ?: default
-
-    private companion object {
-        val MODE = stringPreferencesKey("core.ui.theme.mode")
-        val STYLE = stringPreferencesKey("core.ui.theme.style")
-        val COLOR = stringPreferencesKey("core.ui.theme.color")
+    suspend fun setColor(value: ThemeColor) {
+        state.update { it.copy(color = value) }
     }
 }

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/FullChargeStore.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/FullChargeStore.kt
@@ -1,57 +1,99 @@
 package eu.darken.amply.fullcharge.core
 
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.intPreferencesKey
-import androidx.datastore.preferences.core.longPreferencesKey
-import androidx.datastore.preferences.core.stringPreferencesKey
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.common.AppDataStore
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
+import eu.darken.amply.common.datastore.createValue
+import eu.darken.amply.common.datastore.value
+import eu.darken.amply.common.serialization.ChargePolicySerializer
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
  * Provenance of persisted work: which process created it and during which boot. Used to spot work
- * that survived a process death ([token] mismatch) within the same boot ([bootCount] match). A null
- * value marks a legacy record written before provenance existed.
+ * that survived a process death ([token] mismatch) within the same boot ([bootCount] match).
+ *
+ * **Every field carries a default.** Provenance is diagnostic metadata hanging off a record whose
+ * real payload is a charge policy Amply still owes the user. Making any of it required would let a
+ * missing `pid` take the whole record down with it — and a lost record means the restore never
+ * happens and the battery keeps charging unrestricted. A [token]-less record is treated as un-owned
+ * (see [normalizedProvenance]), which is exactly what a missing owner meant before.
  */
+@Serializable
 data class WorkProvenance(
-    val token: String,
-    val pid: Int,
-    val bootCount: Int?,
-    val createdAtMillis: Long,
+    @SerialName("token") val token: String = "",
+    @SerialName("pid") val pid: Int = -1,
+    @SerialName("bootCount") val bootCount: Int? = null,
+    @SerialName("createdAtMillis") val createdAtMillis: Long = 0L,
 )
 
+@Serializable
 data class ChargeSessionRecord(
+    // The one genuinely fatal field: a policy this build cannot read must not be guessed at, so an
+    // unreadable one collapses the record to "no session" — the pre-refactor behaviour.
+    @SerialName("restorePolicy")
+    @Serializable(with = ChargePolicySerializer::class)
     val restorePolicy: ChargePolicy,
-    val startedAtMillis: Long,
-    val connectedSeen: Boolean,
-    val provenance: WorkProvenance? = null,
+    @SerialName("startedAtMillis") val startedAtMillis: Long = 0L,
+    @SerialName("connectedSeen") val connectedSeen: Boolean = false,
+    @SerialName("provenance") val provenance: WorkProvenance? = null,
     /**
      * Stable correlation id for the owed work, generated once at creation and preserved across
      * process-adoption (unlike [WorkProvenance.token], which is re-stamped to the current owner). An
-     * interruption event ties back to this so a later restore can resolve it. Null on legacy records.
+     * interruption event ties back to this so a later restore can resolve it.
      */
-    val workId: String? = null,
+    @SerialName("workId") val workId: String? = null,
 )
 
+/**
+ * The restore Amply still owes after a boot or an interrupted session, held as one record so its
+ * target, correlation id and provenance can never be read as a mismatched set.
+ */
+@Serializable
+data class RecoveryRecord(
+    @SerialName("target")
+    @Serializable(with = ChargePolicySerializer::class)
+    val target: ChargePolicy,
+    @SerialName("workId") val workId: String? = null,
+    @SerialName("provenance") val provenance: WorkProvenance? = null,
+)
+
+/**
+ * Persistence for the temporary full-charge session and the restore it owes.
+ *
+ * The session and the recovery target are each **one** record under one key, so a half-written
+ * restore cannot exist. An unreadable record — including one carrying an unknown policy id — decodes
+ * to null ("no session"), exactly as the previous multi-key decode did when its policy failed to parse.
+ */
 @Singleton
 class FullChargeStore @Inject constructor(
-    private val dataStore: AppDataStore,
+    dataStore: AppDataStore,
+    json: Json,
 ) {
-    val session: Flow<ChargeSessionRecord?> = dataStore.store.data.map(::toRecord)
-    val quickFullChargeEnabled: Flow<Boolean> = dataStore.store.data.map {
-        it[QUICK_FULL_CHARGE_ENABLED] ?: false
-    }
-    val quickFullChargeAnyLevel: Flow<Boolean> = dataStore.store.data.map {
-        it[QUICK_FULL_CHARGE_ANY_LEVEL] ?: false
-    }
+    private val sessionValue = dataStore.createValue<ChargeSessionRecord?>(
+        key = "session.v2",
+        defaultValue = null,
+        json = json,
+        fallbackToDefault = true,
+    )
 
-    suspend fun currentSession(): ChargeSessionRecord? = session.first()
+    private val recoveryValue = dataStore.createValue<RecoveryRecord?>(
+        key = "recovery.v2",
+        defaultValue = null,
+        json = json,
+        fallbackToDefault = true,
+    )
+
+    private val lastSeenBootCountValue = dataStore.createValue<Int?>("recovery.last_seen_boot_count.v2")
+
+    val session = sessionValue.flow.map { it?.normalized() }
+    val quickFullChargeEnabled = dataStore.createValue("fullcharge.quick_replug_enabled.v2", false)
+    val quickFullChargeAnyLevel = dataStore.createValue("fullcharge.quick_replug_any_level.v2", false)
+
+    suspend fun currentSession(): ChargeSessionRecord? = sessionValue.value()?.normalized()
 
     suspend fun startSession(
         restorePolicy: ChargePolicy,
@@ -59,198 +101,91 @@ class FullChargeStore @Inject constructor(
         workId: String? = null,
         provenance: WorkProvenance? = null,
     ) {
-        dataStore.store.edit {
-            it[SESSION_ACTIVE] = true
-            it[SESSION_RESTORE_POLICY] = restorePolicy.stableId
-            it[SESSION_STARTED_AT] = startedAtMillis
-            it[SESSION_CONNECTED] = false
-            workId?.let { id -> it[SESSION_WORK_ID] = id } ?: it.remove(SESSION_WORK_ID)
-            it.writeSessionProvenance(provenance)
+        sessionValue.update {
+            ChargeSessionRecord(
+                restorePolicy = restorePolicy,
+                startedAtMillis = startedAtMillis,
+                connectedSeen = false,
+                provenance = provenance,
+                workId = workId,
+            )
         }
     }
 
     suspend fun markConnected() {
-        dataStore.store.edit { prefs ->
-            if (prefs[SESSION_ACTIVE] == true) prefs[SESSION_CONNECTED] = true
-        }
+        sessionValue.update { it?.copy(connectedSeen = true) }
     }
 
     /** Adopt the current process as the session's owner and flag CONNECTED in a single atomic edit. */
     suspend fun markConnectedAndAdopt(provenance: WorkProvenance) {
-        dataStore.store.edit { prefs ->
-            if (prefs[SESSION_ACTIVE] != true) return@edit
-            prefs[SESSION_CONNECTED] = true
-            prefs.writeSessionProvenance(provenance)
-        }
+        sessionValue.update { it?.copy(connectedSeen = true, provenance = provenance) }
     }
 
     /** Re-stamp the active session's provenance to the current process, if a session is present. */
     suspend fun adoptSessionOwner(provenance: WorkProvenance) {
-        dataStore.store.edit { prefs ->
-            if (prefs[SESSION_ACTIVE] != true) return@edit
-            prefs.writeSessionProvenance(provenance)
-        }
+        sessionValue.update { it?.copy(provenance = provenance) }
     }
 
     suspend fun clearSession() {
-        dataStore.store.edit {
-            it.remove(SESSION_ACTIVE)
-            it.remove(SESSION_RESTORE_POLICY)
-            it.remove(SESSION_STARTED_AT)
-            it.remove(SESSION_CONNECTED)
-            it.remove(SESSION_WORK_ID)
-            it.remove(SESSION_OWNER_TOKEN)
-            it.remove(SESSION_OWNER_PID)
-            it.remove(SESSION_BOOT_COUNT)
-            it.remove(SESSION_OWNER_SET_AT)
-        }
+        sessionValue.update { null }
     }
 
-    suspend fun pendingRecoveryTarget(): ChargePolicy? =
-        dataStore.store.data.first()[RECOVERY_PENDING_TARGET]?.let(ChargePolicy::fromStableId)
+    /**
+     * The whole owed restore in one read. Callers needing more than one of its fields must use this
+     * rather than the single-field accessors below: reading target, work id and provenance
+     * separately can pair fields from either side of a concurrent adopt or clear.
+     */
+    suspend fun currentRecovery(): RecoveryRecord? = recoveryValue.value()?.normalized()
 
-    suspend fun pendingRecoveryProvenance(): WorkProvenance? =
-        dataStore.store.data.first().recoveryProvenance()
+    suspend fun pendingRecoveryTarget(): ChargePolicy? = currentRecovery()?.target
 
-    suspend fun pendingRecoveryWorkId(): String? =
-        dataStore.store.data.first()[RECOVERY_WORK_ID]
+    suspend fun pendingRecoveryProvenance(): WorkProvenance? = currentRecovery()?.provenance
+
+    suspend fun pendingRecoveryWorkId(): String? = currentRecovery()?.workId
 
     suspend fun setPendingRecoveryTarget(
         policy: ChargePolicy,
         workId: String? = null,
         provenance: WorkProvenance? = null,
     ) {
-        dataStore.store.edit {
-            it[RECOVERY_PENDING_TARGET] = policy.stableId
-            workId?.let { id -> it[RECOVERY_WORK_ID] = id } ?: it.remove(RECOVERY_WORK_ID)
-            it.writeRecoveryProvenance(provenance)
-        }
+        recoveryValue.update { RecoveryRecord(target = policy, workId = workId, provenance = provenance) }
     }
 
     /** Re-stamp the pending recovery target's provenance to the current process, if one is present. */
     suspend fun adoptRecoveryOwner(provenance: WorkProvenance) {
-        dataStore.store.edit { prefs ->
-            if (prefs[RECOVERY_PENDING_TARGET] == null) return@edit
-            prefs.writeRecoveryProvenance(provenance)
-        }
+        recoveryValue.update { it?.copy(provenance = provenance) }
     }
 
     suspend fun clearPendingRecoveryTarget() {
-        dataStore.store.edit {
-            it.remove(RECOVERY_PENDING_TARGET)
-            it.remove(RECOVERY_WORK_ID)
-            it.remove(RECOVERY_OWNER_TOKEN)
-            it.remove(RECOVERY_OWNER_PID)
-            it.remove(RECOVERY_BOOT_COUNT)
-            it.remove(RECOVERY_SET_AT)
-        }
+        recoveryValue.update { null }
     }
 
     /** The boot count during which Amply last ran — used to spot re-delivered BOOT_COMPLETED broadcasts. */
-    suspend fun lastSeenBootCount(): Int? = dataStore.store.data.first()[LAST_SEEN_BOOT_COUNT]
+    suspend fun lastSeenBootCount(): Int? = lastSeenBootCountValue.value()
 
     suspend fun setLastSeenBootCount(count: Int) {
-        dataStore.store.edit { it[LAST_SEEN_BOOT_COUNT] = count }
+        lastSeenBootCountValue.value(count)
     }
 
-    suspend fun isQuickFullChargeEnabled(): Boolean = quickFullChargeEnabled.first()
+    suspend fun isQuickFullChargeEnabled(): Boolean = quickFullChargeEnabled.value()
 
     suspend fun setQuickFullChargeEnabled(enabled: Boolean) {
-        dataStore.store.edit { it[QUICK_FULL_CHARGE_ENABLED] = enabled }
+        quickFullChargeEnabled.value(enabled)
     }
 
-    suspend fun isQuickFullChargeAnyLevel(): Boolean = quickFullChargeAnyLevel.first()
+    suspend fun isQuickFullChargeAnyLevel(): Boolean = quickFullChargeAnyLevel.value()
 
     suspend fun setQuickFullChargeAnyLevel(enabled: Boolean) {
-        dataStore.store.edit { it[QUICK_FULL_CHARGE_ANY_LEVEL] = enabled }
-    }
-
-    private fun toRecord(prefs: Preferences): ChargeSessionRecord? {
-        if (prefs[SESSION_ACTIVE] != true) return null
-        val policy = ChargePolicy.fromStableId(prefs[SESSION_RESTORE_POLICY]) ?: return null
-        return ChargeSessionRecord(
-            restorePolicy = policy,
-            startedAtMillis = prefs[SESSION_STARTED_AT] ?: 0L,
-            connectedSeen = prefs[SESSION_CONNECTED] ?: false,
-            provenance = prefs.sessionProvenance(),
-            workId = prefs[SESSION_WORK_ID],
-        )
-    }
-
-    // A record is only stamped with provenance when a token is present; a missing token (legacy
-    // record) decodes to null so the assessor treats it as un-owned and adopts it silently.
-    private fun Preferences.sessionProvenance(): WorkProvenance? {
-        val token = this[SESSION_OWNER_TOKEN] ?: return null
-        return WorkProvenance(
-            token = token,
-            pid = this[SESSION_OWNER_PID] ?: -1,
-            bootCount = this[SESSION_BOOT_COUNT],
-            // The owner timestamp is written on every (re-)stamp; fall back to the session start for
-            // legacy records that predate it.
-            createdAtMillis = this[SESSION_OWNER_SET_AT] ?: this[SESSION_STARTED_AT] ?: 0L,
-        )
-    }
-
-    private fun Preferences.recoveryProvenance(): WorkProvenance? {
-        val token = this[RECOVERY_OWNER_TOKEN] ?: return null
-        return WorkProvenance(
-            token = token,
-            pid = this[RECOVERY_OWNER_PID] ?: -1,
-            bootCount = this[RECOVERY_BOOT_COUNT],
-            createdAtMillis = this[RECOVERY_SET_AT] ?: 0L,
-        )
-    }
-
-    private fun androidx.datastore.preferences.core.MutablePreferences.writeSessionProvenance(
-        provenance: WorkProvenance?,
-    ) {
-        if (provenance == null) {
-            remove(SESSION_OWNER_TOKEN)
-            remove(SESSION_OWNER_PID)
-            remove(SESSION_BOOT_COUNT)
-            remove(SESSION_OWNER_SET_AT)
-            return
-        }
-        this[SESSION_OWNER_TOKEN] = provenance.token
-        this[SESSION_OWNER_PID] = provenance.pid
-        provenance.bootCount?.let { this[SESSION_BOOT_COUNT] = it } ?: remove(SESSION_BOOT_COUNT)
-        this[SESSION_OWNER_SET_AT] = provenance.createdAtMillis
-    }
-
-    private fun androidx.datastore.preferences.core.MutablePreferences.writeRecoveryProvenance(
-        provenance: WorkProvenance?,
-    ) {
-        if (provenance == null) {
-            remove(RECOVERY_OWNER_TOKEN)
-            remove(RECOVERY_OWNER_PID)
-            remove(RECOVERY_BOOT_COUNT)
-            remove(RECOVERY_SET_AT)
-            return
-        }
-        this[RECOVERY_OWNER_TOKEN] = provenance.token
-        this[RECOVERY_OWNER_PID] = provenance.pid
-        provenance.bootCount?.let { this[RECOVERY_BOOT_COUNT] = it } ?: remove(RECOVERY_BOOT_COUNT)
-        this[RECOVERY_SET_AT] = provenance.createdAtMillis
-    }
-
-    private companion object {
-        val SESSION_ACTIVE = booleanPreferencesKey("session.active")
-        val SESSION_RESTORE_POLICY = stringPreferencesKey("session.restore_policy")
-        val SESSION_STARTED_AT = longPreferencesKey("session.started_at")
-        val SESSION_CONNECTED = booleanPreferencesKey("session.connected_seen")
-        val SESSION_WORK_ID = stringPreferencesKey("session.work_id")
-        val SESSION_OWNER_TOKEN = stringPreferencesKey("session.owner_token")
-        val SESSION_OWNER_PID = intPreferencesKey("session.owner_pid")
-        val SESSION_BOOT_COUNT = intPreferencesKey("session.boot_count")
-        val SESSION_OWNER_SET_AT = longPreferencesKey("session.owner_set_at")
-        val QUICK_FULL_CHARGE_ENABLED = booleanPreferencesKey("fullcharge.quick_replug_enabled")
-        val QUICK_FULL_CHARGE_ANY_LEVEL = booleanPreferencesKey("fullcharge.quick_replug_any_level")
-        val RECOVERY_PENDING_TARGET = stringPreferencesKey("recovery.pending_target")
-        val RECOVERY_WORK_ID = stringPreferencesKey("recovery.work_id")
-        val RECOVERY_OWNER_TOKEN = stringPreferencesKey("recovery.owner_token")
-        val RECOVERY_OWNER_PID = intPreferencesKey("recovery.owner_pid")
-        val RECOVERY_BOOT_COUNT = intPreferencesKey("recovery.boot_count")
-        val RECOVERY_SET_AT = longPreferencesKey("recovery.set_at")
-        val LAST_SEEN_BOOT_COUNT = intPreferencesKey("recovery.last_seen_boot_count")
+        quickFullChargeAnyLevel.value(enabled)
     }
 }
+
+/**
+ * An owner without a token identifies nobody, so it reads as no owner at all — the same answer a
+ * record with no provenance gave before, which the assessor treats as un-owned and adopts silently.
+ */
+private fun WorkProvenance?.normalizedProvenance(): WorkProvenance? = this?.takeIf { it.token.isNotBlank() }
+
+private fun ChargeSessionRecord.normalized() = copy(provenance = provenance.normalizedProvenance())
+
+private fun RecoveryRecord.normalized() = copy(provenance = provenance.normalizedProvenance())

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/InterruptionAssessor.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/InterruptionAssessor.kt
@@ -90,12 +90,16 @@ class InterruptionAssessor @Inject constructor(
      * restore, so provenance is read from the pending target first, then the session. Non-candidate
      * pickups silently adopt any surviving recovery work — but the [RecoveryPickup] still carries the
      * work id so a convergence can resolve a prior event even without an assessment.
+     *
+     * Each store is read exactly **once**: reading provenance and work id through separate accessors
+     * could straddle a concurrent adopt or clear and pair a token from one version of the record with
+     * a work id from another.
      */
     suspend fun captureRecoveryPickup(): RecoveryPickup = runSafeOrNull {
-        val provenance = fullChargeStore.pendingRecoveryProvenance()
-            ?: fullChargeStore.currentSession()?.provenance
-        val workId = fullChargeStore.pendingRecoveryWorkId()
-            ?: fullChargeStore.currentSession()?.workId
+        val recovery = fullChargeStore.currentRecovery()
+        val session = fullChargeStore.currentSession()
+        val provenance = recovery?.provenance ?: session?.provenance
+        val workId = recovery?.workId ?: session?.workId
         if (provenance == null || !isSurvivedSameBoot(provenance)) {
             adoptRecoveryWork()
             return@runSafeOrNull RecoveryPickup(workId = workId, assessment = null)

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/InterruptionStore.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/InterruptionStore.kt
@@ -1,61 +1,71 @@
 package eu.darken.amply.fullcharge.core
 
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.longPreferencesKey
-import androidx.datastore.preferences.core.stringPreferencesKey
 import eu.darken.amply.common.AppDataStore
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import eu.darken.amply.common.datastore.createValue
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /** Why Amply's process most likely went away. Cosmetic only — never asserts a force-stop. */
+@Serializable
 enum class InterruptionReason {
     /** The exit reason matched a user-requested stop (ApplicationExitInfo USER_REQUESTED / USER_STOPPED). */
+    @SerialName("USER_STOPPED")
     USER_STOPPED,
 
     /** Anything else, no matching exit record, or the API is unavailable. */
+    @SerialName("OTHER")
     OTHER,
 }
 
+@Serializable
 enum class InterruptionOutcome {
     /** The catch-up restore succeeded — the protective limit is back. */
+    @SerialName("RESTORED_LATE")
     RESTORED_LATE,
 
     /** The restore failed and retry work remains persisted. */
+    @SerialName("STILL_PENDING")
     STILL_PENDING,
 
     /** Recovery gave up without hardware confirmation and cleared its retry state. */
+    @SerialName("UNCONFIRMED")
     UNCONFIRMED,
 }
 
+@Serializable
 data class InterruptionEvent(
-    val occurredAtMillis: Long,
-    val reason: InterruptionReason,
-    val outcome: InterruptionOutcome,
+    @SerialName("occurredAtMillis") val occurredAtMillis: Long,
+    @SerialName("reason") val reason: InterruptionReason,
+    @SerialName("outcome") val outcome: InterruptionOutcome,
     /** Stable correlation id of the owed work (see [ChargeSessionRecord.workId]); survives adoption. */
-    val workId: String,
+    @SerialName("workId") val workId: String,
 )
 
 /**
  * Single-slot persistence for the "Amply was interrupted while owing a restore" dashboard signal.
- * At most one event is held at a time — a newer event overwrites the old. A malformed/unknown stored
- * enum decodes to no event. Shares the single [AppDataStore] like the other feature facades.
+ * At most one event is held at a time — a newer event overwrites the old. A malformed record (an
+ * unknown stored enum, say) decodes to no event, which matches the all-or-nothing decode this had
+ * when it was spread across four keys. Shares the single [AppDataStore] like the other facades.
  */
 @Singleton
 open class InterruptionStore @Inject constructor(
-    private val dataStore: AppDataStore,
+    dataStore: AppDataStore,
+    json: Json,
 ) {
-    val event: Flow<InterruptionEvent?> = dataStore.store.data.map(::toEvent)
+    private val eventValue = dataStore.createValue<InterruptionEvent?>(
+        key = "interruption.v2",
+        defaultValue = null,
+        json = json,
+        fallbackToDefault = true,
+    )
+
+    val event = eventValue.flow
 
     open suspend fun record(event: InterruptionEvent) {
-        dataStore.store.edit {
-            it[OCCURRED_AT] = event.occurredAtMillis
-            it[REASON] = event.reason.name
-            it[OUTCOME] = event.outcome.name
-            it[WORK_TOKEN] = event.workId
-        }
+        eventValue.update { event }
     }
 
     /**
@@ -64,50 +74,24 @@ open class InterruptionStore @Inject constructor(
      * it is already RESTORED_LATE.
      */
     open suspend fun markRestored(workId: String) {
-        dataStore.store.edit { prefs ->
-            val current = toEvent(prefs) ?: return@edit
-            if (current.workId != workId) return@edit
-            if (current.outcome == InterruptionOutcome.RESTORED_LATE) return@edit
-            prefs[OUTCOME] = InterruptionOutcome.RESTORED_LATE.name
+        eventValue.update { current ->
+            when {
+                current == null -> null
+                current.workId != workId -> current
+                current.outcome == InterruptionOutcome.RESTORED_LATE -> current
+                else -> current.copy(outcome = InterruptionOutcome.RESTORED_LATE)
+            }
         }
     }
 
     /** Clear the event only if it is not a successful (RESTORED_LATE) one — used on an explicit user write. */
     open suspend fun clearPending() {
-        dataStore.store.edit { prefs ->
-            val current = toEvent(prefs) ?: return@edit
-            if (current.outcome == InterruptionOutcome.RESTORED_LATE) return@edit
-            prefs.clearKeys()
+        eventValue.update { current ->
+            if (current?.outcome == InterruptionOutcome.RESTORED_LATE) current else null
         }
     }
 
     open suspend fun clear() {
-        dataStore.store.edit { it.clearKeys() }
-    }
-
-    private fun androidx.datastore.preferences.core.MutablePreferences.clearKeys() {
-        remove(OCCURRED_AT)
-        remove(REASON)
-        remove(OUTCOME)
-        remove(WORK_TOKEN)
-    }
-
-    private fun toEvent(prefs: Preferences): InterruptionEvent? {
-        val occurredAt = prefs[OCCURRED_AT] ?: return null
-        val reason = prefs[REASON]?.let { name ->
-            InterruptionReason.entries.firstOrNull { it.name == name }
-        } ?: return null
-        val outcome = prefs[OUTCOME]?.let { name ->
-            InterruptionOutcome.entries.firstOrNull { it.name == name }
-        } ?: return null
-        val workId = prefs[WORK_TOKEN] ?: return null
-        return InterruptionEvent(occurredAt, reason, outcome, workId)
-    }
-
-    private companion object {
-        val OCCURRED_AT = longPreferencesKey("interruption.v1.occurred_at")
-        val REASON = stringPreferencesKey("interruption.v1.reason")
-        val OUTCOME = stringPreferencesKey("interruption.v1.outcome")
-        val WORK_TOKEN = stringPreferencesKey("interruption.v1.work_token")
+        eventValue.update { null }
     }
 }

--- a/app/src/main/java/eu/darken/amply/main/core/OnboardingSettings.kt
+++ b/app/src/main/java/eu/darken/amply/main/core/OnboardingSettings.kt
@@ -1,27 +1,20 @@
 package eu.darken.amply.main.core
 
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.edit
 import eu.darken.amply.common.AppDataStore
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
+import eu.darken.amply.common.datastore.createValue
+import eu.darken.amply.common.datastore.value
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class OnboardingSettings @Inject constructor(
-    private val dataStore: AppDataStore,
+    dataStore: AppDataStore,
 ) {
-    val isComplete: Flow<Boolean> = dataStore.store.data.map { it[IS_COMPLETE] ?: false }
+    val isComplete = dataStore.createValue("onboarding.v1.complete", false)
 
-    suspend fun isCompleteNow(): Boolean = isComplete.first()
+    suspend fun isCompleteNow(): Boolean = isComplete.value()
 
     suspend fun complete() {
-        dataStore.store.edit { it[IS_COMPLETE] = true }
-    }
-
-    private companion object {
-        val IS_COMPLETE = booleanPreferencesKey("onboarding.v1.complete")
+        isComplete.value(true)
     }
 }

--- a/app/src/main/java/eu/darken/amply/main/core/QuickAccessStore.kt
+++ b/app/src/main/java/eu/darken/amply/main/core/QuickAccessStore.kt
@@ -1,17 +1,18 @@
 package eu.darken.amply.main.core
 
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.edit
 import eu.darken.amply.common.AppDataStore
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import eu.darken.amply.common.datastore.createValue
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@Serializable
 data class QuickAccessState(
-    val dismissed: Boolean = false,
-    val widgetAdded: Boolean = false,
-    val tileAdded: Boolean = false,
+    @SerialName("dismissed") val dismissed: Boolean = false,
+    @SerialName("widgetAdded") val widgetAdded: Boolean = false,
+    @SerialName("tileAdded") val tileAdded: Boolean = false,
 )
 
 /**
@@ -21,31 +22,25 @@ data class QuickAccessState(
  */
 @Singleton
 class QuickAccessStore @Inject constructor(
-    private val dataStore: AppDataStore,
+    dataStore: AppDataStore,
+    json: Json,
 ) {
-    val state: Flow<QuickAccessState> = dataStore.store.data.map {
-        QuickAccessState(
-            dismissed = it[DISMISSED] ?: false,
-            widgetAdded = it[WIDGET_ADDED] ?: false,
-            tileAdded = it[TILE_ADDED] ?: false,
-        )
-    }
+    val state = dataStore.createValue(
+        key = "quickaccess.v2",
+        defaultValue = QuickAccessState(),
+        json = json,
+        fallbackToDefault = true,
+    )
 
     suspend fun dismiss() {
-        dataStore.store.edit { it[DISMISSED] = true }
+        state.update { it.copy(dismissed = true) }
     }
 
     suspend fun markWidgetAdded() {
-        dataStore.store.edit { it[WIDGET_ADDED] = true }
+        state.update { it.copy(widgetAdded = true) }
     }
 
     suspend fun markTileAdded() {
-        dataStore.store.edit { it[TILE_ADDED] = true }
-    }
-
-    private companion object {
-        val DISMISSED = booleanPreferencesKey("quickaccess.v1.dismissed")
-        val WIDGET_ADDED = booleanPreferencesKey("quickaccess.v1.widget_added")
-        val TILE_ADDED = booleanPreferencesKey("quickaccess.v1.tile_added")
+        state.update { it.copy(tileAdded = true) }
     }
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
@@ -133,8 +133,8 @@ class DashboardViewModel @Inject constructor(
 
     // The typed combine overloads stop at five flows; the two gesture booleans are pre-combined.
     private val gestureFlags = combine(
-        fullChargeStore.quickFullChargeEnabled,
-        fullChargeStore.quickFullChargeAnyLevel,
+        fullChargeStore.quickFullChargeEnabled.flow,
+        fullChargeStore.quickFullChargeAnyLevel.flow,
     ) { enabled, anyLevel -> enabled to anyLevel }
 
     // Grouped so the outer combine keeps one slot each: the live battery readout, the alarm config,
@@ -159,7 +159,7 @@ class DashboardViewModel @Inject constructor(
     // run only while capture is enabled — when it's off the card shows a promo, so a user who never
     // turned stats on never gets an empty stats.db created just by opening the dashboard.
     private val statsDashboard = statsDashboardStates(
-        captureEnabled = statsPreferences.captureEnabled,
+        captureEnabled = statsPreferences.captureEnabled.flow,
         health = captureServiceHealth.state,
         recentSessions = { statsRepository.recentSessions(limit = 1) },
         sessionCount = { statsRepository.sessionCount() },
@@ -170,7 +170,7 @@ class DashboardViewModel @Inject constructor(
         combine(
             repository.state,
             fullChargeStore.session,
-            onboardingSettings.isComplete,
+            onboardingSettings.isComplete.flow,
             gestureFlags,
             deviceReport,
         ) { charging, session, onboardingComplete, (quickFullChargeEnabled, quickFullChargeAnyLevel), report ->
@@ -183,7 +183,7 @@ class DashboardViewModel @Inject constructor(
                 deviceReport = report,
             )
         },
-        quickAccessStore.state,
+        quickAccessStore.state.flow,
         quickAccessChecked,
         tileRequestPending,
         unprivilegedExtras,

--- a/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsViewModel.kt
@@ -31,7 +31,7 @@ class SettingsViewModel @Inject constructor(
     private val themeSettings: ThemeSettings,
     private val debugLogManager: DebugLogManager,
 ) : ViewModel() {
-    val themeState: StateFlow<ThemeState> = themeSettings.state.stateIn(
+    val themeState: StateFlow<ThemeState> = themeSettings.state.flow.stateIn(
         viewModelScope,
         SharingStarted.Eagerly,
         ThemeState(),

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRecorder.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRecorder.kt
@@ -6,6 +6,7 @@ import androidx.room.withTransaction
 import dagger.Lazy
 import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.battery.core.BatteryReader
+import eu.darken.amply.common.datastore.value
 import eu.darken.amply.common.debug.logging.Logging
 import eu.darken.amply.common.debug.logging.log
 import eu.darken.amply.common.debug.logging.logTag
@@ -18,7 +19,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -99,7 +99,7 @@ class ChargeStatsRecorder @Inject constructor(
             // it is written after the row is committed, so a process death in between leaves an open
             // row with no stamp. Capture being enabled is therefore also sufficient — such a user gets
             // a stats.db on the next tick anyway, so opening it here costs nothing.
-            if (!capturing && preferences.lastCaptureWallMillis.first() == null) return
+            if (!capturing && preferences.lastCaptureWallMillis.value() == null) return
             reconcileDanglingSessions()
         } catch (e: CancellationException) {
             throw e

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsPreferences.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsPreferences.kt
@@ -1,12 +1,8 @@
 package eu.darken.amply.stats.core
 
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.longPreferencesKey
 import eu.darken.amply.common.AppDataStore
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
+import eu.darken.amply.common.datastore.createValue
+import eu.darken.amply.common.datastore.value
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -15,31 +11,31 @@ import javax.inject.Singleton
  * small pointers — the opt-in flag and the wall time of the last successfully recorded sample (so
  * the UI can honestly show "enabled but not currently capturing" when a gap opens). All time-series
  * data lives in Room, never here.
+ *
+ * [lastCaptureWallMillis] is rewritten on **every** recorded sample (~20s while charging), which is
+ * what makes the shared-store fan-out visible: before these became [eu.darken.amply.common.datastore
+ * .DataStoreValue]s, each of those writes re-emitted [captureEnabled] unchanged and restarted the
+ * dashboard's stats flow, flashing the charging card's loading state on every tick.
  */
 @Singleton
 class StatsPreferences @Inject constructor(
-    private val dataStore: AppDataStore,
+    dataStore: AppDataStore,
 ) {
-    val captureEnabled: Flow<Boolean> = dataStore.store.data.map { it[ENABLED] ?: false }
+    val captureEnabled = dataStore.createValue("stats.capture_enabled", false)
 
-    val lastCaptureWallMillis: Flow<Long?> = dataStore.store.data.map { it[LAST_CAPTURE] }
+    val lastCaptureWallMillis = dataStore.createValue<Long?>("stats.last_capture_wall")
 
-    suspend fun isCaptureEnabledNow(): Boolean = captureEnabled.first()
+    suspend fun isCaptureEnabledNow(): Boolean = captureEnabled.value()
 
     suspend fun setCaptureEnabled(enabled: Boolean) {
-        dataStore.store.edit { it[ENABLED] = enabled }
+        captureEnabled.value(enabled)
     }
 
     suspend fun setLastCaptureWallMillis(millis: Long) {
-        dataStore.store.edit { it[LAST_CAPTURE] = millis }
+        lastCaptureWallMillis.value(millis)
     }
 
     suspend fun clearLastCapture() {
-        dataStore.store.edit { it.remove(LAST_CAPTURE) }
-    }
-
-    private companion object {
-        val ENABLED = booleanPreferencesKey("stats.capture_enabled")
-        val LAST_CAPTURE = longPreferencesKey("stats.last_capture_wall")
+        lastCaptureWallMillis.value(null)
     }
 }

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsViewModel.kt
@@ -74,8 +74,8 @@ class StatsViewModel @Inject constructor(
 ) : ViewModel() {
 
     val captureState: StateFlow<CaptureUiState> = combine(
-        preferences.captureEnabled,
-        preferences.lastCaptureWallMillis,
+        preferences.captureEnabled.flow,
+        preferences.lastCaptureWallMillis.flow,
     ) { enabled, lastCapture ->
         CaptureUiState(captureEnabled = enabled, lastCaptureWallMillis = lastCapture)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS), CaptureUiState())

--- a/app/src/test/java/eu/darken/amply/alarm/core/ChargeAlarmStoreTest.kt
+++ b/app/src/test/java/eu/darken/amply/alarm/core/ChargeAlarmStoreTest.kt
@@ -1,26 +1,67 @@
 package eu.darken.amply.alarm.core
 
-import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
-import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.serialization.SerializationModule
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
 
 class ChargeAlarmStoreTest {
 
     @TempDir
     lateinit var tempDir: File
 
-    private fun store(scope: kotlinx.coroutines.CoroutineScope): ChargeAlarmStore {
-        val prefs: DataStore<Preferences> = PreferenceDataStoreFactory.create(scope = scope) {
+    private fun appDataStore(scope: kotlinx.coroutines.CoroutineScope) = AppDataStore(
+        PreferenceDataStoreFactory.create(scope = scope) {
             File(tempDir, "alarm-${System.nanoTime()}.preferences_pb")
-        }
-        return ChargeAlarmStore(AppDataStore(prefs))
+        },
+    )
+
+    private fun store(scope: kotlinx.coroutines.CoroutineScope): ChargeAlarmStore =
+        ChargeAlarmStore(appDataStore(scope), SerializationModule.json())
+
+    /**
+     * Snapping is many-to-one, so two *different* stored records can normalize to the same config.
+     * The upstream dedupe compares the raw stored string and cannot see that, so the config flow
+     * needs its own guard or the UI gets a pointless re-emission.
+     *
+     * The off-step record is written by hand because the setter snaps on the way in — only a
+     * hand-edited or future-written record can hold an off-tick target.
+     */
+    @Test
+    fun `a raw target that snaps to the current value does not re-emit`() = runBlocking {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        val prefs = appDataStore(scope)
+        val store = ChargeAlarmStore(prefs, SerializationModule.json())
+        prefs.store.edit { it[stringPreferencesKey("alarm.config.v2")] = """{"enabled":true,"targetPercent":83}""" }
+
+        val seen = CopyOnWriteArrayList<ChargeAlarmConfig>()
+        val collector = launch(Dispatchers.IO) { store.config.toList(seen) }
+        withTimeout(5_000) { while (seen.isEmpty()) delay(5) }
+
+        // A genuinely different raw record (83 -> 85) that normalizes to the same 85.
+        store.setTargetPercent(85)
+        delay(200)
+
+        seen.map { it.targetPercent } shouldBe listOf(85)
+        collector.cancel()
+        scope.cancel()
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/alarm/core/ChargeAlarmWatcherTest.kt
+++ b/app/src/test/java/eu/darken/amply/alarm/core/ChargeAlarmWatcherTest.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.serialization.SerializationModule
 import eu.darken.amply.monitor.core.ChargeMonitorTick
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
@@ -41,7 +42,7 @@ class ChargeAlarmWatcherTest {
         val prefs: DataStore<Preferences> = PreferenceDataStoreFactory.create(scope = scope) {
             File(tempDir, "alarm-${System.nanoTime()}.preferences_pb")
         }
-        return ChargeAlarmStore(AppDataStore(prefs))
+        return ChargeAlarmStore(AppDataStore(prefs), SerializationModule.json())
     }
 
     private fun tick(plugged: Boolean, percent: Int, sessionActive: Boolean = false) =

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingPreferencesTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingPreferencesTest.kt
@@ -1,32 +1,40 @@
 package eu.darken.amply.charging.core
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.serialization.SerializationModule
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
 
 class ChargingPreferencesTest {
     @TempDir
     lateinit var tempDir: File
 
     private val storeScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private val preferences by lazy {
-        ChargingPreferences(
-            AppDataStore(
-                PreferenceDataStoreFactory.create(scope = storeScope) {
-                    File(tempDir, "test.preferences_pb")
-                },
-            ),
+    private val appDataStore by lazy {
+        AppDataStore(
+            PreferenceDataStoreFactory.create(scope = storeScope) {
+                File(tempDir, "test.preferences_pb")
+            },
         )
     }
+    private val preferences by lazy { ChargingPreferences(appDataStore, SerializationModule.json()) }
 
     @AfterEach
     fun teardown() {
@@ -70,5 +78,184 @@ class ChargingPreferencesTest {
 
         preferences.lastPersistentPolicyNow() shouldBe ChargePolicy.Adaptive
         preferences.protectivePolicyNow() shouldBe ChargePolicy.Adaptive
+    }
+
+    // --- Per-field corruption -------------------------------------------------------------------
+    // These four facts share one stored record but must degrade INDEPENDENTLY. Falling back
+    // wholesale on any single bad field would quietly swap a user's real protective baseline for the
+    // 80% default, so each field is validated on its own.
+
+    @Test
+    fun `an unreadable last-requested policy leaves the other fields intact`() = runTest {
+        writeRawRecord(
+            """{"lastRequested":"fixed:not-a-number","lastRequestedAt":5,""" +
+                """"protective":"adaptive","lastPersistent":"unrestricted"}""",
+        )
+
+        preferences.lastRequestedNow() shouldBe null
+        preferences.lastRequestedAtNow() shouldBe 5L
+        preferences.protectivePolicyNow() shouldBe ChargePolicy.Adaptive
+        preferences.lastPersistentPolicyNow() shouldBe ChargePolicy.Unrestricted
+    }
+
+    @Test
+    fun `an unreadable protective policy falls back to the limit without touching the rest`() = runTest {
+        writeRawRecord(
+            """{"lastRequested":"adaptive","lastRequestedAt":5,""" +
+                """"protective":"bogus","lastPersistent":"adaptive"}""",
+        )
+
+        preferences.protectivePolicyNow() shouldBe ChargePolicy.FixedLimit(80)
+        preferences.lastRequestedNow() shouldBe ChargePolicy.Adaptive
+        preferences.lastPersistentPolicyNow() shouldBe ChargePolicy.Adaptive
+    }
+
+    @Test
+    fun `an unreadable persistent policy leaves the protective baseline intact`() = runTest {
+        writeRawRecord(
+            """{"lastRequested":"adaptive","lastRequestedAt":5,""" +
+                """"protective":"fixed:90","lastPersistent":"fixed:oops"}""",
+        )
+
+        preferences.lastPersistentPolicyNow() shouldBe null
+        preferences.protectivePolicyNow() shouldBe ChargePolicy.FixedLimit(90)
+    }
+
+    /**
+     * A wrong-typed field is the case a typed whole-record decode gets wrong: it fails on
+     * `lastRequestedAt` and takes the valid 90 % baseline down with it. Losing that baseline is a
+     * real downgrade — Amply would restore the battery to 80 % instead of the user's 90 %.
+     */
+    @Test
+    fun `a wrong-typed field does not destroy the other fields`() = runTest {
+        writeRawRecord(
+            """{"lastRequested":"adaptive","lastRequestedAt":"bad",""" +
+                """"protective":"fixed:90","lastPersistent":"fixed:90"}""",
+        )
+
+        preferences.protectivePolicyNow() shouldBe ChargePolicy.FixedLimit(90)
+        preferences.lastPersistentPolicyNow() shouldBe ChargePolicy.FixedLimit(90)
+        preferences.lastRequestedNow() shouldBe ChargePolicy.Adaptive
+        // Only the unreadable field falls back.
+        preferences.lastRequestedAtNow() shouldBe 0L
+    }
+
+    /** The follow-on damage: a later write must not persist a fallback over the surviving baseline. */
+    @Test
+    fun `a later write preserves fields that survived a wrong-typed record`() = runTest {
+        writeRawRecord(
+            """{"lastRequested":"adaptive","lastRequestedAt":"bad",""" +
+                """"protective":"fixed:90","lastPersistent":"fixed:90"}""",
+        )
+
+        preferences.recordRequested(ChargePolicy.Unrestricted, persistent = false, nowMillis = 7L)
+
+        preferences.protectivePolicyNow() shouldBe ChargePolicy.FixedLimit(90)
+        preferences.lastPersistentPolicyNow() shouldBe ChargePolicy.FixedLimit(90)
+        preferences.lastRequestedNow() shouldBe ChargePolicy.Unrestricted
+        preferences.lastRequestedAtNow() shouldBe 7L
+    }
+
+    @Test
+    fun `a null field reads as absent`() = runTest {
+        writeRawRecord("""{"lastRequested":null,"lastRequestedAt":null,"protective":"adaptive"}""")
+
+        preferences.lastRequestedNow() shouldBe null
+        preferences.lastRequestedAtNow() shouldBe 0L
+        preferences.protectivePolicyNow() shouldBe ChargePolicy.Adaptive
+    }
+
+    @Test
+    fun `a wholly malformed record falls back to empty rather than throwing`() = runTest {
+        writeRawRecord("{not json at all")
+
+        preferences.lastRequestedNow() shouldBe null
+        preferences.lastRequestedAtNow() shouldBe 0L
+        preferences.protectivePolicyNow() shouldBe ChargePolicy.FixedLimit(80)
+        preferences.lastPersistentPolicyNow() shouldBe null
+    }
+
+    @Test
+    fun `a record written by a newer build keeps the fields this build understands`() = runTest {
+        writeRawRecord(
+            """{"lastRequested":"adaptive","lastRequestedAt":5,"protective":"fixed:90",""" +
+                """"lastPersistent":"adaptive","somethingNew":{"nested":true}}""",
+        )
+
+        preferences.lastRequestedNow() shouldBe ChargePolicy.Adaptive
+        preferences.protectivePolicyNow() shouldBe ChargePolicy.FixedLimit(90)
+    }
+
+    // --- Projection dedupe ----------------------------------------------------------------------
+
+    /**
+     * All four projections ride one record now, so each carries its own `distinctUntilChanged`.
+     * Without it, a timestamp-only write would wake every collector — including the widget, which
+     * collects [ChargingPreferences.lastRequested] directly.
+     */
+    @Test
+    fun `re-requesting the same policy does not re-emit the policy projections`() = runBlocking {
+        preferences.recordRequested(ChargePolicy.FixedLimit(80), persistent = true, nowMillis = 1L)
+
+        val requested = CopyOnWriteArrayList<ChargePolicy?>()
+        val protective = CopyOnWriteArrayList<ChargePolicy>()
+        val persistent = CopyOnWriteArrayList<ChargePolicy?>()
+        val stamps = CopyOnWriteArrayList<Long>()
+        val collectors = listOf(
+            launch(Dispatchers.IO) { preferences.lastRequested.toList(requested) },
+            launch(Dispatchers.IO) { preferences.protectivePolicy.toList(protective) },
+            launch(Dispatchers.IO) { preferences.lastPersistentPolicy.toList(persistent) },
+            launch(Dispatchers.IO) { preferences.lastRequestedAt.toList(stamps) },
+        )
+        withTimeout(TIMEOUT) { while (stamps.isEmpty()) delay(5) }
+
+        // Same policy, later clock: only the timestamp genuinely changes.
+        preferences.recordRequested(ChargePolicy.FixedLimit(80), persistent = true, nowMillis = 2L)
+        withTimeout(TIMEOUT) { while (stamps.size < 2) delay(5) }
+        delay(SETTLE)
+
+        requested.toList() shouldBe listOf(ChargePolicy.FixedLimit(80))
+        protective.toList() shouldBe listOf(ChargePolicy.FixedLimit(80))
+        persistent.toList() shouldBe listOf(ChargePolicy.FixedLimit(80))
+        // The timestamp is the one thing that did change.
+        stamps.toList() shouldBe listOf(1L, 2L)
+
+        collectors.forEach { it.cancel() }
+    }
+
+    /** A temporary (non-persistent) request must leave both persistent projections silent. */
+    @Test
+    fun `a temporary request does not re-emit the persistent projections`() = runBlocking {
+        preferences.recordRequested(ChargePolicy.FixedLimit(80), persistent = true, nowMillis = 1L)
+
+        val protective = CopyOnWriteArrayList<ChargePolicy>()
+        val persistent = CopyOnWriteArrayList<ChargePolicy?>()
+        val requested = CopyOnWriteArrayList<ChargePolicy?>()
+        val collectors = listOf(
+            launch(Dispatchers.IO) { preferences.protectivePolicy.toList(protective) },
+            launch(Dispatchers.IO) { preferences.lastPersistentPolicy.toList(persistent) },
+            launch(Dispatchers.IO) { preferences.lastRequested.toList(requested) },
+        )
+        withTimeout(TIMEOUT) { while (requested.isEmpty()) delay(5) }
+
+        preferences.recordRequested(ChargePolicy.Unrestricted, persistent = false, nowMillis = 2L)
+        withTimeout(TIMEOUT) { while (requested.size < 2) delay(5) }
+        delay(SETTLE)
+
+        requested.toList() shouldBe listOf(ChargePolicy.FixedLimit(80), ChargePolicy.Unrestricted)
+        protective.toList() shouldBe listOf(ChargePolicy.FixedLimit(80))
+        persistent.toList() shouldBe listOf(ChargePolicy.FixedLimit(80))
+
+        collectors.forEach { it.cancel() }
+    }
+
+    /** Writes the stored JSON directly, standing in for a corrupt or foreign-written record. */
+    private suspend fun writeRawRecord(json: String) {
+        appDataStore.store.edit { it[stringPreferencesKey("policy.v2")] = json }
+    }
+
+    private companion object {
+        const val TIMEOUT = 5_000L
+        const val SETTLE = 200L
     }
 }

--- a/app/src/test/java/eu/darken/amply/common/datastore/DataStoreValueTest.kt
+++ b/app/src/test/java/eu/darken/amply/common/datastore/DataStoreValueTest.kt
@@ -1,0 +1,180 @@
+package eu.darken.amply.common.datastore
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import eu.darken.amply.common.AppDataStore
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+
+class DataStoreValueTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private val storeScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val dataStore by lazy {
+        AppDataStore(
+            PreferenceDataStoreFactory.create(scope = storeScope) { File(tempDir, "test.preferences_pb") },
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        storeScope.cancel()
+    }
+
+    @Test
+    fun `absent key reads the default`() = runTest {
+        dataStore.createValue("flag", false).value() shouldBe false
+        dataStore.createValue<Long?>("stamp").value() shouldBe null
+    }
+
+    @Test
+    fun `value round-trips`() = runTest {
+        val flag = dataStore.createValue("flag", false)
+        flag.value(true)
+        flag.value() shouldBe true
+    }
+
+    @Test
+    fun `update returns both sides and can clear the key`() = runTest {
+        val counter = dataStore.createValue("counter", 0)
+
+        counter.update { it + 5 } shouldBe DataStoreValue.Updated(old = 0, new = 5)
+        counter.update { it + 1 } shouldBe DataStoreValue.Updated(old = 5, new = 6)
+
+        // Returning null clears the key, so the next read falls back to the default.
+        counter.update { null } shouldBe DataStoreValue.Updated(old = 6, new = 0)
+        counter.value() shouldBe 0
+
+        // Assert the key is genuinely gone rather than holding a persisted 0 — reading back the
+        // default cannot tell those apart, and "absent" is what session/recovery clearing relies on.
+        dataStore.store.data.first().contains(intPreferencesKey("counter")) shouldBe false
+    }
+
+    @Test
+    fun `clearing a nullable value removes the key`() = runTest {
+        val stamp = dataStore.createValue<Long?>("stamp")
+        stamp.value(1_000L)
+        dataStore.store.data.first().contains(longPreferencesKey("stamp")) shouldBe true
+
+        stamp.value(null)
+
+        stamp.value() shouldBe null
+        dataStore.store.data.first().contains(longPreferencesKey("stamp")) shouldBe false
+    }
+
+    /**
+     * [DataStoreValue.update] has to be a single read-modify-write transaction, not a read followed
+     * by a write. Composite records are edited this way — `markConnected` flips one field of the
+     * session while another caller may be stamping its provenance — so a lost update would drop
+     * safety-critical state. Sequential tests cannot tell the two implementations apart.
+     */
+    @Test
+    fun `concurrent updates do not lose writes`() = runBlocking {
+        val counter = dataStore.createValue("counter", 0)
+
+        val workers = 8
+        val incrementsEach = 25
+        (0 until workers).map {
+            launch(Dispatchers.IO) { repeat(incrementsEach) { counter.update { current -> current + 1 } } }
+        }.forEach { it.join() }
+
+        counter.value() shouldBe workers * incrementsEach
+    }
+
+    /**
+     * The defect this whole primitive exists for: Amply keeps one shared DataStore, so an unrelated
+     * write hands the entire snapshot to every collector. Before the dedupe moved into the value, the
+     * stats recorder's ~20s timestamp write re-emitted `captureEnabled` unchanged and flashed the
+     * dashboard's charging card through its loading state.
+     *
+     * Real time, not [runTest]'s virtual clock: the store and its collector run on Dispatchers.IO, so
+     * a virtual clock would race them rather than wait for them.
+     */
+    @Test
+    fun `an unrelated key's write does not re-emit`() = runBlocking {
+        val flag = dataStore.createValue("flag", false)
+        val unrelated = longPreferencesKey("unrelated")
+
+        val seen = CopyOnWriteArrayList<Boolean>()
+        val collector = launch(Dispatchers.IO) { flag.flow.toList(seen) }
+        awaitSize(seen, 1)
+
+        // Four writes of genuinely new values, so DataStore really does emit a new snapshot each
+        // time — it is the *value* that has to stay quiet, not the store.
+        repeat(3) { i -> dataStore.store.edit { it[unrelated] = i.toLong() } }
+        dataStore.store.edit { it[unrelated] = 99L }
+
+        // A real change to our own key still gets through.
+        flag.value(true)
+        awaitSize(seen, 2)
+
+        seen.toList() shouldBe listOf(false, true)
+        collector.cancel()
+    }
+
+    /**
+     * Documents DataStore's own behaviour rather than this class's: an equal snapshot is suppressed
+     * by `SingleProcessDataStore` before any of our code runs, so this still passes with the
+     * dedupe removed. It is here precisely so nobody mistakes it for a guard — a regression test
+     * built on re-writing the *same* value would pass against the very bug it meant to catch.
+     */
+    @Test
+    fun `writing the same value again does not re-emit`() = runBlocking {
+        val flag = dataStore.createValue("flag", false)
+
+        val seen = CopyOnWriteArrayList<Boolean>()
+        val collector = launch(Dispatchers.IO) { flag.flow.toList(seen) }
+        awaitSize(seen, 1)
+
+        flag.value(true)
+        awaitSize(seen, 2)
+        repeat(3) { flag.value(true) }
+
+        seen.toList() shouldBe listOf(false, true)
+        collector.cancel()
+    }
+
+    /**
+     * A key name reused for a different type is the one way a raw value can be the wrong class.
+     * Degrading to the default beats throwing: a ClassCastException inside the reader would kill the
+     * collector's flow permanently, taking a working setting offline until the app restarts.
+     */
+    @Test
+    fun `a key stored under the wrong type reads the default instead of throwing`() = runTest {
+        dataStore.store.edit { it[stringPreferencesKey("flag")] = "not-a-boolean" }
+
+        dataStore.createValue("flag", true).value() shouldBe true
+    }
+
+    /** Waits for exactly [size] emissions, then a beat longer to catch a spurious extra one. */
+    private suspend fun awaitSize(seen: List<*>, size: Int) {
+        withTimeout(TIMEOUT) {
+            while (seen.size < size) delay(5)
+        }
+        delay(SETTLE)
+    }
+
+    private companion object {
+        const val TIMEOUT = 5_000L
+        const val SETTLE = 150L
+    }
+}

--- a/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
+++ b/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
@@ -1,0 +1,166 @@
+package eu.darken.amply.common.datastore
+
+import eu.darken.amply.alarm.core.ChargeAlarmConfig
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.common.serialization.SerializationModule
+import eu.darken.amply.common.theming.ThemeColor
+import eu.darken.amply.common.theming.ThemeMode
+import eu.darken.amply.common.theming.ThemeState
+import eu.darken.amply.common.theming.ThemeStyle
+import eu.darken.amply.fullcharge.core.ChargeSessionRecord
+import eu.darken.amply.fullcharge.core.InterruptionEvent
+import eu.darken.amply.fullcharge.core.InterruptionOutcome
+import eu.darken.amply.fullcharge.core.InterruptionReason
+import eu.darken.amply.fullcharge.core.RecoveryRecord
+import eu.darken.amply.fullcharge.core.WorkProvenance
+import eu.darken.amply.main.core.QuickAccessState
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+/**
+ * These records are a **stored format**, not just internal types: they outlive the process that
+ * wrote them. Pinning the exact JSON here means a rename, a reordered enum or a dropped default
+ * fails this test instead of silently resetting a user's charge session, owed restore or theme to
+ * defaults on the next launch.
+ */
+class StoredRecordFormatTest {
+
+    private val json: Json = SerializationModule.json()
+
+    private val provenance = WorkProvenance(token = "tok-a", pid = 42, bootCount = 7, createdAtMillis = 1_000L)
+
+    @Test
+    fun `session record encodes to the pinned shape`() {
+        val record = ChargeSessionRecord(
+            restorePolicy = ChargePolicy.FixedLimit(80),
+            startedAtMillis = 1_000L,
+            connectedSeen = true,
+            provenance = provenance,
+            workId = "wid-1",
+        )
+
+        json.encodeToString(ChargeSessionRecord.serializer(), record) shouldBe
+            """{"restorePolicy":"fixed:80","startedAtMillis":1000,"connectedSeen":true,""" +
+            """"provenance":{"token":"tok-a","pid":42,"bootCount":7,"createdAtMillis":1000},""" +
+            """"workId":"wid-1"}"""
+    }
+
+    @Test
+    fun `session record decodes from stored JSON`() {
+        val stored = """{"restorePolicy":"adaptive","startedAtMillis":5,"connectedSeen":false}"""
+
+        json.decodeFromString(ChargeSessionRecord.serializer(), stored) shouldBe ChargeSessionRecord(
+            restorePolicy = ChargePolicy.Adaptive,
+            startedAtMillis = 5L,
+            connectedSeen = false,
+            provenance = null,
+            workId = null,
+        )
+    }
+
+    @Test
+    fun `recovery record encodes to the pinned shape`() {
+        val record = RecoveryRecord(
+            target = ChargePolicy.Unrestricted,
+            workId = "wid-r",
+            provenance = provenance.copy(bootCount = null),
+        )
+
+        // Pinned literally, not round-tripped: encode-then-decode with the same serializer stays
+        // green through a @SerialName rename that would orphan every already-stored record.
+        json.encodeToString(RecoveryRecord.serializer(), record) shouldBe
+            """{"target":"unrestricted","workId":"wid-r",""" +
+            """"provenance":{"token":"tok-a","pid":42,"createdAtMillis":1000}}"""
+    }
+
+    @Test
+    fun `recovery record decodes from stored JSON`() {
+        val stored = """{"target":"fixed:90","workId":"wid-r"}"""
+
+        json.decodeFromString(RecoveryRecord.serializer(), stored) shouldBe RecoveryRecord(
+            target = ChargePolicy.FixedLimit(90),
+            workId = "wid-r",
+            provenance = null,
+        )
+    }
+
+    @Test
+    fun `every charge policy has a pinned wire value`() {
+        val expected = mapOf(
+            ChargePolicy.Unrestricted to "unrestricted",
+            ChargePolicy.Adaptive to "adaptive",
+            ChargePolicy.PauseAtFull to "pause_at_full",
+            ChargePolicy.FixedLimit(80) to "fixed:80",
+            ChargePolicy.FixedLimit(95) to "fixed:95",
+            ChargePolicy.FixedLimit(100) to "fixed:100",
+        )
+
+        expected.forEach { (policy, wire) ->
+            json.encodeToString(RecoveryRecord.serializer(), RecoveryRecord(target = policy)) shouldBe
+                """{"target":"$wire"}"""
+            json.decodeFromString(RecoveryRecord.serializer(), """{"target":"$wire"}""").target shouldBe policy
+        }
+    }
+
+    /**
+     * Everything except the policy must be optional. Provenance is diagnostic metadata; letting a
+     * missing `pid` collapse the record would drop a restore Amply still owes the user and leave the
+     * battery charging unrestricted.
+     */
+    @Test
+    fun `records survive missing auxiliary metadata`() {
+        val recovery = """{"target":"fixed:80","provenance":{"token":"old","bootCount":7}}"""
+        json.decodeFromString(RecoveryRecord.serializer(), recovery) shouldBe RecoveryRecord(
+            target = ChargePolicy.FixedLimit(80),
+            workId = null,
+            provenance = WorkProvenance(token = "old", pid = -1, bootCount = 7, createdAtMillis = 0L),
+        )
+
+        val session = """{"restorePolicy":"adaptive"}"""
+        json.decodeFromString(ChargeSessionRecord.serializer(), session) shouldBe ChargeSessionRecord(
+            restorePolicy = ChargePolicy.Adaptive,
+            startedAtMillis = 0L,
+            connectedSeen = false,
+        )
+    }
+
+    @Test
+    fun `interruption enums encode by name`() {
+        val event = InterruptionEvent(
+            occurredAtMillis = 10L,
+            reason = InterruptionReason.USER_STOPPED,
+            outcome = InterruptionOutcome.RESTORED_LATE,
+            workId = "wid-1",
+        )
+
+        json.encodeToString(InterruptionEvent.serializer(), event) shouldBe
+            """{"occurredAtMillis":10,"reason":"USER_STOPPED","outcome":"RESTORED_LATE","workId":"wid-1"}"""
+    }
+
+    @Test
+    fun `theme state encodes by enum name`() {
+        val state = ThemeState(
+            mode = ThemeMode.DARK,
+            style = ThemeStyle.HIGH_CONTRAST,
+            color = ThemeColor.BLUE,
+        )
+
+        json.encodeToString(ThemeState.serializer(), state) shouldBe
+            """{"mode":"DARK","style":"HIGH_CONTRAST","color":"BLUE"}"""
+    }
+
+    @Test
+    fun `absent fields fall back to defaults`() {
+        json.decodeFromString(ThemeState.serializer(), "{}") shouldBe ThemeState()
+        json.decodeFromString(QuickAccessState.serializer(), "{}") shouldBe QuickAccessState()
+        json.decodeFromString(ChargeAlarmConfig.serializer(), "{}") shouldBe ChargeAlarmConfig()
+    }
+
+    @Test
+    fun `unknown fields from a newer build are ignored`() {
+        val stored = """{"mode":"LIGHT","futureSetting":{"deeply":["nested"]}}"""
+
+        json.decodeFromString(ThemeState.serializer(), stored) shouldBe ThemeState(mode = ThemeMode.LIGHT)
+    }
+}

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/FullChargeStoreTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/FullChargeStoreTest.kt
@@ -1,14 +1,19 @@
 package eu.darken.amply.fullcharge.core
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.serialization.SerializationModule
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.job
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -20,32 +25,46 @@ class FullChargeStoreTest {
     lateinit var tempDir: File
 
     private val storeScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private val store by lazy {
-        FullChargeStore(
-            AppDataStore(
-                PreferenceDataStoreFactory.create(scope = storeScope) {
-                    File(tempDir, "test.preferences_pb")
-                },
-            ),
+    private val storeFile by lazy { File(tempDir, "test.preferences_pb") }
+    private val appDataStore by lazy {
+        AppDataStore(PreferenceDataStoreFactory.create(scope = storeScope) { storeFile })
+    }
+
+    // The production Json, so these tests exercise the encoding the app actually ships.
+    private val store by lazy { FullChargeStore(appDataStore, SerializationModule.json()) }
+
+    private val restartScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    /**
+     * A second store over the same file, standing in for the app relaunching after process death.
+     * The first store must be fully released first — DataStore allows only one active instance per
+     * file, which is exactly the constraint a real process death satisfies.
+     */
+    private suspend fun newStoreOverSameFile(): FullChargeStore {
+        storeScope.coroutineContext.job.cancelAndJoin()
+        return FullChargeStore(
+            AppDataStore(PreferenceDataStoreFactory.create(scope = restartScope) { storeFile }),
+            SerializationModule.json(),
         )
     }
 
     @AfterEach
     fun teardown() {
         storeScope.cancel()
+        restartScope.cancel()
     }
 
     @Test
     fun `any-level option defaults to off`() = runTest {
         store.isQuickFullChargeAnyLevel() shouldBe false
-        store.quickFullChargeAnyLevel.first() shouldBe false
+        store.quickFullChargeAnyLevel.flow.first() shouldBe false
     }
 
     @Test
     fun `any-level option round-trips`() = runTest {
         store.setQuickFullChargeAnyLevel(true)
         store.isQuickFullChargeAnyLevel() shouldBe true
-        store.quickFullChargeAnyLevel.first() shouldBe true
+        store.quickFullChargeAnyLevel.flow.first() shouldBe true
 
         store.setQuickFullChargeAnyLevel(false)
         store.isQuickFullChargeAnyLevel() shouldBe false
@@ -195,6 +214,89 @@ class FullChargeStoreTest {
 
         store.clearPendingRecoveryTarget()
         store.pendingRecoveryWorkId() shouldBe null
+    }
+
+    /**
+     * The property the whole session mechanism rests on: a restore that is owed must still be owed
+     * after the process dies. Rebuilds the store from the same file — a fresh [FullChargeStore] over
+     * a fresh DataStore, as a relaunched app would see it — rather than trusting the in-memory cache.
+     */
+    @Test
+    fun `an owed session and recovery survive a process restart`() = runTest {
+        store.startSession(
+            ChargePolicy.Adaptive,
+            startedAtMillis = 1_234L,
+            workId = "wid-1",
+            provenance = WorkProvenance("tok-a", 42, 7, 1_000L),
+        )
+        store.markConnected()
+        store.setPendingRecoveryTarget(
+            ChargePolicy.FixedLimit(90),
+            workId = "wid-r",
+            provenance = WorkProvenance("tok-r", 43, 7, 1_100L),
+        )
+        store.setLastSeenBootCount(7)
+
+        val restarted = newStoreOverSameFile()
+
+        restarted.currentSession() shouldBe ChargeSessionRecord(
+            restorePolicy = ChargePolicy.Adaptive,
+            startedAtMillis = 1_234L,
+            connectedSeen = true,
+            provenance = WorkProvenance("tok-a", 42, 7, 1_000L),
+            workId = "wid-1",
+        )
+        restarted.currentRecovery() shouldBe RecoveryRecord(
+            target = ChargePolicy.FixedLimit(90),
+            workId = "wid-r",
+            provenance = WorkProvenance("tok-r", 43, 7, 1_100L),
+        )
+        restarted.lastSeenBootCount() shouldBe 7
+    }
+
+    /**
+     * Metadata is not worth losing a restore over. A record missing `pid` (or any other auxiliary
+     * field) must still yield the policy Amply owes the user — dropping the record would leave the
+     * battery charging unrestricted with nothing left to trigger the restore.
+     */
+    @Test
+    fun `a record missing auxiliary metadata still yields its policy`() = runTest {
+        appDataStore.store.edit {
+            it[stringPreferencesKey("recovery.v2")] =
+                """{"target":"fixed:80","workId":"wid-r","provenance":{"token":"old","bootCount":7}}"""
+            it[stringPreferencesKey("session.v2")] = """{"restorePolicy":"adaptive"}"""
+        }
+
+        store.pendingRecoveryTarget() shouldBe ChargePolicy.FixedLimit(80)
+        store.pendingRecoveryWorkId() shouldBe "wid-r"
+        store.pendingRecoveryProvenance()?.pid shouldBe -1
+        store.currentSession()?.restorePolicy shouldBe ChargePolicy.Adaptive
+        store.currentSession()?.connectedSeen shouldBe false
+    }
+
+    /** An owner with no token identifies nobody, so it reads as un-owned rather than as a stranger. */
+    @Test
+    fun `a tokenless owner decodes to no provenance`() = runTest {
+        appDataStore.store.edit {
+            it[stringPreferencesKey("session.v2")] =
+                """{"restorePolicy":"adaptive","provenance":{"pid":9,"bootCount":7}}"""
+        }
+
+        val session = store.currentSession()
+        session?.restorePolicy shouldBe ChargePolicy.Adaptive
+        session?.provenance shouldBe null
+    }
+
+    /** A stored record whose policy this build cannot read must not resurrect as a wrong policy. */
+    @Test
+    fun `a session record with an unreadable policy decodes to no session`() = runTest {
+        store.startSession(ChargePolicy.Adaptive, startedAtMillis = 1L)
+        appDataStore.store.edit {
+            it[stringPreferencesKey("session.v2")] =
+                """{"restorePolicy":"fixed:not-a-number","startedAtMillis":1,"connectedSeen":false}"""
+        }
+
+        store.currentSession() shouldBe null
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/InterruptionAssessorTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/InterruptionAssessorTest.kt
@@ -3,6 +3,7 @@ package eu.darken.amply.fullcharge.core
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.serialization.SerializationModule
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
@@ -44,8 +45,8 @@ class InterruptionAssessorTest {
         appDataStore = AppDataStore(
             PreferenceDataStoreFactory.create(scope = scope) { File(tmp.newFolder(), "t.preferences_pb") },
         )
-        fullChargeStore = FullChargeStore(appDataStore)
-        interruptionStore = InterruptionStore(appDataStore)
+        fullChargeStore = FullChargeStore(appDataStore, SerializationModule.json())
+        interruptionStore = InterruptionStore(appDataStore, SerializationModule.json())
         assessor = InterruptionAssessor(
             fullChargeStore = fullChargeStore,
             interruptionStore = interruptionStore,
@@ -282,7 +283,7 @@ class InterruptionAssessorTest {
 
     @Test
     fun `a throwing interruption store never propagates`() = runTest {
-        val throwing = object : InterruptionStore(appDataStore) {
+        val throwing = object : InterruptionStore(appDataStore, SerializationModule.json()) {
             override suspend fun record(event: InterruptionEvent) {
                 throw RuntimeException("boom")
             }

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/InterruptionStoreTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/InterruptionStoreTest.kt
@@ -4,6 +4,7 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.serialization.SerializationModule
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -28,7 +29,7 @@ class InterruptionStoreTest {
             },
         )
     }
-    private val store by lazy { InterruptionStore(appDataStore) }
+    private val store by lazy { InterruptionStore(appDataStore, SerializationModule.json()) }
 
     @AfterEach
     fun teardown() {
@@ -104,7 +105,31 @@ class InterruptionStoreTest {
     @Test
     fun `a malformed stored enum decodes to no event`() = runTest {
         store.record(event())
-        appDataStore.store.edit { it[stringPreferencesKey("interruption.v1.outcome")] = "GARBAGE" }
+        writeRawRecord(
+            """{"occurredAtMillis":1000,"reason":"OTHER","outcome":"GARBAGE","workId":"tok-1"}""",
+        )
         store.event.first() shouldBe null
+    }
+
+    @Test
+    fun `a malformed stored record decodes to no event`() = runTest {
+        store.record(event())
+        writeRawRecord("{not json at all")
+        store.event.first() shouldBe null
+    }
+
+    /**
+     * A missing required field is as unreadable as a bad one — this is the all-or-nothing decode the
+     * event had when it lived across four keys, where any absent key meant "no event".
+     */
+    @Test
+    fun `a record missing a required field decodes to no event`() = runTest {
+        store.record(event())
+        writeRawRecord("""{"occurredAtMillis":1000,"reason":"OTHER"}""")
+        store.event.first() shouldBe null
+    }
+
+    private suspend fun writeRawRecord(json: String) {
+        appDataStore.store.edit { it[stringPreferencesKey("interruption.v2")] = json }
     }
 }

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/StatsDashboardStatesTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/StatsDashboardStatesTest.kt
@@ -1,19 +1,44 @@
 package eu.darken.amply.main.ui.dashboard
 
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import eu.darken.amply.common.AppDataStore
 import eu.darken.amply.stats.core.CaptureServiceHealth.NudgeOutcome
 import eu.darken.amply.stats.core.ChargeSessionSummary
 import eu.darken.amply.stats.core.ChargingType
+import eu.darken.amply.stats.core.StatsPreferences
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
 
 class StatsDashboardStatesTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val storeScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    @AfterEach
+    fun teardown() {
+        storeScope.cancel()
+    }
 
     private val lastSession = ChargeSessionSummary(
         id = 7,
@@ -96,5 +121,57 @@ class StatsDashboardStatesTest {
         ).take(2).toList()
 
         emissions.last() shouldBe StatsDashboardState(enabled = true, unavailable = true)
+    }
+
+    /**
+     * Regression for the charging card's ~20s "blip".
+     *
+     * Driven through the **real** [StatsPreferences] on a real store, because the bug lived in the
+     * wiring rather than in this function: the recorder stamps `lastCaptureWallMillis` on every
+     * sample, that write handed the whole Preferences snapshot to every collector, and an
+     * undeduplicated `captureEnabled` re-emitted `true` — restarting the `flatMapLatest` below and
+     * replaying its loading marker, which blanked the card's chart for a frame.
+     *
+     * Note the stimulus has to be an **unrelated key carrying a new value**. Re-writing
+     * `captureEnabled = true` would prove nothing: an equal snapshot is suppressed by DataStore
+     * itself, so that version of this test passes even against the broken code.
+     */
+    @Test
+    fun `a recorder timestamp write does not restart the stats flow`() = runBlocking {
+        val preferences = StatsPreferences(
+            AppDataStore(
+                PreferenceDataStoreFactory.create(scope = storeScope) { File(tempDir, "test.preferences_pb") },
+            ),
+        )
+        preferences.setCaptureEnabled(true)
+
+        var providersCreated = 0
+        val states = statsDashboardStates(
+            captureEnabled = preferences.captureEnabled.flow,
+            health = flowOf(NudgeOutcome.IDLE),
+            recentSessions = { providersCreated++; flowOf(emptyList()) },
+            sessionCount = { flowOf(0) },
+            currentSession = { flowOf(null) },
+        )
+
+        val seen = CopyOnWriteArrayList<StatsDashboardState>()
+        val collector = launch(Dispatchers.IO) { states.toList(seen) }
+        // Loading marker, then the first real data.
+        withTimeout(TIMEOUT) { while (seen.size < 2) delay(5) }
+
+        // Exactly what the recorder does on every recorded sample while charging.
+        repeat(3) { i -> preferences.setLastCaptureWallMillis(1_000L + i) }
+        delay(SETTLE)
+
+        seen.count { it.loading } shouldBe 1
+        providersCreated shouldBe 1
+        seen.size shouldBe 2
+
+        collector.cancel()
+    }
+
+    private companion object {
+        const val TIMEOUT = 5_000L
+        const val SETTLE = 200L
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,9 @@ plugins {
     id("com.android.application") version "9.1.0" apply false
     id("com.google.devtools.ksp") version "2.3.6" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.3.10" apply false
+    // Persisted settings records are JSON-encoded into the single Preferences DataStore; keep this
+    // version in lockstep with the Kotlin compiler AGP embeds (same as the compose plugin above).
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.3.10" apply false
     id("com.google.dagger.hilt.android") version "2.59.2" apply false
     // Renders @Preview composables to PNGs on the JVM for Play Store screenshots (see fastlane/).
     id("com.android.compose.screenshot") version "0.0.1-alpha15" apply false

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,6 +29,7 @@ private fun DependencyHandler.coreLibraryDesugaring(dependencyNotation: Any): De
 fun DependencyHandlerScope.addBaseKotlin() {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.Kotlin.coroutines}")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.Kotlin.coroutines}")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.Kotlin.serialization}")
 }
 
 fun DependencyHandlerScope.addBaseAndroid() {

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -1,6 +1,7 @@
 object Versions {
     object Kotlin {
         const val coroutines = "1.10.2"
+        const val serialization = "1.9.0"
     }
 
     object Dagger {


### PR DESCRIPTION
## What changed

The charging card on the dashboard no longer flickers. While plugged in with charge recording on, it used to visibly collapse and re-expand for a fraction of a second roughly every 20 seconds — losing its chart and elapsed time each time.

Under the hood this was one missing guard, so the fix also closes the whole class of bug: every stored setting now deduplicates itself, and a few settings that are only meaningful together (a charge session and who owns it, the restore Amply still owes you, the alarm config, theme and shortcut state) are stored as a single record instead of scattered keys, so they can never be read half-written.

**Existing app data is dropped.** Settings reset to defaults on first launch after installing this. Test users only, so no migration was written — but wipe app data before installing rather than updating in place, and don't update while a one-time full charge is running: that session's record won't carry over, and the protective limit wouldn't be restored automatically.

## Technical Context

**Root cause.** Amply keeps one shared Preferences DataStore. Preferences DataStore emits the *entire* snapshot to *every* collector on any write, and none of the 14 preference flows had `distinctUntilChanged()`. `ChargeStatsRecorder` stamps `lastCaptureWallMillis` on every recorded sample (`StatsCadence.CHARGING_MIN_INTERVAL_MILLIS = 20_000`, plus every 1% change) — always a new timestamp, so a genuinely new snapshot. That re-emitted `captureEnabled` unchanged, restarting the `flatMapLatest` in `statsDashboardStates` and replaying its `onStart` loading marker.

**Why the DSL rather than 14 `distinctUntilChanged()` calls.** The guard is a property of the shared-store design, not of any one facade, so it belongs in the primitive. Ported from SD Maid SE's `DataStoreValue`. It dedupes on the **raw stored value, before the reader runs** — so the comparison never depends on a domain type's `equals`, and no decoding happens for a duplicate emission.

**What the record consolidation does and does not buy.** It buys shorter facades and clean `update {}` read-modify-write. It does *not* buy atomicity or fewer emissions — the old code already wrote each record's keys in a single `edit {}`, and DataStore emits the whole snapshot regardless of how many keys changed. Worth stating explicitly since it's the intuitive-but-wrong justification.

**Corruption semantics are per record, deliberately.** Records whose decode was already all-or-nothing (session, recovery, interruption) keep a whole-record fallback. `ChargingPreferences` does not: its four facts degrade *independently* today, so a wholesale fallback would swap a valid Adaptive/90% protective baseline for the 80% default — and the next write would persist that downgrade. It parses field by field from a `JsonObject`, so a wrong-typed `lastRequestedAt` can't take a valid `protective` down with it.

For the same reason every field except the charge policy itself is optional. Provenance is diagnostic metadata; making `pid` required meant a record missing it decoded to `null` — silently discarding a restore Amply still owed the user. There's a test for exactly that.

**Also fixed:** a pre-existing torn read in `InterruptionAssessor.captureRecoveryPickup()`, which read recovery provenance, work id and session through four separate suspend calls and could pair fields from either side of a concurrent adopt or clear. Now one read each.

**Review guidance.** The risk is concentrated in `FullChargeStore` and `ChargingPreferences` — that's the persistence behind restoring the user's charge limit. `common/datastore/DataStoreValue.kt` is the primitive everything else rests on. The rest is mechanical.

## Verification

- 706 tests pass on both flavors; `lintVital` clean on all four beta/release variants; R8 release builds clean with no serialization stripping (new `kotlinx-serialization-json` dependency).
- Every new guard was checked against a **negative control** — reverting the fix must make its test fail. Removing the dedupe: 6 emissions instead of 2, and stats providers recreated 4× instead of 1×. Reverting per-field parsing, the metadata defaults and the alarm normalization dedupe: 7 targeted failures.
- One test in `DataStoreValueTest` is explicitly documented as *not* a guard — re-writing an equal value is suppressed by DataStore itself, so a regression test built that way would pass against the very bug it targets.

## Still outstanding

**Device pass not yet done.** Unit tests can't prove the HAL side. Before merge this needs: a full-charge session end-to-end, a force-stop mid-session (restore still happens + interruption card appears), and a reboot recovery (restore happens, no card). Plus confirming the card no longer blips while plugged in for >60s.
