### PR TITLE
General: Name the gesture in onboarding and test the dispatch core

### DIFF
--- a/app/src/main/java/eu/darken/amply/charging/core/DeviceInfo.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/DeviceInfo.kt
@@ -60,7 +60,8 @@ data class DeviceInfo(
             } ?: true,
         )
 
-        private const val ACTION_CHARGING_OPTIMIZATION =
+        /** Internal so tests can register a resolver for it instead of duplicating the action string. */
+        internal const val ACTION_CHARGING_OPTIMIZATION =
             "com.google.android.settings.intelligence.action.CHARGING_OPTIMIZATION"
 
         // Shared with the Samsung adapters; duplicated here to keep DeviceInfo dependency-free.

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -32,11 +32,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.UUID
 import javax.inject.Inject
@@ -56,25 +53,23 @@ class ChargeSessionService : Service() {
     @Inject lateinit var watchers: Set<@JvmSuppressWildcards ChargeMonitorWatcher>
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-    private val commandMutex = Mutex()
-    // A single-consumer FIFO queue: onStartCommand enqueues on the main thread in arrival order, so rapid
-    // taps (e.g. "∞ 80%" then "∞ 100%") can never be reordered by the dispatcher and finish on the wrong one.
-    private val commandChannel = Channel<Command>(Channel.UNLIMITED)
+    // Commands are a single-consumer FIFO queue: onStartCommand enqueues on the main thread in arrival
+    // order, so rapid taps (e.g. "∞ 80%" then "∞ 100%") can never be reordered by the dispatcher and
+    // finish on the wrong one.
     // Battery evaluations are serialized the same way: the receiver, the 30s poll, and the gesture
-    // expiry nudge all enqueue here and a single consumer drains under commandMutex. Concurrent
+    // expiry nudge all enqueue here and a single consumer drains under the same shared lock. Concurrent
     // evaluations could otherwise observe plug edges out of order and corrupt the gesture state
     // machine (its per-tick preference reads suspend, widening the reorder window). Each entry
-    // carries the time it was OBSERVED — queue latency under a busy mutex must not distort the
-    // gesture's 2-10s reconnect window — and the monitoring generation it belongs to, so events
-    // queued before a monitor stop/restart can never replay into freshly reset gesture state.
-    private val evaluationChannel = Channel<Evaluation>(Channel.UNLIMITED)
+    // carries the time it was OBSERVED — queue latency under a busy lock must not distort the
+    // gesture's 2-10s reconnect window — and the coordinator stamps the monitoring generation it
+    // belongs to, so events queued before a monitor stop/restart can never replay into freshly reset
+    // gesture state.
+    private val coordinator = DispatchCoordinator<Command, Evaluation>()
     private val quickGesture = QuickFullChargeGesture()
     private var monitorJob: Job? = null
     private var gestureExpiryJob: Job? = null
-    @Volatile private var monitorGeneration = 0
-    // Written under commandMutex, but read by the battery receiver/monitor loop outside it.
+    // Written under the dispatch lock, but read by the battery receiver/monitor loop outside it.
     @Volatile private var recoveryJob: Job? = null
-    @Volatile private var monitorReady = false
     private var settingObserverRegistered = false
     @Volatile private var restoring = false
     // One-shot interruption assessment for a freshly resumed persisted session: set when
@@ -84,11 +79,7 @@ class ChargeSessionService : Service() {
 
     private val batteryReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
-            if (monitorReady) {
-                evaluationChannel.trySend(
-                    Evaluation(intent, SystemClock.elapsedRealtime(), monitorGeneration),
-                )
-            }
+            coordinator.submitEvaluationIfOpen(Evaluation(intent, SystemClock.elapsedRealtime()))
         }
     }
 
@@ -96,11 +87,11 @@ class ChargeSessionService : Service() {
         override fun onChange(selfChange: Boolean) {
             if (restoring) return
             scope.launch {
-                commandMutex.withLock {
+                coordinator.withExclusive {
                     // Re-check under the lock: a persistent-policy command can set `restoring` after the
                     // fast-path check above but before we acquire the lock, so its own write must not be
                     // mistaken for a native change and cancelled.
-                    if (restoring) return@withLock
+                    if (restoring) return@withExclusive
                     // Respect a native Settings change instead of restoring over the user's choice.
                     manager.cancelWithoutRestore()
                     unregisterSettingObserver()
@@ -125,42 +116,21 @@ class ChargeSessionService : Service() {
             IntentFilter(Intent.ACTION_BATTERY_CHANGED),
             ContextCompat.RECEIVER_EXPORTED,
         )
-        // Drain commands one at a time, in the order they were enqueued. A failure in one command (e.g. a
-        // surface update throwing) must not kill the consumer and strand every command that follows.
-        scope.launch {
-            for (command in commandChannel) {
-                try {
-                    commandMutex.withLock { handleCommand(command.action, command.target) }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log(TAG, Logging.Priority.ERROR) { "Command ${command.action} failed: ${e.message}" }
-                }
-            }
-        }
-        scope.launch {
-            for (evaluation in evaluationChannel) {
-                if (evaluation.generation != monitorGeneration) continue
-                try {
-                    commandMutex.withLock {
-                        // Re-check under the lock: a command can restart monitoring between the
-                        // fast-path check above and the mutex acquisition.
-                        if (evaluation.generation != monitorGeneration) return@withLock
-                        evaluateBattery(evaluation.intent, evaluation.observedAtElapsed)
-                    }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log(TAG, Logging.Priority.ERROR) { "Battery evaluation failed: ${e.message}" }
-                }
-            }
-        }
+        // Drain commands and evaluations one at a time, in the order they were enqueued and never
+        // concurrently with each other. A failure in one item (e.g. a surface update throwing) must not
+        // kill its consumer and strand everything that follows.
+        coordinator.launch(
+            scope = scope,
+            onCommand = { handleCommand(it.action, it.target) },
+            onEvaluation = { evaluateBattery(it.intent, it.observedAtElapsed) },
+            onError = { label, e -> log(TAG, Logging.Priority.ERROR) { "$label failed: ${e.message}" } },
+        )
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         log(TAG) { "Start command: action=${intent?.action ?: "<restart>"}" }
         val target = intent?.getStringExtra(EXTRA_TARGET_POLICY)?.let(ChargePolicy::fromStableId)
-        commandChannel.trySend(Command(intent?.action, target))
+        coordinator.submitCommand(Command(intent?.action, target))
         return START_STICKY
     }
 
@@ -168,12 +138,14 @@ class ChargeSessionService : Service() {
 
     override fun onDestroy() {
         log(TAG) { "Destroying charge-session service" }
-        monitorReady = false
+        coordinator.close()
         monitorJob?.cancel()
         runCatching { unregisterReceiver(batteryReceiver) }
         unregisterSettingObserver()
-        commandChannel.close()
-        evaluationChannel.close()
+        // Closing the queues lets an in-flight handler finish; only cancelling the scope stops the
+        // consumers, so these two must stay adjacent — otherwise a waiter parked on the shared lock
+        // could acquire it and resume monitoring on a dying service.
+        coordinator.shutdown()
         scope.cancel()
         super.onDestroy()
     }
@@ -200,7 +172,7 @@ class ChargeSessionService : Service() {
         quickGesture.reset()
         registerSettingObserver()
         startMonitoringLoop()
-        monitorReady = true
+        coordinator.open()
         evaluateBattery()
         SurfaceUpdater.updateNow(this)
     }
@@ -232,7 +204,7 @@ class ChargeSessionService : Service() {
         }
         unregisterSettingObserver()
         startMonitoringLoop()
-        monitorReady = true
+        coordinator.open()
         // A watcher-only monitor gets the quiet notification; the gesture path re-posts its own in
         // evaluateBattery. Post here so an alarm-only start replaces the bootstrap notification.
         if (!gestureActive) startAsForeground(SessionNotifications.monitoring(this))
@@ -254,7 +226,7 @@ class ChargeSessionService : Service() {
 
     /**
      * Deliver a battery tick to every optional watcher. Evaluations are already serialized (single
-     * evaluation consumer under [commandMutex]), so no extra lock is needed. Each watcher is bounded
+     * evaluation consumer under the [coordinator]'s lock), so no extra lock is needed. Each watcher is bounded
      * by [WATCHER_TICK_BUDGET_MILLIS] and fully isolated: a hung or throwing watcher can neither
      * strand this evaluation nor, since restore already ran before this point, delay policy recovery.
      */
@@ -268,7 +240,7 @@ class ChargeSessionService : Service() {
     ) {
         if (watchers.isEmpty()) return
         // Pass the exact evaluated intent through; watchers parse it and read live properties off the
-        // evaluation thread. Building the readout here would put Binder calls under commandMutex and
+        // evaluation thread. Building the readout here would put Binder calls under the dispatch lock and
         // could delay a queued restore.
         val tick = ChargeMonitorTick(
             plugged = plugged,
@@ -293,19 +265,17 @@ class ChargeSessionService : Service() {
     private fun startMonitoringLoop() {
         // New monitoring run: evaluations queued for the previous run are stale and must be dropped
         // (the gesture state machine was or will be reset relative to them).
-        monitorGeneration++
+        coordinator.newRun()
         monitorJob?.cancel()
         monitorJob = scope.launch {
             while (true) {
                 delay(30_000)
-                evaluationChannel.trySend(
-                    Evaluation(null, SystemClock.elapsedRealtime(), monitorGeneration),
-                )
+                coordinator.submitEvaluation(Evaluation(null, SystemClock.elapsedRealtime()))
             }
         }
     }
 
-    // Callers must hold commandMutex — either via the evaluation consumer or a command handler.
+    // Callers must hold the dispatch lock — either via the evaluation consumer or a command handler.
     // observedAtElapsed is when the underlying battery state was seen, not when we process it.
     private suspend fun evaluateBattery(
         intent: Intent? = null,
@@ -348,7 +318,7 @@ class ChargeSessionService : Service() {
                     }
                     startAsForeground(SessionNotifications.session(this, connected = true))
                 }
-                // Restore is safety-critical and holds commandMutex: run it BEFORE any optional
+                // Restore is safety-critical and holds the dispatch lock: run it BEFORE any optional
                 // watcher work so a slow/hung watcher can never delay restoring the protective
                 // policy. The suppression latch was already set on the session's earlier
                 // (non-restore) ticks below; the post-restore re-evaluation sees it as fired.
@@ -374,7 +344,7 @@ class ChargeSessionService : Service() {
         // Resolved once, here: DeviceInfo.current() resolves activities/providers, reads Samsung
         // settings and queries UserManager, so it must stay behind the session early-return and the
         // cheap enabled check — hoisting it would newly charge active sessions, disabled gestures
-        // and watcher-only ticks for it under commandMutex. Net cost is unchanged: the availability
+        // and watcher-only ticks for it under the dispatch lock. Net cost is unchanged: the availability
         // check already resolved a selection at exactly this point, and the hardware decode below
         // reuses this one.
         val gestureEnabled = fullChargeStore.isQuickFullChargeEnabled()
@@ -472,11 +442,12 @@ class ChargeSessionService : Service() {
             // waiting evaluations must not push the deadline out — and dropped when it resolves.
             if (decision == QuickFullChargeDecision.WAITING_FOR_RECONNECT) {
                 if (gestureExpiryJob?.isActive != true) {
-                    val generation = monitorGeneration
+                    val generation = coordinator.currentGeneration
                     gestureExpiryJob = scope.launch {
                         delay(QuickFullChargeGesture.MAX_RECONNECT_MILLIS + 500)
-                        evaluationChannel.trySend(
-                            Evaluation(null, SystemClock.elapsedRealtime(), generation),
+                        coordinator.submitEvaluationForGeneration(
+                            Evaluation(null, SystemClock.elapsedRealtime()),
+                            generation,
                         )
                     }
                 }
@@ -486,9 +457,9 @@ class ChargeSessionService : Service() {
         }
     }
 
-    // All command handling is serialized by commandMutex; recoveryJob is only touched
+    // All command handling is serialized by the dispatch lock; recoveryJob is only touched
     // while holding it, except for the recovery job's own tail, which re-acquires the
-    // mutex (a cancelled job aborts at that acquisition instead of blocking a canceller).
+    // lock (a cancelled job aborts at that acquisition instead of blocking a canceller).
     private suspend fun handleCommand(action: String?, target: ChargePolicy?) {
         when (action) {
             ACTION_RESTORE -> if (recoveryJob?.isActive != true) restoreAndContinue()
@@ -538,9 +509,9 @@ class ChargeSessionService : Service() {
         if (recoveryJob?.isActive == true) return
         // Quiesce monitoring before recovery writes: with ACTION_CHECK the service can already be
         // alive in gesture-monitor mode, and the monitor loop / battery receiver run outside the
-        // command mutex — they could replace the recovering notification or begin a session that
+        // dispatch lock — they could replace the recovering notification or begin a session that
         // races the recovery re-writes.
-        monitorReady = false
+        coordinator.close()
         monitorJob?.cancel()
         gestureExpiryJob?.cancel()
         unregisterSettingObserver()
@@ -560,7 +531,7 @@ class ChargeSessionService : Service() {
             } finally {
                 // In finally so an interruption-bookkeeping failure can never strand the recovering
                 // foreground state.
-                commandMutex.withLock {
+                coordinator.withExclusive {
                     // continueGestureOrStop() awaits a surface update on every terminal branch, so no path here
                     // leaves the widget/tile un-pushed (some paths push more than once — updateAll is idempotent).
                     continueGestureOrStop()
@@ -619,7 +590,7 @@ class ChargeSessionService : Service() {
     ) {
         log(TAG) { "Restoring the saved charging policy" }
         restoring = true
-        monitorReady = false
+        coordinator.close()
         unregisterSettingObserver()
         // Read the stable work id before the restore clears the session record, so a later upgrade of
         // a still-pending interruption event can be matched to it (the owner token is not stable).
@@ -673,7 +644,7 @@ class ChargeSessionService : Service() {
         // choice is new owed work, so it gets a fresh work id.
         fullChargeStore.setPendingRecoveryTarget(policy, UUID.randomUUID().toString(), currentWorkProvenance())
         restoring = true
-        monitorReady = false
+        coordinator.close()
         try {
             // Suppress our own settings write from tripping the native-change observer, and end any one-time
             // session without restoring — the new persistent policy IS the intended end state.
@@ -715,13 +686,12 @@ class ChargeSessionService : Service() {
         adapterRegistry.select().adapter?.reconnectGestureSupported == true
 
     private fun stopMonitoring() {
-        monitorReady = false
         // Drop any un-consumed pickup assessment so it can never leak into a later session/monitor run.
         pendingSessionAssessment = null
         // A rapid disable/re-enable can reuse this service instance; neither stale gesture state
         // (an old reconnect window) nor already-queued evaluations from this run may survive into
         // the next monitoring run.
-        monitorGeneration++
+        coordinator.closeAndInvalidate()
         monitorJob?.cancel()
         gestureExpiryJob?.cancel()
         quickGesture.reset()
@@ -762,7 +732,6 @@ class ChargeSessionService : Service() {
     private data class Evaluation(
         val intent: Intent?,
         val observedAtElapsed: Long,
-        val generation: Int,
     )
 
     companion object {

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/DispatchCoordinator.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/DispatchCoordinator.kt
@@ -1,0 +1,169 @@
+package eu.darken.amply.fullcharge.core
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Serialized two-queue dispatch core for the charge-session service: a [C]ommand stream (user/system
+ * intents) and an [E]valuation stream (battery observations), drained by one consumer each but under a
+ * SINGLE shared lock, so a command and an evaluation can never run concurrently.
+ *
+ * Why a queue per stream rather than one:
+ * - Commands arrive from `onStartCommand` on the main thread and must keep arrival order, so rapid taps
+ *   (e.g. "∞ 80%" then "∞ 100%") can never be reordered by the dispatcher and finish on the wrong one.
+ * - Evaluations arrive from the battery receiver, the 30s poll and the gesture expiry nudge. Concurrent
+ *   evaluations could observe plug edges out of order and corrupt the gesture state machine (its per-tick
+ *   preference reads suspend, widening the reorder window).
+ *
+ * Deliberately free of Android types: payloads carry whatever the service needs (`Intent`,
+ * `SystemClock.elapsedRealtime()`), so this stays a pure, JVM-testable unit.
+ *
+ * **Generations.** [newRun] stamps a new monitoring run. Evaluations are stamped on submit and filtered
+ * TWICE on drain — once before acquiring the lock, and once inside it, because a command can restart
+ * monitoring between the two. Events queued for a previous run can therefore never replay into freshly
+ * reset state. The counter is an [AtomicInteger] so a concurrent increment cannot be lost, but that is
+ * NOT a substitute for the ordering invariant: [newRun] and [closeAndInvalidate] must only ever be called
+ * from a path that already holds exclusivity (a command handler, an evaluation handler, or [withExclusive]),
+ * so the generation change stays atomic with respect to the gesture-state mutation it belongs to.
+ *
+ * **Lifecycle.** [launch] is single-shot — a second consumer per channel would race for the lock and
+ * destroy FIFO order — and [shutdown] is terminal: afterwards [open] is a no-op and every submit is
+ * rejected. [shutdown] closes the queues and does NOTHING else; it deliberately does not cancel the
+ * consumers. Closing lets an in-flight handler finish; stopping them is the owning scope's job, and the
+ * owner must cancel that scope immediately after [shutdown]. Cancelling consumers here would release the
+ * lock mid-handler and let a waiter (e.g. a recovery tail parked in [withExclusive]) run during teardown.
+ */
+class DispatchCoordinator<C : Any, E : Any> {
+
+    private data class Envelope<E : Any>(val payload: E, val generation: Int)
+
+    // One lock for BOTH consumers: this is what serializes commands against evaluations.
+    private val mutex = Mutex()
+    private val commands = Channel<C>(Channel.UNLIMITED)
+    private val evaluations = Channel<Envelope<E>>(Channel.UNLIMITED)
+    private val generation = AtomicInteger(0)
+
+    @Volatile private var accepting = false
+    @Volatile private var launched = false
+    @Volatile private var terminated = false
+
+    /** The current monitoring run, for callers that must capture it now and submit later. */
+    val currentGeneration: Int get() = generation.get()
+
+    /** Whether broadcast-driven evaluations are currently welcome (see [submitEvaluationIfOpen]). */
+    val isOpen: Boolean get() = accepting
+
+    /**
+     * Start the two consumers on [scope]. Single-shot: throws [IllegalStateException] if already launched
+     * or if the coordinator was already shut down.
+     *
+     * A failure in one item (e.g. a surface update throwing) must not kill its consumer and strand
+     * everything queued behind it, so each item is isolated: cancellation propagates, anything else is
+     * reported to [onError] and the consumer moves on.
+     */
+    fun launch(
+        scope: CoroutineScope,
+        onCommand: suspend (C) -> Unit,
+        onEvaluation: suspend (E) -> Unit,
+        onError: (String, Exception) -> Unit,
+    ) {
+        check(!launched) { "DispatchCoordinator was already launched" }
+        check(!terminated) { "DispatchCoordinator was already shut down" }
+        launched = true
+        scope.launch {
+            for (command in commands) {
+                try {
+                    mutex.withLock { onCommand(command) }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    onError("Command $command", e)
+                }
+            }
+        }
+        scope.launch {
+            for (envelope in evaluations) {
+                if (envelope.generation != generation.get()) continue
+                try {
+                    mutex.withLock {
+                        // Re-check under the lock: a command can restart monitoring between the
+                        // fast-path check above and the mutex acquisition.
+                        if (envelope.generation != generation.get()) return@withLock
+                        onEvaluation(envelope.payload)
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    onError("Battery evaluation", e)
+                }
+            }
+        }
+    }
+
+    /**
+     * Begin a new monitoring run: everything already queued for the previous one is dropped on drain.
+     * Only call from an already-exclusive path (see the generations note in the class doc).
+     */
+    fun newRun(): Int = generation.incrementAndGet()
+
+    /** Start accepting broadcast-driven evaluations. No-op once [shutdown] has run. */
+    fun open() {
+        if (terminated) return
+        accepting = true
+    }
+
+    /** Stop accepting broadcast-driven evaluations; already-queued ones stay valid. */
+    fun close() {
+        accepting = false
+    }
+
+    /**
+     * Stop accepting broadcast-driven evaluations AND invalidate everything already queued for this run.
+     * Only call from an already-exclusive path (see the generations note in the class doc).
+     */
+    fun closeAndInvalidate() {
+        accepting = false
+        generation.incrementAndGet()
+    }
+
+    fun submitCommand(command: C): Boolean = commands.trySend(command).isSuccess
+
+    /** Submit only while [isOpen] — for the battery receiver, which must fall silent while quiesced. */
+    fun submitEvaluationIfOpen(payload: E): Boolean {
+        if (!accepting) return false
+        return submitEvaluation(payload)
+    }
+
+    /** Submit for the current run regardless of [isOpen] — for the service's own polling paths. */
+    fun submitEvaluation(payload: E): Boolean = submitEvaluationForGeneration(payload, generation.get())
+
+    /**
+     * Submit for a run captured earlier, so a delayed nudge scheduled while that run was live cannot
+     * leak into a later one.
+     */
+    fun submitEvaluationForGeneration(payload: E, generation: Int): Boolean =
+        evaluations.trySend(Envelope(payload, generation)).isSuccess
+
+    /**
+     * Run [block] under the same lock the consumers use, for service paths that mutate dispatch state
+     * outside a handler. A bare, cancellable delegation on purpose: no `NonCancellable`, no retry, no
+     * swallowed cancellation. Callers that cancel-and-join a job while already holding this lock rely on
+     * a cancelled waiter aborting its acquisition instead of blocking the canceller.
+     */
+    suspend fun <T> withExclusive(block: suspend () -> T): T = mutex.withLock { block() }
+
+    /**
+     * Close both queues. Terminal, and deliberately nothing else — see the lifecycle note in the class
+     * doc. The owner must cancel the consumers' scope immediately afterwards.
+     */
+    fun shutdown() {
+        terminated = true
+        commands.close()
+        evaluations.close()
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRecorder.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRecorder.kt
@@ -29,7 +29,7 @@ import javax.inject.Singleton
  * [offer], which only enqueues (never blocks, never touches Room/Binder/DataStore), so all
  * enrichment (parsing the intent, reading live battery properties, boot id) and all database work
  * happen on this recorder's own IO coroutine — entirely off the charge-session service's
- * `commandMutex`. That is what guarantees a slow read/write here can never delay the safety-critical
+ * dispatch lock. That is what guarantees a slow read/write here can never delay the safety-critical
  * charge-policy restore. The command channel is FIFO and unbounded, so plug transitions are never
  * dropped and enable/disable/clear/purge are strictly ordered against samples.
  *

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsWatcher.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsWatcher.kt
@@ -13,7 +13,7 @@ import javax.inject.Singleton
  *
  * [onBatteryTick] does no blocking work: it copies the tick into a [RawStatsTick] and hands it to
  * [ChargeStatsRecorder], which does every DataStore/Binder/Room read on its own IO thread. This runs
- * under the service's `commandMutex`, so it must never touch the disk or a Binder — a slow read here
+ * under the service's dispatch lock, so it must never touch the disk or a Binder — a slow read here
  * could delay the safety-critical charge-policy restore.
  */
 @Singleton

--- a/app/src/main/java/eu/darken/amply/stats/core/RawStatsTick.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/RawStatsTick.kt
@@ -7,7 +7,7 @@ import android.content.Intent
  * charge-session service's evaluation thread with only cheap in-memory copies plus a reference to
  * the already-evaluated battery intent — no Binder or DataStore reads. The recorder parses the
  * intent and reads live battery properties on its own IO thread, keeping all such work off the
- * service's `commandMutex`.
+ * service's dispatch lock.
  */
 data class RawStatsTick(
     val plugged: Boolean,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,7 +49,7 @@
     <string name="onboarding_feature_protection_body">Switch policies without digging through Android Settings.</string>
     <string name="onboarding_feature_fullcharge_title">Charge fully once</string>
     <string name="onboarding_feature_fullcharge_body">Protection returns automatically at full or when unplugged.</string>
-    <string name="onboarding_feature_shortcut_title">Optional cable shortcut</string>
+    <string name="onboarding_feature_shortcut_title">Optional reconnect gesture</string>
     <string name="onboarding_feature_shortcut_body" formatted="false">Reconnect at the 80% hold to request one full charge.</string>
     <string name="onboarding_next_action">Next</string>
     <string name="onboarding_continue_action">Get started</string>

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryPersistenceTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryPersistenceTest.kt
@@ -1,0 +1,183 @@
+package eu.darken.amply.charging.core
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
+import android.content.pm.ResolveInfo
+import android.os.Build
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.charging.core.access.AccessResolver
+import eu.darken.amply.charging.core.access.DirectSettingsBackend
+import eu.darken.amply.charging.core.access.LineageSettingsClient
+import eu.darken.amply.charging.core.access.ShizukuSettingsBackend
+import eu.darken.amply.charging.core.access.shizuku.ShizukuController
+import eu.darken.amply.charging.core.access.shizuku.ShizukuInstallationDetector
+import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.adapter.LineageChargingAdapter
+import eu.darken.amply.charging.core.adapter.LineageLabAdapter
+import eu.darken.amply.charging.core.adapter.OnePlusChargingAdapter
+import eu.darken.amply.charging.core.adapter.OnePlusLabAdapter
+import eu.darken.amply.charging.core.adapter.PixelChargingAdapter
+import eu.darken.amply.charging.core.adapter.SamsungLabAdapter
+import eu.darken.amply.charging.core.adapter.SamsungLegacyChargingAdapter
+import eu.darken.amply.charging.core.adapter.SamsungModernChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiLabAdapter
+import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.serialization.SerializationModule
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+import java.io.File
+
+/**
+ * Repository-level persistence of the two policy signals, over the real object graph (adapter registry,
+ * access resolver, direct WSS backend, DataStore-backed preferences) rather than the preference facade
+ * alone. What the facade tests cannot catch is the repository handing the wrong `persistent` flag down:
+ * a temporary session write recorded as persistent silently rewrites the user's protective baseline and
+ * disables the any-level reconnect-gesture basis.
+ *
+ * The baseline is deliberately [ChargePolicy.Adaptive], never FixedLimit(80): `protectivePolicyNow()`
+ * defaults to FixedLimit(80) when nothing was ever persisted, so applying 80 and asserting 80 would pass
+ * even if the repository recorded nothing at all.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36])
+class ChargingRepositoryPersistenceTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val storeScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    private lateinit var preferences: ChargingPreferences
+    private lateinit var repository: ChargingRepository
+
+    @Before
+    fun setup() {
+        // Satisfy the Pixel capability gate: Google manufacturer, a supported model, telephony, and a
+        // resolvable Settings Intelligence charging-optimization activity (API level comes from @Config).
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "Google")
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "Pixel 9 Pro")
+        val shadowPackageManager = shadowOf(context.packageManager)
+        shadowPackageManager.setSystemFeature(PackageManager.FEATURE_TELEPHONY, true)
+        shadowPackageManager.addResolveInfoForIntent(
+            Intent(DeviceInfo.ACTION_CHARGING_OPTIMIZATION),
+            ResolveInfo().apply {
+                activityInfo = ActivityInfo().apply {
+                    packageName = "com.google.android.settings.intelligence"
+                    name = "ChargingOptimizationActivity"
+                }
+            },
+        )
+
+        val appDataStore = AppDataStore(
+            PreferenceDataStoreFactory.create(scope = storeScope) {
+                File(tempFolder.root, "test.preferences_pb")
+            },
+        )
+        preferences = ChargingPreferences(appDataStore, SerializationModule.json())
+
+        val shizukuController = ShizukuController(context, ShizukuInstallationDetector(context))
+        repository = ChargingRepository(
+            context = context,
+            registry = AdapterRegistry(
+                context = context,
+                lineage = LineageChargingAdapter(LineageSettingsClient(context)),
+                lineageLab = LineageLabAdapter(),
+                pixel = PixelChargingAdapter(),
+                samsungModern = SamsungModernChargingAdapter(),
+                samsungLegacy = SamsungLegacyChargingAdapter(),
+                samsungLab = SamsungLabAdapter(),
+                xiaomi = XiaomiChargingAdapter(),
+                xiaomiLab = XiaomiLabAdapter(),
+                onePlus = OnePlusChargingAdapter(),
+                onePlusLab = OnePlusLabAdapter(),
+            ),
+            accessResolver = AccessResolver(
+                direct = DirectSettingsBackend(context),
+                shizuku = ShizukuSettingsBackend(shizukuController),
+            ),
+            preferences = preferences,
+            shizukuController = shizukuController,
+            // A real WorkManager scheduler adds nothing here; the surface re-push is out of scope.
+            settleScheduler = object : SettleScheduler {
+                override fun schedule(requestedAtMillis: Long) = Unit
+            },
+        )
+    }
+
+    @After
+    fun teardown() {
+        storeScope.cancel()
+    }
+
+    @Test
+    fun `a persistent apply records both the persistent policy and the protective baseline`() = runTest {
+        grantWriteSecureSettings()
+
+        repository.applyPersistent(ChargePolicy.Adaptive).success shouldBe true
+
+        preferences.lastPersistentPolicyNow() shouldBe ChargePolicy.Adaptive
+        preferences.protectivePolicyNow() shouldBe ChargePolicy.Adaptive
+    }
+
+    /** The regression that would silently disable the any-level gesture basis. */
+    @Test
+    fun `a temporary apply leaves the persistent policy and the protective baseline untouched`() = runTest {
+        grantWriteSecureSettings()
+        repository.applyPersistent(ChargePolicy.Adaptive).success shouldBe true
+
+        repository.applyTemporary(ChargePolicy.Unrestricted).success shouldBe true
+
+        preferences.lastRequestedNow() shouldBe ChargePolicy.Unrestricted
+        preferences.lastPersistentPolicyNow() shouldBe ChargePolicy.Adaptive
+        preferences.protectivePolicyNow() shouldBe ChargePolicy.Adaptive
+    }
+
+    @Test
+    fun `a forced persistent re-apply moves both signals`() = runTest {
+        grantWriteSecureSettings()
+        repository.applyPersistent(ChargePolicy.Adaptive).success shouldBe true
+
+        repository.reapplyPersistent(ChargePolicy.FixedLimit(80)).success shouldBe true
+
+        preferences.lastPersistentPolicyNow() shouldBe ChargePolicy.FixedLimit(80)
+        preferences.protectivePolicyNow() shouldBe ChargePolicy.FixedLimit(80)
+    }
+
+    /** A write that never landed must leave no journal at all — neither persistent nor temporary. */
+    @Test
+    fun `a failed apply records nothing`() = runTest {
+        revokeWriteSecureSettings()
+
+        repository.applyPersistent(ChargePolicy.Adaptive).success shouldBe false
+
+        preferences.lastPersistentPolicyNow() shouldBe null
+        preferences.lastRequestedNow() shouldBe null
+        preferences.lastRequestedAtNow() shouldBe 0L
+    }
+
+    private fun grantWriteSecureSettings() = shadowOf(context as Application)
+        .grantPermissions(Manifest.permission.WRITE_SECURE_SETTINGS)
+
+    private fun revokeWriteSecureSettings() = shadowOf(context as Application)
+        .denyPermissions(Manifest.permission.WRITE_SECURE_SETTINGS)
+}

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/DispatchCoordinatorTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/DispatchCoordinatorTest.kt
@@ -1,0 +1,329 @@
+package eu.darken.amply.fullcharge.core
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * The dispatch core of [ChargeSessionService]: FIFO per stream, mutual exclusion across both streams,
+ * generation filtering, and the lifecycle rules the service depends on.
+ *
+ * Wherever a test claims to prove exclusion, the handler suspends on a [CompletableDeferred]. With
+ * non-suspending handlers on a single test dispatcher an "only one ran at a time" assertion holds even
+ * with the lock deleted, so it would prove nothing.
+ */
+class DispatchCoordinatorTest {
+
+    private val commandsSeen = mutableListOf<String>()
+    private val evaluationsSeen = mutableListOf<String>()
+    private val errors = mutableListOf<Pair<String, Exception>>()
+
+    private var onCommand: suspend (String) -> Unit = { commandsSeen += it }
+    private var onEvaluation: suspend (String) -> Unit = { evaluationsSeen += it }
+
+    private fun TestScope.launched(): DispatchCoordinator<String, String> =
+        DispatchCoordinator<String, String>().also { it.launchInto(backgroundScope) }
+
+    private fun DispatchCoordinator<String, String>.launchInto(scope: CoroutineScope) = launch(
+        scope = scope,
+        onCommand = { onCommand(it) },
+        onEvaluation = { onEvaluation(it) },
+        onError = { label, e -> errors += label to e },
+    )
+
+    // --- Ordering ---------------------------------------------------------------------------------
+
+    @Test
+    fun `commands drain in submission order`() = runTest {
+        val coordinator = launched()
+
+        coordinator.submitCommand("a") shouldBe true
+        coordinator.submitCommand("b") shouldBe true
+        coordinator.submitCommand("c") shouldBe true
+        advanceUntilIdle()
+
+        commandsSeen shouldBe listOf("a", "b", "c")
+    }
+
+    @Test
+    fun `evaluations drain in submission order`() = runTest {
+        val coordinator = launched()
+
+        coordinator.submitEvaluation("A") shouldBe true
+        coordinator.submitEvaluation("B") shouldBe true
+        coordinator.submitEvaluation("C") shouldBe true
+        advanceUntilIdle()
+
+        evaluationsSeen shouldBe listOf("A", "B", "C")
+    }
+
+    // --- Per-item failure isolation ---------------------------------------------------------------
+
+    @Test
+    fun `a throwing command is reported and the consumer keeps draining`() = runTest {
+        onCommand = {
+            if (it == "boom") throw IllegalStateException("nope")
+            commandsSeen += it
+        }
+        val coordinator = launched()
+
+        coordinator.submitCommand("boom")
+        coordinator.submitCommand("next")
+        advanceUntilIdle()
+
+        commandsSeen shouldBe listOf("next")
+        errors.map { it.first } shouldBe listOf("Command boom")
+        errors.single().second.message shouldBe "nope"
+    }
+
+    @Test
+    fun `a throwing evaluation is reported and the consumer keeps draining`() = runTest {
+        onEvaluation = {
+            if (it == "boom") throw IllegalStateException("nope")
+            evaluationsSeen += it
+        }
+        val coordinator = launched()
+
+        coordinator.submitEvaluation("boom")
+        coordinator.submitEvaluation("next")
+        advanceUntilIdle()
+
+        evaluationsSeen shouldBe listOf("next")
+        errors.map { it.first } shouldBe listOf("Battery evaluation")
+    }
+
+    // --- Generations ------------------------------------------------------------------------------
+
+    @Test
+    fun `an evaluation queued before a new run is dropped`() = runTest {
+        val coordinator = launched()
+
+        coordinator.submitEvaluation("stale")
+        coordinator.newRun()
+        coordinator.submitEvaluation("live")
+        advanceUntilIdle()
+
+        evaluationsSeen shouldBe listOf("live")
+    }
+
+    /**
+     * The post-lock re-check specifically: the consumer already passed the fast-path check and is parked
+     * on the lock when a command restarts monitoring. Queue-then-newRun only covers the fast path.
+     */
+    @Test
+    fun `an evaluation that passed the fast path is dropped when the run changes under the lock`() = runTest {
+        val coordinator = launched()
+        val gate = CompletableDeferred<Unit>()
+        backgroundScope.launch { coordinator.withExclusive { gate.await() } }
+        advanceUntilIdle()
+
+        coordinator.submitEvaluation("stale")
+        // The evaluation consumer receives it, passes the generation fast path, and parks on the lock.
+        advanceUntilIdle()
+        coordinator.newRun()
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        evaluationsSeen shouldBe emptyList()
+    }
+
+    @Test
+    fun `a stale captured generation is dropped while the live one is delivered`() = runTest {
+        val coordinator = launched()
+        val stale = coordinator.currentGeneration
+        coordinator.newRun()
+
+        coordinator.submitEvaluationForGeneration("stale", stale)
+        coordinator.submitEvaluationForGeneration("live", coordinator.currentGeneration)
+        advanceUntilIdle()
+
+        evaluationsSeen shouldBe listOf("live")
+    }
+
+    // --- Open / closed ----------------------------------------------------------------------------
+
+    @Test
+    fun `submitEvaluationIfOpen drops while closed and enqueues while open`() = runTest {
+        val coordinator = launched()
+
+        coordinator.isOpen shouldBe false
+        coordinator.submitEvaluationIfOpen("closed") shouldBe false
+        coordinator.open()
+        coordinator.isOpen shouldBe true
+        coordinator.submitEvaluationIfOpen("open") shouldBe true
+        advanceUntilIdle()
+
+        evaluationsSeen shouldBe listOf("open")
+    }
+
+    /** The 30s poll and the expiry nudge submit unconditionally — only the receiver gates on open. */
+    @Test
+    fun `submitEvaluation enqueues even while closed`() = runTest {
+        val coordinator = launched()
+
+        coordinator.isOpen shouldBe false
+        coordinator.submitEvaluation("poll") shouldBe true
+        advanceUntilIdle()
+
+        evaluationsSeen shouldBe listOf("poll")
+    }
+
+    @Test
+    fun `closeAndInvalidate stops accepting and invalidates what is already queued`() = runTest {
+        val coordinator = launched()
+        coordinator.open()
+        coordinator.submitEvaluationIfOpen("queued") shouldBe true
+
+        coordinator.closeAndInvalidate()
+
+        coordinator.isOpen shouldBe false
+        coordinator.submitEvaluationIfOpen("after") shouldBe false
+        advanceUntilIdle()
+        evaluationsSeen shouldBe emptyList()
+    }
+
+    // --- Mutual exclusion -------------------------------------------------------------------------
+
+    @Test
+    fun `a suspended command handler blocks a queued evaluation from starting`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        onCommand = {
+            commandsSeen += it
+            gate.await()
+        }
+        val coordinator = launched()
+
+        coordinator.submitCommand("held")
+        coordinator.submitEvaluation("waiting")
+        advanceUntilIdle()
+
+        commandsSeen shouldBe listOf("held")
+        evaluationsSeen shouldBe emptyList()
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        evaluationsSeen shouldBe listOf("waiting")
+    }
+
+    @Test
+    fun `withExclusive blocks both consumers until it releases`() = runTest {
+        val coordinator = launched()
+        val gate = CompletableDeferred<Unit>()
+        backgroundScope.launch { coordinator.withExclusive { gate.await() } }
+        advanceUntilIdle()
+
+        coordinator.submitCommand("c")
+        coordinator.submitEvaluation("e")
+        advanceUntilIdle()
+
+        commandsSeen shouldBe emptyList()
+        evaluationsSeen shouldBe emptyList()
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        commandsSeen shouldBe listOf("c")
+        evaluationsSeen shouldBe listOf("e")
+    }
+
+    /**
+     * ACTION_START cancel-and-joins the recovery job while already holding the lock, and the recovery
+     * tail waits on that same lock. That only avoids deadlock because a cancelled waiter aborts its
+     * acquisition instead of blocking the canceller.
+     */
+    @Test
+    fun `a waiter cancelled while the lock is held aborts its acquisition`() = runTest {
+        val coordinator = launched()
+        val gate = CompletableDeferred<Unit>()
+        backgroundScope.launch { coordinator.withExclusive { gate.await() } }
+        advanceUntilIdle()
+
+        var ran = false
+        val waiter = backgroundScope.launch { coordinator.withExclusive { ran = true } }
+        advanceUntilIdle()
+
+        // Cancelled and joined WHILE the lock is still held: the join must complete.
+        waiter.cancelAndJoin()
+        ran shouldBe false
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        ran shouldBe false
+    }
+
+    // --- Lifecycle --------------------------------------------------------------------------------
+
+    @Test
+    fun `launching twice throws`() = runTest {
+        val coordinator = launched()
+
+        shouldThrow<IllegalStateException> { coordinator.launchInto(backgroundScope) }
+    }
+
+    @Test
+    fun `launching after shutdown throws`() = runTest {
+        val coordinator = DispatchCoordinator<String, String>()
+        coordinator.shutdown()
+
+        shouldThrow<IllegalStateException> { coordinator.launchInto(backgroundScope) }
+    }
+
+    @Test
+    fun `open and every submit are inert after shutdown`() = runTest {
+        val coordinator = launched()
+
+        coordinator.shutdown()
+
+        coordinator.open()
+        coordinator.isOpen shouldBe false
+        coordinator.submitCommand("c") shouldBe false
+        coordinator.submitEvaluation("e") shouldBe false
+        coordinator.submitEvaluationIfOpen("e") shouldBe false
+        coordinator.submitEvaluationForGeneration("e", coordinator.currentGeneration) shouldBe false
+        advanceUntilIdle()
+
+        commandsSeen shouldBe emptyList()
+        evaluationsSeen shouldBe emptyList()
+    }
+
+    /**
+     * shutdown() closes the queues and nothing else: an in-flight handler runs to completion (only the
+     * owner cancelling the scope stops it), and both consumers end once the queues are drained.
+     */
+    @Test
+    fun `shutdown ends both consumers without cutting an in-flight handler short`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        var finished = false
+        onCommand = {
+            commandsSeen += it
+            gate.await()
+            finished = true
+        }
+        val coordinator = launched()
+
+        coordinator.submitCommand("held")
+        advanceUntilIdle()
+        commandsSeen shouldBe listOf("held")
+        finished shouldBe false
+
+        coordinator.shutdown()
+        advanceUntilIdle()
+        finished shouldBe false
+        consumersActive() shouldBe true
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        finished shouldBe true
+        consumersActive() shouldBe false
+    }
+
+    private fun TestScope.consumersActive(): Boolean =
+        backgroundScope.coroutineContext[Job]!!.children.any { it.isActive }
+}

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/DispatchCoordinatorTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/DispatchCoordinatorTest.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
@@ -19,6 +19,13 @@ import org.junit.jupiter.api.Test
  * Wherever a test claims to prove exclusion, the handler suspends on a [CompletableDeferred]. With
  * non-suspending handlers on a single test dispatcher an "only one ran at a time" assertion holds even
  * with the lock deleted, so it would prove nothing.
+ *
+ * The consumers are endless loops, so they live in [TestScope.backgroundScope] — anywhere else and
+ * [runTest] would hang waiting for them. That makes them *background* work to the test scheduler, and
+ * `advanceUntilIdle()` deliberately stops as soon as no **foreground** task is left: with the whole
+ * coordinator in the background it runs nothing at all and every assertion sees an empty list. Drain with
+ * [runCurrent] instead, which runs every task queued at the current virtual time regardless of tier. None
+ * of these tests use virtual delays, so that is a full drain.
  */
 class DispatchCoordinatorTest {
 
@@ -48,7 +55,7 @@ class DispatchCoordinatorTest {
         coordinator.submitCommand("a") shouldBe true
         coordinator.submitCommand("b") shouldBe true
         coordinator.submitCommand("c") shouldBe true
-        advanceUntilIdle()
+        runCurrent()
 
         commandsSeen shouldBe listOf("a", "b", "c")
     }
@@ -60,7 +67,7 @@ class DispatchCoordinatorTest {
         coordinator.submitEvaluation("A") shouldBe true
         coordinator.submitEvaluation("B") shouldBe true
         coordinator.submitEvaluation("C") shouldBe true
-        advanceUntilIdle()
+        runCurrent()
 
         evaluationsSeen shouldBe listOf("A", "B", "C")
     }
@@ -77,7 +84,7 @@ class DispatchCoordinatorTest {
 
         coordinator.submitCommand("boom")
         coordinator.submitCommand("next")
-        advanceUntilIdle()
+        runCurrent()
 
         commandsSeen shouldBe listOf("next")
         errors.map { it.first } shouldBe listOf("Command boom")
@@ -94,7 +101,7 @@ class DispatchCoordinatorTest {
 
         coordinator.submitEvaluation("boom")
         coordinator.submitEvaluation("next")
-        advanceUntilIdle()
+        runCurrent()
 
         evaluationsSeen shouldBe listOf("next")
         errors.map { it.first } shouldBe listOf("Battery evaluation")
@@ -109,7 +116,7 @@ class DispatchCoordinatorTest {
         coordinator.submitEvaluation("stale")
         coordinator.newRun()
         coordinator.submitEvaluation("live")
-        advanceUntilIdle()
+        runCurrent()
 
         evaluationsSeen shouldBe listOf("live")
     }
@@ -123,14 +130,14 @@ class DispatchCoordinatorTest {
         val coordinator = launched()
         val gate = CompletableDeferred<Unit>()
         backgroundScope.launch { coordinator.withExclusive { gate.await() } }
-        advanceUntilIdle()
+        runCurrent()
 
         coordinator.submitEvaluation("stale")
         // The evaluation consumer receives it, passes the generation fast path, and parks on the lock.
-        advanceUntilIdle()
+        runCurrent()
         coordinator.newRun()
         gate.complete(Unit)
-        advanceUntilIdle()
+        runCurrent()
 
         evaluationsSeen shouldBe emptyList()
     }
@@ -143,7 +150,7 @@ class DispatchCoordinatorTest {
 
         coordinator.submitEvaluationForGeneration("stale", stale)
         coordinator.submitEvaluationForGeneration("live", coordinator.currentGeneration)
-        advanceUntilIdle()
+        runCurrent()
 
         evaluationsSeen shouldBe listOf("live")
     }
@@ -159,7 +166,7 @@ class DispatchCoordinatorTest {
         coordinator.open()
         coordinator.isOpen shouldBe true
         coordinator.submitEvaluationIfOpen("open") shouldBe true
-        advanceUntilIdle()
+        runCurrent()
 
         evaluationsSeen shouldBe listOf("open")
     }
@@ -171,7 +178,7 @@ class DispatchCoordinatorTest {
 
         coordinator.isOpen shouldBe false
         coordinator.submitEvaluation("poll") shouldBe true
-        advanceUntilIdle()
+        runCurrent()
 
         evaluationsSeen shouldBe listOf("poll")
     }
@@ -186,7 +193,7 @@ class DispatchCoordinatorTest {
 
         coordinator.isOpen shouldBe false
         coordinator.submitEvaluationIfOpen("after") shouldBe false
-        advanceUntilIdle()
+        runCurrent()
         evaluationsSeen shouldBe emptyList()
     }
 
@@ -203,13 +210,13 @@ class DispatchCoordinatorTest {
 
         coordinator.submitCommand("held")
         coordinator.submitEvaluation("waiting")
-        advanceUntilIdle()
+        runCurrent()
 
         commandsSeen shouldBe listOf("held")
         evaluationsSeen shouldBe emptyList()
 
         gate.complete(Unit)
-        advanceUntilIdle()
+        runCurrent()
         evaluationsSeen shouldBe listOf("waiting")
     }
 
@@ -218,17 +225,17 @@ class DispatchCoordinatorTest {
         val coordinator = launched()
         val gate = CompletableDeferred<Unit>()
         backgroundScope.launch { coordinator.withExclusive { gate.await() } }
-        advanceUntilIdle()
+        runCurrent()
 
         coordinator.submitCommand("c")
         coordinator.submitEvaluation("e")
-        advanceUntilIdle()
+        runCurrent()
 
         commandsSeen shouldBe emptyList()
         evaluationsSeen shouldBe emptyList()
 
         gate.complete(Unit)
-        advanceUntilIdle()
+        runCurrent()
         commandsSeen shouldBe listOf("c")
         evaluationsSeen shouldBe listOf("e")
     }
@@ -243,18 +250,18 @@ class DispatchCoordinatorTest {
         val coordinator = launched()
         val gate = CompletableDeferred<Unit>()
         backgroundScope.launch { coordinator.withExclusive { gate.await() } }
-        advanceUntilIdle()
+        runCurrent()
 
         var ran = false
         val waiter = backgroundScope.launch { coordinator.withExclusive { ran = true } }
-        advanceUntilIdle()
+        runCurrent()
 
         // Cancelled and joined WHILE the lock is still held: the join must complete.
         waiter.cancelAndJoin()
         ran shouldBe false
 
         gate.complete(Unit)
-        advanceUntilIdle()
+        runCurrent()
         ran shouldBe false
     }
 
@@ -287,7 +294,7 @@ class DispatchCoordinatorTest {
         coordinator.submitEvaluation("e") shouldBe false
         coordinator.submitEvaluationIfOpen("e") shouldBe false
         coordinator.submitEvaluationForGeneration("e", coordinator.currentGeneration) shouldBe false
-        advanceUntilIdle()
+        runCurrent()
 
         commandsSeen shouldBe emptyList()
         evaluationsSeen shouldBe emptyList()
@@ -309,17 +316,17 @@ class DispatchCoordinatorTest {
         val coordinator = launched()
 
         coordinator.submitCommand("held")
-        advanceUntilIdle()
+        runCurrent()
         commandsSeen shouldBe listOf("held")
         finished shouldBe false
 
         coordinator.shutdown()
-        advanceUntilIdle()
+        runCurrent()
         finished shouldBe false
         consumersActive() shouldBe true
 
         gate.complete(Unit)
-        advanceUntilIdle()
+        runCurrent()
         finished shouldBe true
         consumersActive() shouldBe false
     }


### PR DESCRIPTION
## What changed

**User-visible:** one string. The onboarding feature page called the unplug/replug feature an "Optional cable shortcut"; it is now "Optional reconnect gesture", matching what the dashboard, the settings screen and the ongoing notification have called it since #30. That was the last surface still using a different name.

**Everything else is internal, with no user-facing behaviour change:** the charge-session service's dispatch core is now a separate, unit-testable class, and two new test suites cover behaviour that previously had none.

## Technical Context

### Dispatch core extraction

`ChargeSessionService` kept its two unbounded FIFO queues, their single consumers, the one shared lock and the monitoring generation/ready gate as private fields, so none of it could be tested without a device. That machinery is now `DispatchCoordinator<C, E>` — generic and free of Android types, because the payloads (`Intent`, `elapsedRealtime()`) stay in the service. That is what makes it a plain JVM unit.

This is a **behaviour-preserving refactor**, deliberately mapped 1:1 onto the previous call sites, on a `specialUse` foreground service that controls real charge hardware. Three properties were treated as load-bearing rather than incidental, because each is easy to "clean up" into a bug:

- **`shutdown()` closes the queues and does nothing else.** It must not cancel the consumers. Closing lets an in-flight handler finish; stopping them is `scope.cancel()`'s job, and `onDestroy` still calls it immediately afterwards. Cancelling consumers there would release the shared lock mid-handler and let the recovery-job tail — parked in `withExclusive` — run `continueGestureOrStop()` during teardown, reopening monitoring on a dying service.
- **`withExclusive` is a bare, cancellable `mutex.withLock`.** No `NonCancellable`, no retry, no swallowed cancellation: `ACTION_START` and `ACTION_SET_PERSISTENT_POLICY` cancel-and-`join()` the recovery job *while already holding that lock*, and only a cancelled waiter aborting its acquisition prevents deadlock.
- **`launch()` is single-shot, `shutdown()` is terminal.** A second consumer per queue would race for the lock and silently destroy the FIFO ordering the queues exist to guarantee.

The gating asymmetry is preserved exactly: only the battery receiver gates on `isOpen`; the 30-second poll and the reconnect-window expiry nudge submit unconditionally, and the expiry nudge carries the generation captured when its window opened rather than the current one. Generation is filtered twice — before taking the lock and again inside it, since a command can restart monitoring in between. The counter moved to an `AtomicInteger`; that removes a latent non-atomic `++` but is not a substitute for the ordering invariant, which is documented on the class.

### Test coverage

`DispatchCoordinatorTest` (17 cases) pins FIFO per stream, cross-stream exclusion, generation filtering including the post-lock re-check, cancellable acquisition, and the lifecycle rules. Exclusion is proven with handlers suspended on a `CompletableDeferred` — with non-suspending handlers on one test dispatcher, an "only one ran at a time" assertion holds even with the lock deleted.

Worth knowing for anyone writing coroutine tests here: `advanceUntilIdle()` only drains **foreground** events. These consumers are endless `for (x in channel)` loops, so they must live in `runTest`'s `backgroundScope` — which made `advanceUntilIdle()` a no-op that executed zero tasks. `runCurrent()` has no tier filter and is the correct primitive. The suite was then mutation-tested to confirm it is not vacuous: splitting the shared lock fails 3 cases, removing the post-lock generation check fails 1, and wrapping `withExclusive` in `NonCancellable` hangs the cancellation test.

`ChargingRepositoryPersistenceTest` (Robolectric, real object graph — there is no mocking library here) pins that a temporary override cannot overwrite the saved persistent policy. Its baseline is deliberately `Adaptive`: `protectivePolicyNow()` *defaults* to `FixedLimit(80)`, so applying 80 and asserting 80 would pass even if the repository wrote nothing. `DeviceInfo.ACTION_CHARGING_OPTIMIZATION` was widened `private` → `internal` so the test references the constant instead of duplicating the action string.

### Review guidance

The extraction is the risk surface; the mapping table is the thing to check, particularly the four `close()` sites, the single `closeAndInvalidate()`, and the two `open()` sites. Everything else is tests plus one string.

## Verification

760 tests per flavour (739 + 21 new), lint for both flavours in beta and release, and both flavour debug assembles — verified from the test-result XML on disk, not just the task summary.

Device-verified on a Pixel 8 (Android 17): the gesture arms on live hardware evidence, an unplug/replug triggers a session, restore returns the protective policy, a sub-2-second replug is correctly rejected by the debounce floor, and the reconnect-window expiry nudge fires 10.549 s after unplug — far too early for the 30-second poll to account for it, which is what makes it evidence that the captured-generation path still works.

**Not verified on hardware:** the stale-generation race — a nudge captured for one monitoring run must not act on the next. Reaching it needs a monitoring restart inside a 10.5-second window; UI interaction was too slow, and the service is not exported so it cannot be driven from adb. It is covered by unit tests and by the mutation testing above, but has no on-device confirmation.
