### PR TITLE
FullCharge: Silence the gesture notification, warn on failed restores

### DIFF
--- a/app/src/main/java/eu/darken/amply/fullcharge/core/SessionNotifications.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/SessionNotifications.kt
@@ -18,6 +18,8 @@ import eu.darken.amply.main.ui.MainActivity
 object SessionNotifications {
     const val SESSION_ID = 4101
     private const val RECOVERY_ID = 4102
+    // Channel ids are invisible to the user and permanent — changing one resets that channel's
+    // settings — so this keeps its original id while its display name has moved on.
     private const val SESSION_CHANNEL = "temporary_full_charge"
     private const val GESTURE_CHANNEL = "reconnect_gesture"
     private const val RECOVERY_CHANNEL = "charge_policy_recovery"
@@ -25,37 +27,55 @@ object SessionNotifications {
 
     fun ensureChannels(context: Context) {
         val manager = context.getSystemService(NotificationManager::class.java)
+        // Covers the whole temporary-override lifecycle — lifting the limit and putting it back —
+        // because [recovering] shares it with [session]. Unlike importance, a channel's name and
+        // description do update on an existing channel, so widening the wording reaches installs
+        // that already have it.
         manager.createNotificationChannel(
             NotificationChannel(
                 SESSION_CHANNEL,
                 context.getString(R.string.session_channel_name),
                 NotificationManager.IMPORTANCE_LOW,
             ).apply {
-                description = "Shows while Amply temporarily allows charging to 100%"
+                description = context.getString(R.string.session_channel_description)
                 setShowBadge(false)
             },
         )
-        // Its own channel at DEFAULT importance so the persistent reconnect monitor is
-        // reliably visible in the status bar (the shared low channel was easy to miss).
+        // Its own channel, kept separate from the session so the user can silence one without the
+        // other, but LOW: the gesture notification is a passive standing cue that can sit there for
+        // hours, so it belongs in the shade's silent section. DEFAULT bought nothing anyway — all
+        // notifications here share SESSION_ID and set onlyAlertOnce, so the reconnect countdown
+        // never re-alerted; the importance only produced one ding when the service went foreground.
+        // LOW still keeps a status-bar icon, which is what makes an armed gesture discoverable.
+        // Importance is fixed once a channel exists, so this only takes effect on a fresh install —
+        // deliberately not migrated with a new channel id while the app is pre-launch.
         manager.createNotificationChannel(
             NotificationChannel(
                 GESTURE_CHANNEL,
                 context.getString(R.string.gesture_channel_name),
-                NotificationManager.IMPORTANCE_DEFAULT,
+                NotificationManager.IMPORTANCE_LOW,
             ).apply {
-                description = "Shows while the reconnect-for-100% gesture is watching for a replug"
+                description = context.getString(R.string.gesture_channel_description)
                 setShowBadge(false)
             },
         )
+        // HIGH, matching the charge alarm: this fires when the protective policy could NOT be
+        // restored, so the battery charges unprotected until the user intervenes — the exact
+        // failure the app exists to prevent, and one that otherwise goes unnoticed overnight. It
+        // would be backwards for a convenience reminder to out-rank it. Rare, auto-cancelling, and
+        // withdrawn the moment a restore succeeds, so the heads-up costs nothing when all is well.
         manager.createNotificationChannel(
             NotificationChannel(
                 RECOVERY_CHANNEL,
                 context.getString(R.string.recovery_channel_name),
-                NotificationManager.IMPORTANCE_DEFAULT,
-            ),
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = context.getString(R.string.recovery_channel_description)
+            },
         )
-        // Quiet channel for the "alive only to observe battery" case (e.g. charge alarm). LOW so the
-        // background foreground-service notification doesn't draw attention like the gesture cue.
+        // Quiet channel for the "alive only to observe battery" case (e.g. charge alarm). Separate
+        // from the gesture channel despite sharing LOW, so silencing the watcher's presence entirely
+        // does not also hide the gesture that the user opted into.
         manager.createNotificationChannel(
             NotificationChannel(
                 MONITOR_CHANNEL,
@@ -191,6 +211,12 @@ object SessionNotifications {
         return builder.build()
     }
 
+    /**
+     * Progress while a restore converges on the charging hardware. Deliberately shares
+     * [SESSION_CHANNEL] with [session] rather than the alerting recovery channel: this is the
+     * passive end of the same override the user started, and the recovery channel is HIGH, which
+     * would make it heads-up on every boot that owes a restore.
+     */
     fun recovering(context: Context): Notification {
         ensureChannels(context)
         val openPendingIntent = PendingIntent.getActivity(
@@ -236,6 +262,9 @@ object SessionNotifications {
                     .setContentTitle(context.getString(R.string.recovery_notification_title))
                     .setContentText(context.getString(bodyRes))
                     .setContentIntent(openIntent)
+                    // The only notification here reporting a failed state, so it is the only one
+                    // that should rank and filter as an error rather than as service noise.
+                    .setCategory(NotificationCompat.CATEGORY_ERROR)
                     .setAutoCancel(true)
                     .build(),
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,12 +4,14 @@
     <string name="tile_active">Restore limit</string>
     <string name="tile_override_active">Temporary override active</string>
     <string name="widget_description">Amply charge controls</string>
-    <string name="session_channel_name">Temporary full charge</string>
+    <string name="session_channel_name">Full charge and restore</string>
+    <string name="session_channel_description" formatted="false">Shows while Amply is allowing a full charge, and while it restores your limit afterwards</string>
     <string name="session_notification_title" formatted="false">Charging to 100% once</string>
     <string name="session_notification_armed">Waiting for a charger</string>
     <string name="session_notification_active">Charge protection returns at 100% or when unplugged.</string>
     <string name="session_notification_restore">Restore now</string>
     <string name="gesture_channel_name">Reconnect gesture</string>
+    <string name="gesture_channel_description" formatted="false">Shows while the reconnect-for-100% gesture is watching for a replug</string>
     <string name="gesture_notification_title">Reconnect gesture is on</string>
     <string name="gesture_notification_waiting">Waiting for a quick unplug and reconnect while your charge limit is holding.</string>
     <string name="gesture_notification_waiting_limit">Waiting for a quick unplug and reconnect at your %1$d%% limit.</string>
@@ -20,6 +22,7 @@
     <string name="gesture_notification_waiting_any_level">Waiting for a quick unplug and reconnect at any charge level.</string>
     <string name="gesture_notification_disable_hint">You can turn this notification off (long-press it) without stopping the gesture.</string>
     <string name="recovery_channel_name">Charge policy recovery</string>
+    <string name="recovery_channel_description">Alerts you when your protective charge limit could not be restored</string>
     <string name="recovery_notification_title">Charge limit needs attention</string>
     <string name="recovery_notification_body">Open Amply and restart Shizuku to restore your protective policy.</string>
     <string name="recovery_notification_body_convergence">The protective policy was rewritten, but the charging hardware has not confirmed it yet. Open Amply to check.</string>


### PR DESCRIPTION
## What changed

**The reconnect-gesture notification is now silent.** It sits in the notification shade's less-important section instead of the default one, so it no longer makes a sound when it appears. It still shows a status-bar icon, so an armed gesture stays discoverable. Previously the only way to get this was to change it by hand in Android's notification settings.

**"Charge limit needs attention" now alerts properly.** This is the notification that appears when Amply could not put your protective charge limit back — the battery keeps charging unprotected until you step in. It was ranked *below* the charge alarm, so a convenience reminder was more prominent than the one failure the app exists to prevent. It now alerts at the same level, and is marked as an error so Do Not Disturb and notification ranking treat it accordingly. It is rare, dismisses itself, and disappears the moment a restore succeeds.

**One notification category was renamed.** "Temporary full charge" is now "Full charge and restore", because it covers both halves of the lifecycle — allowing the full charge, and putting your limit back afterwards. The restore-progress notification was already filed under it, which the old name didn't reflect.

**Every notification category now describes itself** in Android's notification settings. One had no description at all, and two others were not translatable.

## Technical Context

**Why the gesture channel lost nothing by dropping to LOW.** All four foreground-service notifications (`monitoring`, `session`, `gesture`, `recovering`) share `SESSION_ID` and set `setOnlyAlertOnce(true)`. The `WAITING_FOR_RECONNECT` countdown is an *update* to an already-posted notification, so it never re-alerted regardless of importance. DEFAULT bought exactly one alert, when the service first went foreground. LOW keeps the status-bar icon; only MIN would have removed it.

**Neither importance change reaches an existing install, deliberately.** A channel's importance is fixed at creation — `createNotificationChannel` on an existing channel ignores it, and a channel the user has adjusted has that field locked outright. Reaching existing installs would need new channel ids, which is migration cruft the app does not need pre-launch. Names and descriptions *do* update on an existing channel, so the rename and the new descriptions apply everywhere immediately. **Verifying the two importance changes therefore requires a fresh install — `pm clear` does not delete channels.**

**Why `recovering()` still shares the session channel** rather than moving to `charge_policy_recovery`, whose name matches it better: that channel is now HIGH, which would make a passive progress notification heads-up on every boot that owes a restore. It is the passive tail of the same override the user started, so it belongs with `session()`. The channel rename is what resolves the mismatch. There is a comment on the function recording this, so it does not get "fixed" later.

**The session channel keeps its `temporary_full_charge` id** despite the rename. Channel ids are invisible to users and permanent; changing one resets that channel's settings. Also commented at the constant.

## Review guidance

The behavioural surface is four constant/string values; the rest is comments explaining decisions that are easy to reverse by accident. Worth a look:

- Is HIGH right for `charge_policy_recovery`? It is the one judgement call here. The argument is severity — unprotected overnight charging — against the risk of a heads-up for something the user may not be able to fix immediately (it fires on write failures, including transient ones).
- The recovery channel deliberately does **not** call `enableVibration(true)`, which `charge_alarm` does. So it will heads-up and sound but may not buzz. Left inconsistent on purpose rather than silently widened; say the word and it is one line.

## Testing

Both flavours assemble, 739 unit tests pass, `lintFossDebug` reports 0 errors and no new warnings. **Not yet verified on a device** — that needs a fresh install to observe the new importances, which is why this is a draft.
