### PR TITLE
General: Bump CI actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -13,7 +13,7 @@ runs:
         cache: gradle
 
     - name: Set up Android SDK
-      uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 #v3.2.2
+      uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 #v4.0.1
 
     - name: Validate Gradle wrapper
-      uses: gradle/actions/wrapper-validation@748248ddd2a24f49513d8f472f81c3a07d4d50e1 #v4.4.4
+      uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 #v6.2.0


### PR DESCRIPTION
**What changed**

No user-facing behavior change. CI-only: two GitHub Actions in the shared `common-setup` composite are re-pinned to releases that run natively on Node 24, clearing the deprecation warning GitHub emits on every job that uses them.

**Technical Context**

GitHub is deprecating the Node 20 runtime and currently *force-runs* these two actions on Node 24, warning on each job:

- `android-actions/setup-android` v3.2.2 → **v4.0.1**. v4.0.0 was the Node 24 migration. Inputs are unchanged and the composite passes none, so the only behavioral delta is the default `cmdline-tools-version` moving `11076708` → `14742923` (20.0) — the version recent AGP/compileSdk wants anyway. If the SDK install ever regresses, pinning `cmdline-tools-version: 11076708` restores the old behavior.
- `gradle/actions/wrapper-validation` v4.4.4 → **v6.2.0**. Node 24 since v5; inputs (`min-wrapper-count`/`allow-snapshots`/`allow-checksums`) are identical and we pass none.

On the v6 licensing question: v6 extracted caching into the proprietary `gradle-actions-caching` component. That does **not** apply here — `wrapper-validation` is part of the MIT-licensed action runner, its `dist/wrapper-validation` bundle is standalone and never loads the caching library, and this repo gets its Gradle cache from `actions/setup-java`'s `cache: gradle` rather than `setup-gradle`.

No other action in the repo targets Node 20 (checked every `uses:` across `.github/workflows` and `.github/actions`).

**Review guidance:** the real verification is CI itself — the warning should be gone from the jobs that use `common-setup`, and the Android SDK setup should still succeed on the newer cmdline-tools default.