### PR TITLE
General: Move on-demand agent docs out of the always-loaded rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,22 +21,20 @@ gated to a **physically-qualified device-codename allowlist** (HAL enforcement i
 system user; **reads are unprivileged (ContentResolver), writes require Shizuku** (the shell UID holds
 `lineageos.permission.WRITE_SETTINGS`, which `WRITE_SECURE_SETTINGS` does not cover). Other Pixels, Samsung on
 unverified One UI versions (6/7, 9+), non-HyperOS-2 Xiaomi devices, non-ColorOS-15 Oplus devices, and unqualified
-LineageOS builds remain diagnostics-only. See the qualification ledger in `.claude/rules/privileged-access.md` for
+LineageOS builds remain diagnostics-only. See the qualification ledger (`.claude/skills/device-qualification/`) for
 the verified devices and mappings.
 
-Package: `eu.darken.amply`. License: GPL-3.0-or-later. Status: pre-launch (`0.1.0-beta1`).
+Package: `eu.darken.amply`. License: GPL-3.0-or-later. Status: pre-launch (current version in `VERSION`).
 
 ## Project Shape
 
-- **Single Gradle module**: `:app` (declared in `settings.gradle.kts`). This is *not* a multi-module project.
-- **Product flavors** (`distribution` dimension): `foss` and `gplay`.
-- **Build types**: `debug`, `beta` (minified), `release` (minified). Every variant shares the single applicationId
-  `eu.darken.amply` — no build-type suffixes; installed variants are mutually exclusive (different signing keys).
-- **SDKs**: `compileSdk`/`targetSdk` 36, `minSdk` 26. Core-library desugaring enabled.
+Single Gradle module (`:app`), flavors and build types are declared in `app/build.gradle.kts`. Two non-obvious
+constraints:
+
 - **Java**: build/test toolchain needs **JDK 21** (Robolectric requires it to emulate Android SDK 36); compiled
   bytecode still targets **Java 17** (`compileOptions`/`jvmTarget` in `app/build.gradle.kts`).
-- **Stack**: Kotlin, Jetpack Compose + Material 3, Navigation3, Glance (widget), Hilt/KSP, Coroutines/Flow,
-  Preferences DataStore, Shizuku (AIDL user service).
+- **Every variant shares the single applicationId** `eu.darken.amply` — no build-type suffixes. Because signing
+  certificates differ, installed variants are mutually exclusive on a device; switching requires an uninstall.
 
 ## Package Layout (feature/core/ui)
 
@@ -45,7 +43,8 @@ Under `app/src/main/java/eu/darken/amply/`:
 - `charging/core` — policies, device capability checks, OEM adapters, WSS, Shizuku access (`access/shizuku`, `adapter`)
 - `fullcharge/core` — temporary sessions, boot recovery, reconnect gesture
 - `main/ui` — activity, onboarding, dashboard, settings, setup guide, `tile`, `widget`
-- `diagnostics/core` + `diagnostics/ui` — privileged settings comparison and its guided UI
+- `diagnostics/core` + `diagnostics/ui` — "Help add support" contribution wizard: read-only multi-mode setting
+  discovery + on-device privacy review
 - `common` — shared DataStore owner (`AppDataStore`) and cross-feature primitives
 - `common/datastore` — the `createValue()` settings DSL every preference facade is built on (`DataStoreValue`)
 - `common/serialization` — the single `Json` plus `ChargePolicySerializer`, for JSON-backed setting records
@@ -67,17 +66,23 @@ AIDL boundary: `app/src/main/aidl/eu/darken/amply/charging/core/access/shizuku/I
 
 ## Rules
 
-Topic-specific guidance lives in `.claude/rules/`:
+Always-loaded topic guidance lives in `.claude/rules/`:
 
-- `architecture.md` — package layout, data flow, `ChargeObservation`, adapters, session/recovery, privileged boundary
-- `privileged-access.md` — Shizuku/WSS access paths, capability gate, AIDL safety boundary (read before touching control code)
+- `architecture.md` — data flow, `ChargeObservation`, session/recovery, reconnect gesture, pitfalls
+- `privileged-access.md` — Shizuku/WSS access paths, capability gates, AIDL safety boundary (read before touching control code)
 - `build-commands.md` — gradle build/test/lint commands, flavors, build types
 - `code-style.md` — Kotlin/Compose conventions, logging, DataStore
 - `testing.md` — JUnit 5 + Kotest conventions (JUnit 4 only for Robolectric)
 - `commit-guidelines.md` — commit/PR format and prefixes
 - `localization.md` — string extraction conventions and the current gap
-- `release.md` — versioning, signing, CI (pre-launch state)
 - `agent-instructions.md` — sub-agent usage and working principles
+
+Loaded on demand, as skills (`.claude/skills/`) — there are **no nested `CLAUDE.md` files** in this repo, all
+guidance lives under `.claude/`:
+
+- `oem-adapters` — per-OEM adapter detail (keys, value domains, write ordering, session overrides)
+- `device-qualification` — physical qualification protocol, verified-device ledger, per-OEM known gaps
+- `release` — versioning, `bump.sh`, signing, release workflows, store metadata + screenshots
 
 ## Safety Boundary (read first)
 

--- a/.claude/rules/agent-instructions.md
+++ b/.claude/rules/agent-instructions.md
@@ -16,31 +16,16 @@ Per the global rules, prefer these for this Kotlin/Android project:
 - **`debugbadger`** tools/agent for on-device use-case runs and logcat capture (Android device automation).
 - **`Explore`** / **`general-purpose`** for broad codebase searches when you only need the conclusion.
 
-## When to use sub-agents
-
-**Use for:** exploring unfamiliar parts of the codebase, cross-file pattern searches, multi-file research, parallel
-work. **Handle directly:** known-path reads, single-file edits with clear requirements, quick grep/glob.
-
 ## Reading before changing control code
 
 Before editing charge-control, Shizuku/WSS access, the AIDL, or the capability gate, read `privileged-access.md` and
 the relevant part of `architecture.md`. These paths have real safety constraints (allowlist, no shell strings,
-capability gate) that must not be relaxed casually.
-
-## Multi-step work
-
-1. Break complex tasks into discrete steps (use TaskCreate/TaskUpdate to track).
-2. Complete and verify one step before the next.
-3. Separate exploring (read-only) from implementing (minimal, focused edits) — when uncertain, explore first.
-
-## Error handling
-
-Understand a tool failure before retrying; don't repeat a failing approach. Report blockers early rather than working
-around them silently. Ask for clarification on ambiguous requirements via the AskUserQuestion tool.
+capability gate) that must not be relaxed casually. For adapter internals (keys, value domains, write ordering), use
+the `oem-adapters` skill.
 
 ## Device testing
 
 Follow the global Test-Target rules: never adopt an Android device/emulator you didn't start unless interference is
 positively ruled out, and never re-point a named target without confirmation. Amply's control paths are
-capability-gated to specific Pixels — record device results in the qualification ledger in `privileged-access.md`
+capability-gated to specific Pixels — record device results in the qualification ledger (`device-qualification` skill)
 rather than loosening the gate to run on an unqualified device.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -10,22 +10,7 @@ project's convention. Code is grouped by **feature**, not framework layer.
 
 ## Package Map
 
-```
-eu.darken.amply
-├── charging/core            policies, capability gate, OEM adapters, WSS + Shizuku access
-│   ├── access/shizuku       Shizuku detection, user-service client, AIDL boundary
-│   └── adapter              AdapterRegistry + adapters (Pixel, Samsung, Xiaomi, OnePlus/ColorOS, LineageOS live)
-├── fullcharge/core          temporary session, boot recovery, reconnect gesture, decision engines
-├── diagnostics/core + ui    "Help add support" contribution wizard: read-only multi-mode setting discovery + on-device privacy review
-├── main
-│   ├── core                 app-level wiring
-│   └── ui                   MainActivity, onboarding, dashboard, settings, setup, tile, widget
-└── common
-    ├── AppDataStore         single process-safe Preferences DataStore owner
-    ├── theming              brand / Material You / mode / contrast prefs
-    ├── settings             reusable hierarchical settings rows + sections
-    └── debug/logging        Logging fan-out + backends (Logcat, File)
-```
+See "Package Layout" in `.claude/CLAUDE.md`.
 
 Feature-specific preference facades live with their owning feature but share the one `AppDataStore` instance. They
 declare their settings with the `createValue()` DSL (`common/datastore`) rather than touching `store.data` — with a
@@ -60,95 +45,11 @@ sticky broadcast keeps its last powered value, so hardware state is never treate
 to the last request. Normal (`1`) stays unknown without Shizuku (inactive adaptive vs. unrestricted are
 indistinguishable).
 
-## Samsung Adapters
+## OEM Adapters
 
-Two live adapters, gated by `ro.build.version.oneui` ranges plus `protect_battery` presence plus system user
-(all in world-readable `global` namespace; only writes need WSS):
-
-- **Modern (One UI 8.x)**: `protect_battery` 0=off / 1=Maximum / 3=Standard(pause at 100%, resume 95%), plus
-  `battery_protection_threshold` 80|85|90|95 (absent = 80, only valid ticks decode; malformed → Unknown).
-  Policies: FixedLimit(80/85/90/95), PauseAtFull, Unrestricted. Session override = **PauseAtFull** (reaches 100%
-  while keeping Samsung's own safety net). Threshold is written before mode.
-- **Legacy (One UI 4.x/5.x)**: `protect_battery` 0/1 toggle, fixed 85% cap. Policies: FixedLimit(85),
-  Unrestricted. Session override = Unrestricted.
-
-Writes apply **synchronously** (`VerificationStrategy.SYNC_READBACK`): `apply()` requires read-back equality, no
-pending-settle window, boot recovery converges on settings readback, and no reapply-inversion trick is needed.
-The reconnect gesture is Pixel-only (`reconnectGestureSupported`). One UI 6/7 and 9+ fall through to the
-diagnostics-only lab adapter. An external `protect_battery=0` makes One UI forget the user's prior mode (it falls back
-to the OEM default on re-enable), so Amply restores the exact prior policy itself rather than trusting Samsung's
-bookkeeping. Verified devices + coverage: see the qualification ledger in `privileged-access.md`.
-
-## Xiaomi Adapter
-
-One live adapter (`xiaomi-hyperos2-v1`), gated to the HyperOS ROM version (the setting is a ROM
-feature, not a per-model one): manufacturer Xiaomi (covers Redmi/POCO — they report Xiaomi as
-manufacturer) + `ro.mi.os.version.code == 2` (HyperOS 2.x) + system user. Use `ro.mi.os.version.code`,
-NOT the frozen legacy `ro.miui.ui.version.code`. Single key
-`secure/security_pc_secure_protect_mode_key`: `0`=charge fully, `1`=Intelligent (heuristic 80% hold →
-`ChargePolicy.Adaptive`), absent=Intelligent (factory state). No hard-cap mode exists. SYNC_READBACK
-with read-back equality; session override = Unrestricted; protective default = Adaptive. HyperOS 1,
-pre-HyperOS MIUI, and a future HyperOS 3 fall to `XiaomiLabAdapter` (diagnostics + contribution). Two
-documented assumptions: the feature is treated as present on any HyperOS 2 device (a device lacking it
-reads the key absent → a harmless false claim of control), and daemon-level enforcement of external
-writes is pending long-term observation (see the qualification ledger in `privileged-access.md`).
-
-## OnePlus / ColorOS Adapter
-
-One live adapter (`oplus-coloros15-v1`) for the ColorOS/OxygenOS (Oplus) family — OnePlus, Oppo, Realme —
-gated to `ro.build.version.oplusrom == 15` (Oplus-exclusive property, so it doubles as the family signal) +
-system user. Two mutually-exclusive **`system`** keys under Battery health: `regular_charge_protection_switch_state`
-= "Charging limit" (fixed 80% cap → `FixedLimit(80)`) and `smart_charge_protection_switch_state` = "Smart charging"
-(adaptive → `Adaptive`); neither on = Unrestricted; both on = Unknown/unrecognized. The OEM enforces exclusion and
-keeps a `_status` mirror (Amply writes only `_switch_state`). SYNC_READBACK with read-back equality; session
-override = Unrestricted; protective default = FixedLimit(80). **Writes require Shizuku** — the keys are `system`
-namespace, which WRITE_SECURE_SETTINGS cannot write (reads are unprivileged); the adapter sets
-`preferShizukuForWrites`. Unqualified Oplus versions fall to `OnePlusLabAdapter`. Enforcement is directly
-observable (device holds at 80%). See the qualification ledger in `privileged-access.md`.
-
-## LineageOS Adapter
-
-One live adapter (`lineageos-chargingcontrol-v1`) plus a `LineageLabAdapter`, for LineageOS's native Charging
-Control. **Manufacturer-agnostic** — the ROM changes charging control regardless of the OEM hardware — so both are
-registered **first** in `AdapterRegistry`, ahead of every OEM adapter; a LineageOS build on Samsung/Xiaomi/OnePlus/
-Pixel hardware is handled by these, never the OEM lab adapters (stock devices have `lineageOsVersion == null` and
-skip both). Gate: `ro.lineage.build.version` present + `Build.DEVICE` in a **physically-qualified codename
-allowlist** (`QUALIFIED_CODENAMES`) + `lineagesettings` provider present + system user. Unqualified LineageOS builds
-fall to `LineageLabAdapter`.
-
-The three keys live in the private `content://lineagesettings/system` provider (`SettingNamespace.LINEAGE_SYSTEM`),
-NOT any AOSP `settings` namespace: `charging_control_enabled` (0/1), `charging_control_mode` (3=LIMIT), and
-`charging_control_charging_limit` (the discrete ticks 70/75/80/85/90/95). A hard cap is `enabled=1`+`mode=3`+`limit=N`;
-`enabled=0` is Unrestricted. Writes are ordered limit→mode→enabled (the observable "on" flip last). **Reads are
-unprivileged** (`LineageSettingsClient` via ContentResolver, shared by both backends); **writes require Shizuku**
-(`content insert`; the shell UID holds `lineageos.permission.WRITE_SETTINGS`, which `WRITE_SECURE_SETTINGS` cannot
-cover — `preferShizukuForWrites`, and the WSS auto-grant is skipped). `SYNC_READBACK` with read-back equality;
-session override = Unrestricted; protective default = FixedLimit(80); reconnect gesture unsupported.
-
-LineageOS's own `ChargingControlController` observes these keys and re-drives the `vendor.lineage.health.
-IChargingControl` HAL, so an external write is honored. But the HAL is **device-dependent** (the setting can flip
-while charging never actually stops — the `mIsLimitSet:false` bug), which is why the gate is a qualified-codename
-allowlist and control ships disabled until a codename is physically proven. `read()` returns `Verified` **only** for
-states v1 can restore exactly (a supported fixed limit, or Unrestricted); AUTO/CUSTOM schedules, off-tick limits, and
-an absent/malformed `enabled` decode to `Unknown(unrecognizedValue=true)` so a temporary session refuses rather than
-clobbering the user's native choice. Verified devices + coverage: see the qualification ledger in `privileged-access.md`.
-
-## Pixel Adapter
-
-Writes **only** two secure settings:
-
-- `secure/adaptive_charging_enabled`
-- `secure/charge_optimization_mode`
-
-Ordering matters:
-
-- Fixed 80%: adaptive `0`, then mode `1`
-- Unrestricted: mode `0`, then adaptive `0`
-- Adaptive: mode `0`, then adaptive `1`
-
-Google's Settings Intelligence worker applies external secure-setting changes **asynchronously** (measured
-charging-HAL delay ≈ 11–12 s on tested Pixels). A same-package same-value write does **not** fire the settings
-observer — re-writes briefly invert `charge_optimization_mode` before applying the target.
+Per-adapter detail (Samsung, Xiaomi, OnePlus/ColorOS, LineageOS, Pixel — keys, value domains, write ordering,
+session overrides) lives in the **`oem-adapters` skill** — read it before changing anything under
+`charging/core/adapter`.
 
 ## Temporary Session & Recovery
 
@@ -190,5 +91,5 @@ Android does not deliver `ACTION_POWER_CONNECTED` / `ACTION_POWER_DISCONNECTED` 
   replace this runtime gate with an exact-model allowlist or a version-only check.
 - Shizuku installation is detected by resolving the owner of `ShizukuProvider.PERMISSION`, **not** a fixed package
   name — this recognizes renamed forks and hidden-package mode. Don't hardcode a package name.
-- Pixel/Samsung/Xiaomi/Oplus keys are all live on gated devices (see the adapter sections). New writable keys must
+- Pixel/Samsung/Xiaomi/Oplus keys are all live on gated devices (see the `oem-adapters` skill). New writable keys must
   be spike-verified and added to `SettingWritePolicy` with an explicit per-key value domain.

--- a/.claude/rules/build-commands.md
+++ b/.claude/rules/build-commands.md
@@ -11,7 +11,7 @@ wrapper (`./gradlew`). Build/test on **JDK 21** (Robolectric needs it for Androi
 ./gradlew assembleFossDebug
 ./gradlew assembleGplayDebug
 
-# Release APKs (minified; signed when signing material is present, unsigned otherwise — see release.md)
+# Release APKs (minified; signed when signing material is present, unsigned otherwise — see the `release` skill)
 ./gradlew assembleFossRelease
 ./gradlew assembleGplayRelease
 
@@ -42,23 +42,7 @@ bash fastlane/check_metadata_length.sh
 
 ## Play Store Screenshots
 
-Screenshots are rendered from `@Preview` composables on the JVM (no device) via the Compose Preview Screenshot
-Testing plugin (`com.android.compose.screenshot`, enabled by `android.experimental.enableScreenshotTest=true` in
-`gradle.properties`). The store composables live in `app/src/debug/.../screenshots/ScreenshotContent.kt`; the capture
-entry points (`@PreviewTest`) and locale annotations live in `app/src/screenshotTest/.../screenshots/`.
-
-```bash
-# 1. Render (writes to app/src/screenshotTestGplayDebug/reference/, which is gitignored)
-./fastlane/generate_screenshots.sh
-# 2. Normalize (flatten alpha → opaque 1080x1920) + sort into the committed metadata tree
-./fastlane/copy_screenshots.sh
-```
-
-Committed output lands in `fastlane/metadata/android/en-US/images/phoneScreenshots/` as `1_dashboard_light.png …
-6_reconnect_gesture.png` (names come from `copy_screenshots.sh`'s `screen_file` map). Both scripts fail
-loudly on any count/dimension/format mismatch and `copy_screenshots.sh` requires ImageMagick. Needs the JDK 21 build
-toolchain like everything else. CI compiles these sources (`compileGplayDebugScreenshotTestKotlin`) but does **not**
-render — layoutlib output differs across machines — so **regenerating screenshots is a manual pre-release step**.
+Rendered from `@Preview` composables on the JVM — see the `release` skill.
 
 ## Install & Inspect
 

--- a/.claude/rules/privileged-access.md
+++ b/.claude/rules/privileged-access.md
@@ -3,6 +3,10 @@
 Amply writes hidden/secure Android settings to control OEM charge protection. This is the highest-risk surface in the
 app. Read this before modifying anything under `charging/core/access/`, the AIDL, or the capability gate.
 
+Two on-demand companions: the **`oem-adapters` skill** holds the per-OEM keys, value domains, and write ordering the
+gates below govern; the **`device-qualification` skill** holds the protocol and the ledger of physically-verified
+devices that justify each gate's current width.
+
 ## Two Access Paths
 
 `AccessResolver` probes both independently:
@@ -52,7 +56,7 @@ Direct Pixel control requires **all** of:
 
 This runtime gate deliberately avoids both a brittle exact-model allowlist and an unsafe version-only match. Devices
 that fail the gate remain **diagnostics-only**. Do not loosen or short-circuit the gate to "make it work" on an
-unqualified device — record the device in the qualification ledger below instead.
+unqualified device — record the device in the qualification ledger (`device-qualification` skill) instead.
 
 ### Samsung
 
@@ -60,7 +64,7 @@ Samsung control requires **all** of: Samsung manufacturer, a **verified One UI r
 multi-mode adapter; One UI 4.x/5.x for the legacy toggle adapter — read from `ro.build.version.oneui`), a present
 `global protect_battery` key, and the **system user** (the keys are device-wide; sessions are per-user). One UI
 6.x/7.x and 9.x+ are unverified and fall through to the diagnostics-only lab adapter — do not widen the ranges
-without a qualified device; record results in the qualification ledger below.
+without a qualified device; record results in the qualification ledger (`device-qualification` skill).
 
 Unlike Pixel's hidden secure settings, Samsung's `global` keys are world-readable: configured-state verification
 works without Shizuku, and writes apply synchronously (no Settings-Intelligence-style async middleman).
@@ -71,14 +75,14 @@ Oplus control requires **all** of: `ro.build.version.oplusrom == 15` (ColorOS/Ox
 Oplus-exclusive and covers OnePlus/Oppo/Realme) and the system user. **Writes require Shizuku**: the two keys are in
 the `system` namespace, which `WRITE_SECURE_SETTINGS` cannot write (reads are unprivileged). The adapter sets
 `preferShizukuForWrites` and read-back-verifies, so a WSS-only write fails honestly. Do not widen to ColorOS 16+
-without a qualified device; record results in the qualification ledger below.
+without a qualified device; record results in the qualification ledger (`device-qualification` skill).
 
 ### Xiaomi
 
 Xiaomi control requires **all** of: Xiaomi manufacturer (covers Redmi/POCO, which report Xiaomi as
 manufacturer), `ro.mi.os.version.code == 2` (HyperOS 2.x — the ROM feature is version-scoped, not
 model-scoped), and the system user. Use `ro.mi.os.version.code`, NOT the frozen legacy
-`ro.miui.ui.version.code`. Do not widen to HyperOS 3+ without qualifying a device; record results in the qualification ledger below. The single key is per-user `secure`, applied synchronously. Two deliberate
+`ro.miui.ui.version.code`. Do not widen to HyperOS 3+ without qualifying a device; record results in the qualification ledger (`device-qualification` skill). The single key is per-user `secure`, applied synchronously. Two deliberate
 assumptions: the feature is treated as present on any HyperOS 2 device (a device lacking it reads the key
 absent → a harmless false claim of control), and daemon-level enforcement of external writes is pending
 long-term observation (see Known gaps below).
@@ -123,86 +127,10 @@ identifiers** and include only setting differences — never widen what a diagno
 
 ## Qualifying a new device / OEM
 
-Adding or widening a live adapter requires physical qualification, not just a settings mapping:
+Adding or widening a live adapter requires **physical qualification**, not just a settings mapping — a setting can
+read back correctly while the charging HAL never actually limits. Do not loosen or short-circuit a gate to "make it
+work" on an unqualified device.
 
-1. **Characterize** — record model/codename, build fingerprint, OS + OEM-component versions, and the native
-   charge-protection options. Diff `settings list {secure,system,global}` before/after each native UI state to isolate
-   the exact key(s) and value domain. Note whether a key is **absent** in factory state (absent ≠ off).
-2. **Validate hardware** — drive the raw key transitions unplugged, and charging below/near/above the limit, wired
-   **and** wireless. The gate passes only if writes move the **real charging hardware** (battery status / sysfs
-   `charging_policy` / current), not just the Settings UI.
-3. **Validate access tiers** — WSS-only (writes apply, hidden reads stay truthfully "requested", grant survives
-   reboot), Shizuku-only (authoritative readback, denial + binder-death + restart), and both (WSS write → Shizuku
-   readback). An external native change must never be claimed as verified.
-4. **Validate sessions** — full charge, early disconnect, manual restore, arm + safety timeouts, process death,
-   force-stop, notification denial, real reboot + deferred `BOOT_COMPLETED` redelivery. Confirm exact restore of the
-   prior value **including a previously-absent key**, and that an unknown/malformed value **refuses** the session
-   without mutating the setting. Also confirm the interrupted-session surface both ways: a **force-stop that leaves a
-   restore owed** must, on next open, restore the limit *and* show the dashboard interruption card, while a **reboot**
-   must restore via boot recovery and show **no** card (the boot-count guard). A device that holds at its limit often
-   reports `NOT_CHARGING`, which ends a session immediately — drive the lifecycle with `adb shell dumpsys battery set
-   status 2 / set level N` (then `dumpsys battery reset`) so the session behaves as it would mid-charge.
-5. **Minified build** — repeat the smoke path on an R8 `foss` beta (past runs caught R8-only startup/reflection
-   breakage that debug builds hid).
-
-Record every scenario as **PASS / FAIL / NOT RUN / BLOCKED** — an untestable hardware condition is not a pass. Never
-commit device serials or user data. Requalify after a relevant OS / OEM-component update.
-
-**Go / no-go**: *Go* only if writes reliably control the hardware and restore safely (enable just the tested model/OS
-row). *Shizuku-only* if control needs an extra safe op invokable through the typed service. *No-go* → keep the device
-diagnostics-only.
-
-## Verified devices (physically tested)
-
-The gate's supported *scope* (see Capability Gates) is broader than what has been physically tested below. Widen a gate
-only after adding a row here. Detailed run narratives live in each adapter's landing commit.
-
-| OEM | Tested device / build | Hardware evidence | Coverage | Landed |
-|---|---|---|---|---|
-| Pixel | Pixel 8 `shiba` A17/API37; Pixel 9 Pro `caiman` A16/API36; Pixel 7a `lynx` A16/API36 | Full — sysfs `charging_policy` follows writes (~11–12s) | Access tiers, sessions, boot recovery, wireless hold, at-threshold, reconnect gesture, natural 100%, interrupted-session detection (7a) | 2026-07-15/-19/-20/-25 |
-| Samsung | Galaxy Tab A9+ SM-X210 One UI 8.0; Galaxy S20 FE SM-G781B One UI 4.1 | Full — sync readback + HAL enforcement | Modern multi-mode + legacy toggle, session E2E, native-change cancel, reboot recovery, R8 beta | 2026-07-21 |
-| Xiaomi | Xiaomi 13T `2306EPN60G` HyperOS 2.0 (`ro.mi.os.version.code=2`) | **Partial** — mapping/readback/session verified; the adaptive 80% hold could not be triggered, so daemon-level hardware enforcement is **not yet demonstrated** | Read matrix, both-direction writes, session at 100%, unknown-value refusal, R8 beta | 2026-07-21 |
-| OnePlus (Oplus) | OnePlus Nord CE4 Lite `CPH2621` ColorOS 15 (`ro.build.version.oplusrom=V15.0.0`) | Full — enforcement directly observable (device holds at 80%); external writes stick | Two mutually-exclusive `system` keys (Charging limit / Smart charging), WSS-only write rejected + Shizuku write succeeds for all three policies, WSS-only UX (controls disabled + Shizuku-required banner) | 2026-07-21 |
-
-## Known gaps
-
-- **LineageOS** — landed **diagnostics-only**: `QUALIFIED_CODENAMES` ships **empty**, so the live adapter never
-  matches and every LineageOS build falls to `LineageLabAdapter`. A codename is added only after that device passes
-  qualification (real charging cessation at the limit, wired + wireless, below/at/above threshold) and gets a
-  "Verified devices" row.
-  - **Pixel 6 (oriole) on LineageOS 20.0 / Android 13 — tested 2026-07-22, result NO-GO (no hardware enforcement).**
-    The *software chain is fully validated* — both raw (shell-UID `content query`/`content insert`) **and through the
-    app's real Shizuku backend end-to-end** (R8 debug build + Shizuku granted): tapping 80 % wrote the trio via
-    `writeLineageSetting` and read back `Verified(FixedLimit(80), SHIZUKU)`. LineageOS's `ChargingControlController`
-    **observes the external write** and updates its live config (`dumpsys lineagehealth` → `mConfigEnabled:true,
-    mConfigMode:3, mConfigLimit:80`); the `vendor.lineage.health.IChargingControl/default` HAL is registered and its
-    service runs. The refuse-don't-clobber decode was also confirmed live: a native `mode=2` (CUSTOM) state read as
-    `Unknown(unrecognized)` ("Policy not verified"), never overwritten. And the diagnostics-only path was smoke-tested
-    (empty allowlist → `lineageos-lab` → "Detected for diagnostics only", no crash). **But the hard percent
-    limit did not cut charging** — with `limit=80` set, the battery charged 92→95 %+ at ~1.2 A (`charge_stage=Inactive`,
-    `charge_limit` sysfs empty, `mChargingStopReason:0`). On Pixel the charge hardware is driven by Google's
-    adaptive/`charge_deadline` mechanism, and this Lineage build's HAL does not map the %-cap to a real cutoff — the
-    `mIsLimitSet:false` device-dependent class of gap. So oriole stays **out** of the allowlist. This is a clean
-    validation of the conservative gate: an "any LineageOS device" gate would have claimed 80 % protection while the
-    phone charged to 100 %. (Qualifying a device with a *working* charge-control HAL remains open; the adapter's
-    provider/observer mechanism is proven, only per-device HAL enforcement varies.)
-  - Also confirmed on oriole: `charging_control_*` keys are **absent in factory state** (validates the conservative
-    "absent → unrecognized" decode). Still open: the provider's change-notification URI form (per-key vs table)
-    against the registered `observedSettingUris`, to be checked on a HAL-enforcing device.
-  - **Pixel 6 (oriole) on LineageOS 23.2 / Android 16 — retested 2026-07-22 after an anti-rollback firmware bump,
-    result NO-GO (HAL no longer offers LIMIT mode at all).** A *sharper* root cause than the LOS 20 run: the
-    `vendor.lineage.health.IChargingControl` HAL reports `getSupportedMode()` **without the LIMIT bit**, so
-    `ChargingControlController.isChargingModeSupported(LIMIT)` is false and LineageOS **coerces `charging_control_mode=3`
-    → `1` (AUTO)** — verified live: every raw shell-UID `content insert` of `mode=3` (even while `enabled=0`) read back
-    as `1`. Enabling then logs `LineageHealth: No alarm found, auto charging control has no effect` and `Setting charge
-    deadline: … 73353`; the active provider is `ccprovider.Deadline` (Google Adaptive Charging — time/alarm-based, **no
-    fixed-percent cap**). `charging_policy`/`charge_stage` sysfs never changed. So oriole is NO-GO on **both** builds for
-    different reasons: LOS 20 *accepted* LIMIT but the HAL silently didn't cut; LOS 23.2's HAL dropped LIMIT and falls
-    back to the Deadline mechanism. Consequence for the adapter (unchanged — correct by design): SYNC_READBACK
-    `apply(FixedLimit)` writes `mode=3`, reads back `mode=1 ≠ 3` → decodes `Unknown(unrecognizedValue=true)` → `apply`
-    returns false, so it **refuses without a false claim of control**. Reinforces the allowlist bar: a device must both
-    expose the LIMIT mode bit **and** actually cut charging. `charging_control_*` again **absent in factory state**.
-- **Xiaomi** — adaptive hardware enforcement of external writes unconfirmed; treat the adapter as provisional until
-  the 80% hold is physically observed.
-- **Pixel** — wireless at-threshold hold/charge-past and the widget under Shizuku-only remain unexercised (both share
-  the verified wired mechanism).
+The full protocol, the ledger of physically-verified devices, and the per-OEM known gaps live in the
+**`device-qualification` skill** (`.claude/skills/device-qualification/SKILL.md`). Read it before qualifying a
+device, widening a gate, or adding a codename to an allowlist.

--- a/.claude/skills/device-qualification/SKILL.md
+++ b/.claude/skills/device-qualification/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: device-qualification
+description: Amply's physical qualification protocol for OEM charge-control adapters, the ledger of verified devices (Pixel/Samsung/Xiaomi/OnePlus), and known gaps per OEM. Use when qualifying a new device or ROM, widening a capability gate, adding a codename to an allowlist, or recording device test results.
+---
+
+# Device Qualification & Ledger
+
+Companion to `.claude/rules/privileged-access.md`, which holds the always-loaded safety boundary and the capability
+gates themselves. **Never widen a gate without adding a row to "Verified devices" below.**
+
+## Qualifying a new device / OEM
+
+Adding or widening a live adapter requires physical qualification, not just a settings mapping:
+
+1. **Characterize** — record model/codename, build fingerprint, OS + OEM-component versions, and the native
+   charge-protection options. Diff `settings list {secure,system,global}` before/after each native UI state to isolate
+   the exact key(s) and value domain. Note whether a key is **absent** in factory state (absent ≠ off).
+2. **Validate hardware** — drive the raw key transitions unplugged, and charging below/near/above the limit, wired
+   **and** wireless. The gate passes only if writes move the **real charging hardware** (battery status / sysfs
+   `charging_policy` / current), not just the Settings UI.
+3. **Validate access tiers** — WSS-only (writes apply, hidden reads stay truthfully "requested", grant survives
+   reboot), Shizuku-only (authoritative readback, denial + binder-death + restart), and both (WSS write → Shizuku
+   readback). An external native change must never be claimed as verified.
+4. **Validate sessions** — full charge, early disconnect, manual restore, arm + safety timeouts, process death,
+   force-stop, notification denial, real reboot + deferred `BOOT_COMPLETED` redelivery. Confirm exact restore of the
+   prior value **including a previously-absent key**, and that an unknown/malformed value **refuses** the session
+   without mutating the setting. Also confirm the interrupted-session surface both ways: a **force-stop that leaves a
+   restore owed** must, on next open, restore the limit *and* show the dashboard interruption card, while a **reboot**
+   must restore via boot recovery and show **no** card (the boot-count guard). A device that holds at its limit often
+   reports `NOT_CHARGING`, which ends a session immediately — drive the lifecycle with `adb shell dumpsys battery set
+   status 2 / set level N` (then `dumpsys battery reset`) so the session behaves as it would mid-charge.
+5. **Minified build** — repeat the smoke path on an R8 `foss` beta (past runs caught R8-only startup/reflection
+   breakage that debug builds hid).
+
+Record every scenario as **PASS / FAIL / NOT RUN / BLOCKED** — an untestable hardware condition is not a pass. Never
+commit device serials or user data. Requalify after a relevant OS / OEM-component update.
+
+**Go / no-go**: *Go* only if writes reliably control the hardware and restore safely (enable just the tested model/OS
+row). *Shizuku-only* if control needs an extra safe op invokable through the typed service. *No-go* → keep the device
+diagnostics-only.
+
+## Verified devices (physically tested)
+
+The gate's supported *scope* (see Capability Gates) is broader than what has been physically tested below. Widen a gate
+only after adding a row here. Detailed run narratives live in each adapter's landing commit.
+
+| OEM | Tested device / build | Hardware evidence | Coverage | Landed |
+|---|---|---|---|---|
+| Pixel | Pixel 8 `shiba` A17/API37; Pixel 9 Pro `caiman` A16/API36; Pixel 7a `lynx` A16/API36 | Full — sysfs `charging_policy` follows writes (~11–12s) | Access tiers, sessions, boot recovery, wireless hold, at-threshold, reconnect gesture, natural 100%, interrupted-session detection (7a) | 2026-07-15/-19/-20/-25 |
+| Samsung | Galaxy Tab A9+ SM-X210 One UI 8.0; Galaxy S20 FE SM-G781B One UI 4.1 | Full — sync readback + HAL enforcement | Modern multi-mode + legacy toggle, session E2E, native-change cancel, reboot recovery, R8 beta | 2026-07-21 |
+| Xiaomi | Xiaomi 13T `2306EPN60G` HyperOS 2.0 (`ro.mi.os.version.code=2`) | **Partial** — mapping/readback/session verified; the adaptive 80% hold could not be triggered, so daemon-level hardware enforcement is **not yet demonstrated** | Read matrix, both-direction writes, session at 100%, unknown-value refusal, R8 beta | 2026-07-21 |
+| OnePlus (Oplus) | OnePlus Nord CE4 Lite `CPH2621` ColorOS 15 (`ro.build.version.oplusrom=V15.0.0`) | Full — enforcement directly observable (device holds at 80%); external writes stick | Two mutually-exclusive `system` keys (Charging limit / Smart charging), WSS-only write rejected + Shizuku write succeeds for all three policies, WSS-only UX (controls disabled + Shizuku-required banner) | 2026-07-21 |
+
+## Known gaps
+
+- **LineageOS** — landed **diagnostics-only**: `QUALIFIED_CODENAMES` ships **empty**, so the live adapter never
+  matches and every LineageOS build falls to `LineageLabAdapter`. A codename is added only after that device passes
+  qualification (real charging cessation at the limit, wired + wireless, below/at/above threshold) and gets a
+  "Verified devices" row.
+  - **Pixel 6 (oriole) on LineageOS 20.0 / Android 13 — tested 2026-07-22, result NO-GO (no hardware enforcement).**
+    The *software chain is fully validated* — both raw (shell-UID `content query`/`content insert`) **and through the
+    app's real Shizuku backend end-to-end** (R8 debug build + Shizuku granted): tapping 80 % wrote the trio via
+    `writeLineageSetting` and read back `Verified(FixedLimit(80), SHIZUKU)`. LineageOS's `ChargingControlController`
+    **observes the external write** and updates its live config (`dumpsys lineagehealth` → `mConfigEnabled:true,
+    mConfigMode:3, mConfigLimit:80`); the `vendor.lineage.health.IChargingControl/default` HAL is registered and its
+    service runs. The refuse-don't-clobber decode was also confirmed live: a native `mode=2` (CUSTOM) state read as
+    `Unknown(unrecognized)` ("Policy not verified"), never overwritten. And the diagnostics-only path was smoke-tested
+    (empty allowlist → `lineageos-lab` → "Detected for diagnostics only", no crash). **But the hard percent
+    limit did not cut charging** — with `limit=80` set, the battery charged 92→95 %+ at ~1.2 A (`charge_stage=Inactive`,
+    `charge_limit` sysfs empty, `mChargingStopReason:0`). On Pixel the charge hardware is driven by Google's
+    adaptive/`charge_deadline` mechanism, and this Lineage build's HAL does not map the %-cap to a real cutoff — the
+    `mIsLimitSet:false` device-dependent class of gap. So oriole stays **out** of the allowlist. This is a clean
+    validation of the conservative gate: an "any LineageOS device" gate would have claimed 80 % protection while the
+    phone charged to 100 %. (Qualifying a device with a *working* charge-control HAL remains open; the adapter's
+    provider/observer mechanism is proven, only per-device HAL enforcement varies.)
+  - Also confirmed on oriole: `charging_control_*` keys are **absent in factory state** (validates the conservative
+    "absent → unrecognized" decode). Still open: the provider's change-notification URI form (per-key vs table)
+    against the registered `observedSettingUris`, to be checked on a HAL-enforcing device.
+  - **Pixel 6 (oriole) on LineageOS 23.2 / Android 16 — retested 2026-07-22 after an anti-rollback firmware bump,
+    result NO-GO (HAL no longer offers LIMIT mode at all).** A *sharper* root cause than the LOS 20 run: the
+    `vendor.lineage.health.IChargingControl` HAL reports `getSupportedMode()` **without the LIMIT bit**, so
+    `ChargingControlController.isChargingModeSupported(LIMIT)` is false and LineageOS **coerces `charging_control_mode=3`
+    → `1` (AUTO)** — verified live: every raw shell-UID `content insert` of `mode=3` (even while `enabled=0`) read back
+    as `1`. Enabling then logs `LineageHealth: No alarm found, auto charging control has no effect` and `Setting charge
+    deadline: … 73353`; the active provider is `ccprovider.Deadline` (Google Adaptive Charging — time/alarm-based, **no
+    fixed-percent cap**). `charging_policy`/`charge_stage` sysfs never changed. So oriole is NO-GO on **both** builds for
+    different reasons: LOS 20 *accepted* LIMIT but the HAL silently didn't cut; LOS 23.2's HAL dropped LIMIT and falls
+    back to the Deadline mechanism. Consequence for the adapter (unchanged — correct by design): SYNC_READBACK
+    `apply(FixedLimit)` writes `mode=3`, reads back `mode=1 ≠ 3` → decodes `Unknown(unrecognizedValue=true)` → `apply`
+    returns false, so it **refuses without a false claim of control**. Reinforces the allowlist bar: a device must both
+    expose the LIMIT mode bit **and** actually cut charging. `charging_control_*` again **absent in factory state**.
+- **Xiaomi** — adaptive hardware enforcement of external writes unconfirmed; treat the adapter as provisional until
+  the 80% hold is physically observed.
+- **Pixel** — wireless at-threshold hold/charge-past and the widget under Shizuku-only remain unexercised (both share
+  the verified wired mechanism).

--- a/.claude/skills/oem-adapters/SKILL.md
+++ b/.claude/skills/oem-adapters/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: oem-adapters
+description: Per-OEM charge-control adapter detail for Amply — the exact settings keys, value domains, write ordering, verification strategy, and session override of the Samsung, Xiaomi, OnePlus/ColorOS, LineageOS, and Pixel adapters. Use when reading or changing anything under charging/core/adapter, adding an adapter, or reasoning about how a policy maps to real settings values.
+---
+
+# Charging adapters
+
+Per-OEM adapter detail, for work under `charging/core/adapter`. The always-loaded companions are
+`.claude/rules/architecture.md` (data flow, `ChargeObservation`, session/recovery) and
+`.claude/rules/privileged-access.md` (safety boundary, capability gates) — **read the latter before changing any
+control code**. The ledger of physically-verified devices lives in the `device-qualification` skill.
+
+## Samsung Adapters
+
+Two live adapters, gated by `ro.build.version.oneui` ranges plus `protect_battery` presence plus system user
+(all in world-readable `global` namespace; only writes need WSS):
+
+- **Modern (One UI 8.x)**: `protect_battery` 0=off / 1=Maximum / 3=Standard(pause at 100%, resume 95%), plus
+  `battery_protection_threshold` 80|85|90|95 (absent = 80, only valid ticks decode; malformed → Unknown).
+  Policies: FixedLimit(80/85/90/95), PauseAtFull, Unrestricted. Session override = **PauseAtFull** (reaches 100%
+  while keeping Samsung's own safety net). Threshold is written before mode.
+- **Legacy (One UI 4.x/5.x)**: `protect_battery` 0/1 toggle, fixed 85% cap. Policies: FixedLimit(85),
+  Unrestricted. Session override = Unrestricted.
+
+Writes apply **synchronously** (`VerificationStrategy.SYNC_READBACK`): `apply()` requires read-back equality, no
+pending-settle window, boot recovery converges on settings readback, and no reapply-inversion trick is needed.
+The reconnect gesture is Pixel-only (`reconnectGestureSupported`). One UI 6/7 and 9+ fall through to the
+diagnostics-only lab adapter. An external `protect_battery=0` makes One UI forget the user's prior mode (it falls back
+to the OEM default on re-enable), so Amply restores the exact prior policy itself rather than trusting Samsung's
+bookkeeping. Verified devices + coverage: see the qualification ledger (`device-qualification` skill).
+
+## Xiaomi Adapter
+
+One live adapter (`xiaomi-hyperos2-v1`), gated to the HyperOS ROM version (the setting is a ROM
+feature, not a per-model one): manufacturer Xiaomi (covers Redmi/POCO — they report Xiaomi as
+manufacturer) + `ro.mi.os.version.code == 2` (HyperOS 2.x) + system user. Use `ro.mi.os.version.code`,
+NOT the frozen legacy `ro.miui.ui.version.code`. Single key
+`secure/security_pc_secure_protect_mode_key`: `0`=charge fully, `1`=Intelligent (heuristic 80% hold →
+`ChargePolicy.Adaptive`), absent=Intelligent (factory state). No hard-cap mode exists. SYNC_READBACK
+with read-back equality; session override = Unrestricted; protective default = Adaptive. HyperOS 1,
+pre-HyperOS MIUI, and a future HyperOS 3 fall to `XiaomiLabAdapter` (diagnostics + contribution). Two
+documented assumptions: the feature is treated as present on any HyperOS 2 device (a device lacking it
+reads the key absent → a harmless false claim of control), and daemon-level enforcement of external
+writes is pending long-term observation (see the `device-qualification` skill).
+
+## OnePlus / ColorOS Adapter
+
+One live adapter (`oplus-coloros15-v1`) for the ColorOS/OxygenOS (Oplus) family — OnePlus, Oppo, Realme —
+gated to `ro.build.version.oplusrom == 15` (Oplus-exclusive property, so it doubles as the family signal) +
+system user. Two mutually-exclusive **`system`** keys under Battery health: `regular_charge_protection_switch_state`
+= "Charging limit" (fixed 80% cap → `FixedLimit(80)`) and `smart_charge_protection_switch_state` = "Smart charging"
+(adaptive → `Adaptive`); neither on = Unrestricted; both on = Unknown/unrecognized. The OEM enforces exclusion and
+keeps a `_status` mirror (Amply writes only `_switch_state`). SYNC_READBACK with read-back equality; session
+override = Unrestricted; protective default = FixedLimit(80). **Writes require Shizuku** — the keys are `system`
+namespace, which WRITE_SECURE_SETTINGS cannot write (reads are unprivileged); the adapter sets
+`preferShizukuForWrites`. Unqualified Oplus versions fall to `OnePlusLabAdapter`. Enforcement is directly
+observable (device holds at 80%). See the qualification ledger (`device-qualification` skill).
+
+## LineageOS Adapter
+
+One live adapter (`lineageos-chargingcontrol-v1`) plus a `LineageLabAdapter`, for LineageOS's native Charging
+Control. **Manufacturer-agnostic** — the ROM changes charging control regardless of the OEM hardware — so both are
+registered **first** in `AdapterRegistry`, ahead of every OEM adapter; a LineageOS build on Samsung/Xiaomi/OnePlus/
+Pixel hardware is handled by these, never the OEM lab adapters (stock devices have `lineageOsVersion == null` and
+skip both). Gate: `ro.lineage.build.version` present + `Build.DEVICE` in a **physically-qualified codename
+allowlist** (`QUALIFIED_CODENAMES`) + `lineagesettings` provider present + system user. Unqualified LineageOS builds
+fall to `LineageLabAdapter`.
+
+The three keys live in the private `content://lineagesettings/system` provider (`SettingNamespace.LINEAGE_SYSTEM`),
+NOT any AOSP `settings` namespace: `charging_control_enabled` (0/1), `charging_control_mode` (3=LIMIT), and
+`charging_control_charging_limit` (the discrete ticks 70/75/80/85/90/95). A hard cap is `enabled=1`+`mode=3`+`limit=N`;
+`enabled=0` is Unrestricted. Writes are ordered limit→mode→enabled (the observable "on" flip last). **Reads are
+unprivileged** (`LineageSettingsClient` via ContentResolver, shared by both backends); **writes require Shizuku**
+(`content insert`; the shell UID holds `lineageos.permission.WRITE_SETTINGS`, which `WRITE_SECURE_SETTINGS` cannot
+cover — `preferShizukuForWrites`, and the WSS auto-grant is skipped). `SYNC_READBACK` with read-back equality;
+session override = Unrestricted; protective default = FixedLimit(80); reconnect gesture unsupported.
+
+LineageOS's own `ChargingControlController` observes these keys and re-drives the `vendor.lineage.health.
+IChargingControl` HAL, so an external write is honored. But the HAL is **device-dependent** (the setting can flip
+while charging never actually stops — the `mIsLimitSet:false` bug), which is why the gate is a qualified-codename
+allowlist and control ships disabled until a codename is physically proven. `read()` returns `Verified` **only** for
+states v1 can restore exactly (a supported fixed limit, or Unrestricted); AUTO/CUSTOM schedules, off-tick limits, and
+an absent/malformed `enabled` decode to `Unknown(unrecognizedValue=true)` so a temporary session refuses rather than
+clobbering the user's native choice. Verified devices + coverage: see the qualification ledger (`device-qualification` skill).
+
+## Pixel Adapter
+
+Writes **only** two secure settings:
+
+- `secure/adaptive_charging_enabled`
+- `secure/charge_optimization_mode`
+
+Ordering matters:
+
+- Fixed 80%: adaptive `0`, then mode `1`
+- Unrestricted: mode `0`, then adaptive `0`
+- Adaptive: mode `0`, then adaptive `1`
+
+Google's Settings Intelligence worker applies external secure-setting changes **asynchronously** (measured
+charging-HAL delay ≈ 11–12 s on tested Pixels). A same-package same-value write does **not** fire the settings
+observer — re-writes briefly invert `charge_optimization_mode` before applying the target.
+

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: release
+description: Amply's release process — versioning via version.properties/bump.sh, signing material, the release-prepare/release-tag workflows, store-listing metadata, Play Store screenshot generation, and the Google Play publication gate. Use when cutting a release, bumping a version, regenerating store screenshots, or touching signing/release CI.
+---
+
 # Release
 
 ## Current state (honest)
@@ -12,9 +17,24 @@ into CI and are gated (see below), so `release-tag.yml` still publishes a **FOSS
 
 - **Metadata**: `fastlane/metadata/android/en-US/{title,short_description,full_description}.txt` + `changelogs/default.txt`,
   validated in CI by `check_metadata_length.sh` (title 30 / short 80 / full 3800 / changelog 500 chars).
-- **Screenshots**: generated from `@Preview` composables on the JVM — see `build-commands.md` for the
-  `generate_screenshots.sh` → `copy_screenshots.sh` workflow. Committed under `.../images/phoneScreenshots/`.
-  Regenerate before a store update; CI compiles but never renders them.
+- **Screenshots**: generated from `@Preview` composables on the JVM (no device) via the Compose Preview Screenshot
+  Testing plugin (`com.android.compose.screenshot`, enabled by `android.experimental.enableScreenshotTest=true` in
+  `gradle.properties`). The store composables live in `app/src/debug/.../screenshots/ScreenshotContent.kt`; the
+  capture entry points (`@PreviewTest`) and locale annotations live in `app/src/screenshotTest/.../screenshots/`.
+
+  ```bash
+  # 1. Render (writes to app/src/screenshotTestGplayDebug/reference/, which is gitignored)
+  ./fastlane/generate_screenshots.sh
+  # 2. Normalize (flatten alpha → opaque 1080x1920) + sort into the committed metadata tree
+  ./fastlane/copy_screenshots.sh
+  ```
+
+  Committed output lands in `fastlane/metadata/android/en-US/images/phoneScreenshots/` as `1_dashboard_light.png …
+  6_reconnect_gesture.png` (names come from `copy_screenshots.sh`'s `screen_file` map). Both scripts fail loudly on
+  any count/dimension/format mismatch and `copy_screenshots.sh` requires ImageMagick. Needs the JDK 21 build
+  toolchain like everything else. CI compiles these sources (`compileGplayDebugScreenshotTestKotlin`) but does
+  **not** render — layoutlib output differs across machines — so **regenerating screenshots is a manual pre-release
+  step**.
 - **`supply` lanes** (`beta` / `production` / `listing_only` / `screenshots_only`): every lane that mutates Play state
   refuses to run unless `AMPLY_PLAY_PUBLISH_APPROVED=1`, keeping publication behind the `specialUse` gate below.
   Prerequisites (all manual, none automated): an existing Play app for `eu.darken.amply`, a service-account JSON at the

--- a/app/src/main/java/eu/darken/amply/charging/core/access/shizuku/ChargingControlUserService.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/access/shizuku/ChargingControlUserService.kt
@@ -171,7 +171,7 @@ internal class BoundedStreamReader(
  * Pure validation for the privileged write path. Every writable setting carries an explicit
  * per-key value domain — the boundary itself rejects out-of-domain values instead of trusting
  * the adapter layer. Keys must be physically qualified before being added (see the qualification
- * ledger in .claude/rules/privileged-access.md); the OnePlus key is present for a future lab adapter
+ * ledger in .claude/skills/device-qualification/); the OnePlus key is present for a future lab adapter
  * and is not invoked by production code.
  */
 internal object SettingWritePolicy {
@@ -189,7 +189,7 @@ internal object SettingWritePolicy {
             "battery_protection_threshold" to setOf("80", "85", "90", "95"),
         ),
         "system" to mapOf(
-            // ColorOS/OxygenOS (Oplus) charging protection (qualification ledger in .claude/rules/privileged-access.md).
+            // ColorOS/OxygenOS (Oplus) charging protection (qualification ledger in .claude/skills/device-qualification/).
             // System namespace: writable only via Shizuku (shell UID), not direct WRITE_SECURE_SETTINGS.
             "regular_charge_protection_switch_state" to setOf("0", "1"),
             "smart_charge_protection_switch_state" to setOf("0", "1"),

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapter.kt
@@ -34,7 +34,7 @@ import javax.inject.Singleton
  * class of bug), so control is gated to a **physically-qualified codename allowlist**
  * ([QUALIFIED_CODENAMES]) that ships **empty** until a device passes qualification; every LineageOS build
  * otherwise falls through to [LineageLabAdapter]. See the qualification ledger in
- * `.claude/rules/privileged-access.md`.
+ * `.claude/skills/device-qualification/`.
  */
 @Singleton
 class LineageChargingAdapter @Inject constructor(
@@ -165,7 +165,7 @@ class LineageChargingAdapter @Inject constructor(
         /**
          * Physically-qualified device codenames (`Build.DEVICE`) where the charge-control HAL is confirmed
          * to enforce the limit. **Ships empty** — the adapter is diagnostics-only until a device passes the
-         * qualification protocol and gets a ledger row (see `.claude/rules/privileged-access.md`). Widen
+         * qualification protocol and gets a ledger row (see `.claude/skills/device-qualification/`). Widen
          * ONLY with a qualified device.
          */
         val QUALIFIED_CODENAMES = emptySet<String>()

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/OnePlusChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/OnePlusChargingAdapter.kt
@@ -18,7 +18,7 @@ import javax.inject.Singleton
 /**
  * ColorOS / OxygenOS (Oplus) charging protection via two mutually-exclusive `system` keys
  * (verified on a OnePlus Nord CE4 Lite / ColorOS 15; see the qualification ledger in
- * .claude/rules/privileged-access.md):
+ * .claude/skills/device-qualification/):
  *
  * - `regular_charge_protection_switch_state` — "Charging limit": a hard cap that keeps the
  *   battery at 80% while charging → [ChargePolicy.FixedLimit] at 80.

--- a/app/src/main/java/eu/darken/amply/diagnostics/core/ContributionAllowlist.kt
+++ b/app/src/main/java/eu/darken/amply/diagnostics/core/ContributionAllowlist.kt
@@ -12,7 +12,7 @@ import eu.darken.amply.charging.core.access.SettingNamespace
  *
  * Mirrors the spike-verified charge keys (kept deliberately separate from the privileged `SettingWritePolicy`, which
  * governs writes; these two domains happen to coincide today but answer different questions). Extend only with
- * spike-documented keys — see the qualification ledger in `.claude/rules/privileged-access.md`.
+ * spike-documented keys — see the qualification ledger in `.claude/skills/device-qualification/`.
  */
 object ContributionAllowlist {
     private val ROWS: Map<SettingId, Set<String>> = mapOf(


### PR DESCRIPTION
## What changed

No user-facing behavior change — this is AI-assistant documentation under `.claude/` plus four source comments.

The repository guidance is split into what every session needs (always-loaded `.claude/rules/`) and what only some sessions need (`.claude/skills/`, loaded on demand).

## Technical Context

**Why now:** #36 renamed `.claude/rules/release.md` → `.claude/skills/release/SKILL.md` as a pure rename with zero content change. A skill needs YAML frontmatter (`name`, `description`) to be loadable, so `release` has been sitting in `main` as a broken skill since that commit. This PR finishes the restructuring it started.

**What moved** (content is unchanged in each move — verified verbatim):

| To | From | Holds |
|---|---|---|
| `skills/release` | — | frontmatter added; also takes back the screenshot workflow that `rules/build-commands.md` was duplicating |
| `skills/device-qualification` | `rules/privileged-access.md` | qualification protocol, verified-device ledger, per-OEM known gaps |
| `skills/oem-adapters` | `rules/architecture.md` | per-OEM adapter detail — keys, value domains, write ordering, session overrides |

`rules/architecture.md` goes 208 → 95 lines, `rules/privileged-access.md` 231 → 136. Each keeps a pointer to its skill, so the reading path from "I'm touching control code" to the adapter/ledger detail is still one hop.

**No nested `CLAUDE.md`.** An earlier draft of this work put the adapter detail in `app/src/main/java/eu/darken/amply/charging/CLAUDE.md` to get directory-scoped auto-loading. That is not a pattern this repo wants, so it became a skill instead, and `.claude/CLAUDE.md` now states the rule explicitly to stop it being re-nested next to the code later.

**Source comments:** four files referenced the qualification ledger at `.claude/rules/privileged-access.md`, which no longer holds it — they now point at `.claude/skills/device-qualification/`. Comment-only edits; `compileFossDebugKotlin` passes. `SettingsSnapshotSource.kt` still points at `privileged-access.md` for the wizard rules, which is correct — that section did not move.

**Also:** `.claude/CLAUDE.md` claimed status `0.1.0-beta1` (actual: `0.2.1-beta0`); it now defers to `VERSION` so it cannot drift again.

## Review guidance

Diff is large but almost entirely relocation. The parts worth actually reading are the three skill frontmatter blocks (do the `description` fields describe when to invoke them accurately?) and the pointer lines left behind in `rules/architecture.md`, `rules/privileged-access.md`, `rules/agent-instructions.md`, and `.claude/CLAUDE.md`.