### PR TITLE
Fix: Reconnect gesture stopped working after a mistimed replug

### DIFF
--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -354,6 +354,10 @@ class ChargeSessionService : Service() {
             // Gesture inactive: keep running only if a watcher still wants the service, showing the
             // quiet monitoring notification instead of the gesture cue.
             if (anyWatcherEnabled()) {
+                // Only stopMonitoring() resets the engine, so a watcher keeping this instance alive
+                // across a disable/re-enable cycle would otherwise resume on stale gesture state
+                // (a latched basis or an open reconnect window from before the disable).
+                quickGesture.reset()
                 startAsForeground(SessionNotifications.monitoring(this))
             } else {
                 stopMonitoring()

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/QuickFullChargeGesture.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/QuickFullChargeGesture.kt
@@ -23,9 +23,11 @@ enum class PolicyEvidence { PROTECTIVE, UNRESTRICTED, UNKNOWN }
  * reading alone can never reconstruct a limit hold, and every retry after a missed window used to be
  * inert. A rejected sub-[minReconnectMillis] gap is deliberately treated as a *non-event*: the basis
  * returns to the ordinary plugged-period latch and from there persists exactly as long as a freshly
- * observed hold would — it carries no timestamp and is retired only by the out-of-band check below,
- * by [reset], or by consuming a trigger. So a retry is not bounded by the original window; that is
- * the point (see `a retry long after the original unplug still triggers`).
+ * observed hold would. Carrying no timestamp of its own, it is subject to the same retirement paths
+ * as any latched basis — the out-of-band check below, an any-level revocation, expiry of a reconnect
+ * window it later opens, a replug that re-derives to nothing, [reset], or consuming a trigger. What
+ * it is *not* bound by is the original reconnect window; that is the point (see `a retry long after
+ * the original unplug still triggers`).
  *
  * Two arming bases exist:
  * - Limit hold (default): Android's charging-policy hardware state reports the Pixel policy actively

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/QuickFullChargeGesture.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/QuickFullChargeGesture.kt
@@ -15,6 +15,15 @@ enum class PolicyEvidence { PROTECTIVE, UNRESTRICTED, UNKNOWN }
 /**
  * Detects a deliberate unplug/replug gesture that starts a one-time full charge.
  *
+ * The engine is a three-state machine — `Idle`, `Armed(basis)`, `AwaitingReconnect(basis, since)` —
+ * plus the orthogonal plug-edge memory [previousPlugged]. The arming basis is *carried* through the
+ * unplugged gap by `AwaitingReconnect`, and a replug that is merely mistimed hands it back to
+ * `Armed` instead of discarding it. That carry-over is what makes retrying possible: a physically
+ * replugged phone reports `CHARGING` while it tops back up, so re-deriving the basis from the replug
+ * reading alone can never reconstruct a limit hold, and every retry after a missed window used to be
+ * inert. No memory concept or extra timeout constant is needed for this — the basis lifetime equals
+ * the window lifetime, so staleness is bounded structurally.
+ *
  * Two arming bases exist:
  * - Limit hold (default): Android's charging-policy hardware state reports the Pixel policy actively
  *   holding near its limit. Only the hardware signal is trusted, never Amply's cached request.
@@ -22,7 +31,8 @@ enum class PolicyEvidence { PROTECTIVE, UNRESTRICTED, UNKNOWN }
  *   is conclusively protective ([PolicyEvidence.PROTECTIVE]); percent, battery status, and the
  *   hardware hold are deliberately ignored. This basis is revoked — including an already-open
  *   reconnect window — by an explicit opt-out or by *conclusive* [PolicyEvidence.UNRESTRICTED]
- *   evidence, so an opt-out can never produce a trigger.
+ *   evidence, so an opt-out can never produce a trigger. Revocation runs before the plug edges, so a
+ *   revoked basis is never carried over by a mistimed replug either.
  *
  * [PolicyEvidence.UNKNOWN] is tolerated **only** on an unplugged tick or while a reconnect window is
  * open — that is the one place the strongest evidence is structurally unavailable, because the
@@ -39,7 +49,8 @@ enum class PolicyEvidence { PROTECTIVE, UNRESTRICTED, UNKNOWN }
  * costs nothing — the basis re-arms on the very next tick that reports protective evidence again.
  *
  * The reconnect window has a debounce floor: a disconnect shorter than [minReconnectMillis] never
- * triggers, filtering momentary power cuts (car ignition, connector jostle). Timestamps must come
+ * triggers, filtering momentary power cuts (car ignition, connector jostle); such a replug returns to
+ * `Armed` with the carried basis, so the next deliberate attempt can fire. Timestamps must come
  * from `SystemClock.elapsedRealtime()` so wall-clock changes cannot distort the window.
  */
 class QuickFullChargeGesture(
@@ -69,9 +80,21 @@ class QuickFullChargeGesture(
 
     private enum class ArmedBy { LIMIT_HOLD, ANY_LEVEL }
 
+    private sealed interface State {
+        data object Idle : State
+        data class Armed(val basis: ArmedBy) : State
+        data class AwaitingReconnect(val basis: ArmedBy, val sinceMillis: Long) : State
+    }
+
+    private val State.armingBasis: ArmedBy?
+        get() = when (this) {
+            State.Idle -> null
+            is State.Armed -> basis
+            is State.AwaitingReconnect -> basis
+        }
+
     private var previousPlugged: Boolean? = null
-    private var armedBy: ArmedBy? = null
-    private var disconnectedAtMillis: Long? = null
+    private var state: State = State.Idle
 
     fun update(input: Input): Output {
         val heldAtLimit = input.plugged &&
@@ -85,81 +108,100 @@ class QuickFullChargeGesture(
         // An any-level basis is dropped by an explicit opt-out, by conclusive evidence that charging
         // is unrestricted, or by inconclusive evidence on a tick where conclusive evidence was
         // available (plugged, no open window) — a natively-removed limit reads UNKNOWN, not
-        // UNRESTRICTED, on a journal-less device. The `disconnectedAtMillis == null` guard is
-        // load-bearing: this block runs before the replug edge is handled, so without it a replug
-        // tick whose hardware has not re-reported its hold yet would destroy its own trigger.
+        // UNRESTRICTED, on a journal-less device. The "not mid-window" guard is load-bearing: this
+        // block runs before the replug edge is handled, so without it a replug tick whose hardware
+        // has not re-reported its hold yet would destroy its own trigger.
         // A latched limit-hold basis survives option flips: its evidence was the (momentary)
         // hardware hold, which is mode-independent.
-        if (armedBy == ArmedBy.ANY_LEVEL &&
+        if (state.armingBasis == ArmedBy.ANY_LEVEL &&
             (!input.anyLevelEnabled ||
                 input.policyEvidence == PolicyEvidence.UNRESTRICTED ||
                 (input.policyEvidence == PolicyEvidence.UNKNOWN &&
                     input.plugged &&
-                    disconnectedAtMillis == null))
+                    state !is State.AwaitingReconnect))
         ) {
-            armedBy = null
-            disconnectedAtMillis = null
+            state = State.Idle
         }
 
         val previous = previousPlugged
         previousPlugged = input.plugged
 
         if (previous == null) {
-            armedBy = basisOf(heldAtLimit, anyLevelHeld)
+            state = armFrom(heldAtLimit, anyLevelHeld)
             return statusOutput(input)
         }
 
         if (previous && !input.plugged) {
-            disconnectedAtMillis = input.nowMillis.takeIf { armedBy != null }
+            // Carry the basis across the gap: the hardware evidence is already gone by this tick.
+            state = (state as? State.Armed)
+                ?.let { State.AwaitingReconnect(it.basis, input.nowMillis) }
+                ?: State.Idle
             return statusOutput(input)
         }
 
         if (!previous && input.plugged) {
-            val windowBasis = armedBy
-            val delta = disconnectedAtMillis?.let { input.nowMillis - it }
-            disconnectedAtMillis = null
-            armedBy = null
-            if (windowBasis != null && delta != null && delta in minReconnectMillis..maxReconnectMillis) {
-                return Output(QuickFullChargeDecision.TRIGGER, windowBasis == ArmedBy.ANY_LEVEL)
+            val awaiting = state as? State.AwaitingReconnect
+            if (awaiting != null) {
+                val delta = input.nowMillis - awaiting.sinceMillis
+                return when {
+                    delta in minReconnectMillis..maxReconnectMillis -> {
+                        state = State.Idle
+                        Output(QuickFullChargeDecision.TRIGGER, awaiting.basis == ArmedBy.ANY_LEVEL)
+                    }
+                    // Too fast (a momentary power cut): keep the basis the window carried. The
+                    // replug reading itself can never re-derive it — a phone topping back up
+                    // reports CHARGING, not a settled hold — so discarding it here made every
+                    // retry after a rejected attempt inert.
+                    delta < minReconnectMillis -> {
+                        state = State.Armed(awaiting.basis)
+                        statusOutput(input)
+                    }
+                    // Too late: the window is spent, but the fresh plugged state may already
+                    // qualify again — re-arm immediately instead of waiting for another broadcast.
+                    else -> {
+                        state = armFrom(heldAtLimit, anyLevelHeld)
+                        statusOutput(input)
+                    }
+                }
             }
-            // A too-fast or too-late replug is no trigger, but the fresh plugged state may already
-            // qualify again — re-arm immediately instead of waiting for another broadcast.
-            armedBy = basisOf(heldAtLimit, anyLevelHeld)
+            state = armFrom(heldAtLimit, anyLevelHeld)
             return statusOutput(input)
         }
 
         if (input.plugged) {
             when {
                 // Latch the hold: at the later unplug tick the hardware evidence is already gone.
-                heldAtLimit -> armedBy = ArmedBy.LIMIT_HOLD
-                armedBy == null && anyLevelHeld -> armedBy = ArmedBy.ANY_LEVEL
+                heldAtLimit -> state = State.Armed(ArmedBy.LIMIT_HOLD)
+                state is State.Idle && anyLevelHeld -> state = State.Armed(ArmedBy.ANY_LEVEL)
             }
-        } else if (disconnectedAtMillis?.let { input.nowMillis - it > maxReconnectMillis } == true) {
-            disconnectedAtMillis = null
-            armedBy = null
+        } else {
+            val awaiting = state as? State.AwaitingReconnect
+            if (awaiting != null && input.nowMillis - awaiting.sinceMillis > maxReconnectMillis) {
+                state = State.Idle
+            }
         }
         return statusOutput(input)
     }
 
     fun reset() {
         previousPlugged = null
-        armedBy = null
-        disconnectedAtMillis = null
+        state = State.Idle
     }
 
-    private fun basisOf(heldAtLimit: Boolean, anyLevelHeld: Boolean): ArmedBy? = when {
-        heldAtLimit -> ArmedBy.LIMIT_HOLD
-        anyLevelHeld -> ArmedBy.ANY_LEVEL
-        else -> null
+    private fun armFrom(heldAtLimit: Boolean, anyLevelHeld: Boolean): State = when {
+        heldAtLimit -> State.Armed(ArmedBy.LIMIT_HOLD)
+        anyLevelHeld -> State.Armed(ArmedBy.ANY_LEVEL)
+        else -> State.Idle
     }
 
     private fun statusOutput(input: Input): Output {
+        val current = state
         val decision = when {
-            input.plugged && armedBy != null -> QuickFullChargeDecision.ARMED
-            !input.plugged && disconnectedAtMillis != null -> QuickFullChargeDecision.WAITING_FOR_RECONNECT
+            input.plugged && current is State.Armed -> QuickFullChargeDecision.ARMED
+            !input.plugged && current is State.AwaitingReconnect -> QuickFullChargeDecision.WAITING_FOR_RECONNECT
             else -> QuickFullChargeDecision.IDLE
         }
-        return Output(decision, armedBy == ArmedBy.ANY_LEVEL)
+        return Output(decision, current.armingBasis == ArmedBy.ANY_LEVEL)
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/QuickFullChargeGesture.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/QuickFullChargeGesture.kt
@@ -51,6 +51,15 @@ enum class PolicyEvidence { PROTECTIVE, UNRESTRICTED, UNKNOWN }
  * (a natively-removed limit reads as UNKNOWN, not UNRESTRICTED, on a journal-less device). Dropping
  * costs nothing — the basis re-arms on the very next tick that reports protective evidence again.
  *
+ * A latched *limit-hold* basis is retired by any readable percent outside the arming band. This is
+ * defence in depth for a **pre-existing** gap, not a consequence of the carry-over: the
+ * steady-plugged branch has never dropped a latched basis, so a limit removed in system settings
+ * left the gesture armed while the battery climbed past the band. The check runs before the plug
+ * edges, so an out-of-band reading also cancels an already-open reconnect window. It is deliberately
+ * narrow: an any-level basis is percent-independent by design and would lose windows it may
+ * legitimately hold, and an unreadable percent (`< 0`) retires nothing, so one failed
+ * sticky-broadcast read cannot disarm a healthy gesture.
+ *
  * The reconnect window has a debounce floor: a disconnect shorter than [minReconnectMillis] never
  * triggers, filtering momentary power cuts (car ignition, connector jostle); such a replug returns to
  * `Armed` with the carried basis, so the next deliberate attempt can fire. Timestamps must come
@@ -122,6 +131,19 @@ class QuickFullChargeGesture(
                 (input.policyEvidence == PolicyEvidence.UNKNOWN &&
                     input.plugged &&
                     state !is State.AwaitingReconnect))
+        ) {
+            state = State.Idle
+        }
+
+        // Defence in depth for a latched limit-hold basis: the steady-plugged branch has never
+        // dropped one, so a limit removed in system settings left the gesture armed while the
+        // battery climbed past the arming band. A reading outside the band retires it. Only a
+        // limit-hold basis — an any-level basis is percent-independent by design. An unreadable
+        // percent (< 0) retires nothing, so a single failed sticky-broadcast read cannot disarm a
+        // healthy gesture.
+        if (input.percent >= 0 &&
+            input.percent !in MIN_ARM_PERCENT..MAX_ARM_PERCENT &&
+            state.armingBasis == ArmedBy.LIMIT_HOLD
         ) {
             state = State.Idle
         }

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/QuickFullChargeGesture.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/QuickFullChargeGesture.kt
@@ -21,8 +21,11 @@ enum class PolicyEvidence { PROTECTIVE, UNRESTRICTED, UNKNOWN }
  * `Armed` instead of discarding it. That carry-over is what makes retrying possible: a physically
  * replugged phone reports `CHARGING` while it tops back up, so re-deriving the basis from the replug
  * reading alone can never reconstruct a limit hold, and every retry after a missed window used to be
- * inert. No memory concept or extra timeout constant is needed for this — the basis lifetime equals
- * the window lifetime, so staleness is bounded structurally.
+ * inert. A rejected sub-[minReconnectMillis] gap is deliberately treated as a *non-event*: the basis
+ * returns to the ordinary plugged-period latch and from there persists exactly as long as a freshly
+ * observed hold would — it carries no timestamp and is retired only by the out-of-band check below,
+ * by [reset], or by consuming a trigger. So a retry is not bounded by the original window; that is
+ * the point (see `a retry long after the original unplug still triggers`).
  *
  * Two arming bases exist:
  * - Limit hold (default): Android's charging-policy hardware state reports the Pixel policy actively

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
@@ -32,14 +32,12 @@ import eu.darken.amply.common.debug.logging.asLog
 import eu.darken.amply.common.debug.logging.log
 import eu.darken.amply.common.debug.logging.logTag
 import eu.darken.amply.common.flow.combine as combine6
-import eu.darken.amply.fullcharge.core.ChargeSessionManager
 import eu.darken.amply.fullcharge.core.ChargeSessionRecord
 import eu.darken.amply.fullcharge.core.ChargeSessionService
 import eu.darken.amply.fullcharge.core.FullChargeStore
 import eu.darken.amply.fullcharge.core.InterruptionEvent
 import eu.darken.amply.fullcharge.core.InterruptionStore
 import eu.darken.amply.fullcharge.core.ServiceDispatch
-import eu.darken.amply.fullcharge.core.SessionNotifications
 import eu.darken.amply.main.core.DeviceSupportReport
 import eu.darken.amply.main.core.DeviceSupportReporter
 import eu.darken.amply.main.core.OnboardingSettings
@@ -113,7 +111,6 @@ class DashboardViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val repository: ChargingRepository,
     private val fullChargeStore: FullChargeStore,
-    private val sessionManager: ChargeSessionManager,
     private val onboardingSettings: OnboardingSettings,
     private val deviceSupportReporter: DeviceSupportReporter,
     private val quickAccessStore: QuickAccessStore,
@@ -340,25 +337,23 @@ class DashboardViewModel @Inject constructor(
 
     fun completeOnboarding() = viewModelScope.launch { onboardingSettings.complete() }
 
-    fun applyPolicy(policy: ChargePolicy) = viewModelScope.launch {
+    /**
+     * Routed through the service (same command the widget's ∞ buttons use) rather than writing the
+     * policy here: the service serializes the write against session/recovery writes, refuses when no
+     * backend can write, persists the recovery target before the risky write, suppresses its own
+     * settings-observer trip, force-writes so a same-value write still re-triggers the HAL, clears
+     * the interruption warning plus its recovery notification on success (and posts one on failure)
+     * — and resets the gesture engine, which the plain ACTION_MONITOR nudge never did, so a stale
+     * arming basis could survive a persistent-policy change.
+     */
+    fun applyPolicy(policy: ChargePolicy) {
         log(TAG, Logging.Priority.INFO) { "applyPolicy(${policy.stableId})" }
-        if (fullChargeStore.currentSession() != null) sessionManager.cancelWithoutRestore()
-        val result = repository.applyPersistent(policy)
-        if (result.success) {
-            // An explicit policy choice supersedes any non-successful interruption warning and its
-            // lingering recovery notification.
-            interruptionStore.clearPending()
-            SessionNotifications.cancelRecovery(context)
-        }
-        // The persistent policy is an any-level arming input; nudge a running gesture monitor so
-        // arming and notification copy react now instead of on the next broadcast/30s poll.
-        if (fullChargeStore.isQuickFullChargeEnabled()) {
-            ContextCompat.startForegroundService(
-                context,
-                Intent(context, ChargeSessionService::class.java)
-                    .setAction(ChargeSessionService.ACTION_MONITOR),
-            )
-        }
+        ContextCompat.startForegroundService(
+            context,
+            Intent(context, ChargeSessionService::class.java)
+                .setAction(ChargeSessionService.ACTION_SET_PERSISTENT_POLICY)
+                .putExtra(ChargeSessionService.EXTRA_TARGET_POLICY, policy.stableId),
+        )
     }
 
     fun startFullCharge() {

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/QuickFullChargeGestureTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/QuickFullChargeGestureTest.kt
@@ -113,6 +113,20 @@ class QuickFullChargeGestureTest {
         charging(8_000) shouldBe QuickFullChargeDecision.TRIGGER
     }
 
+    // Characterization test: a carried basis is not bounded by the window it came from. It exists to
+    // stop a future "carry deadline" anchored to the original unplug from silently re-breaking the
+    // reported bug — such a deadline was proposed, and it would have made exactly this retry inert.
+    @Test
+    fun `a retry long after the original unplug still triggers`() {
+        atLimit(0) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(1_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        // A 500ms blip is rejected and hands the basis back to the plugged-period latch.
+        charging(1_500) shouldBe QuickFullChargeDecision.ARMED
+        // The deliberate retry comes 19s after the original unplug — far past the 10s ceiling.
+        disconnected(20_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        charging(25_000) shouldBe QuickFullChargeDecision.TRIGGER
+    }
+
     @Test
     fun `a carried limit-hold basis reports a non any-level basis`() {
         atLimit(0) shouldBe QuickFullChargeDecision.ARMED

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/QuickFullChargeGestureTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/QuickFullChargeGestureTest.kt
@@ -58,7 +58,7 @@ class QuickFullChargeGestureTest {
         // Debounce floor: exactly the minimum triggers, one millisecond less does not.
         atLimit(0)
         disconnected(1_000)
-        atLimit(1_000 + QuickFullChargeGesture.MIN_RECONNECT_MILLIS - 1) shouldBe QuickFullChargeDecision.ARMED
+        charging(1_000 + QuickFullChargeGesture.MIN_RECONNECT_MILLIS - 1) shouldBe QuickFullChargeDecision.ARMED
 
         gesture.reset()
         atLimit(0)
@@ -81,10 +81,144 @@ class QuickFullChargeGestureTest {
     fun `rejected fast blip immediately re-arms and a second attempt can trigger`() {
         atLimit(0) shouldBe QuickFullChargeDecision.ARMED
         disconnected(1_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
-        // A 500ms blip (car ignition) is rejected, but the replug observation itself re-arms.
-        atLimit(1_500) shouldBe QuickFullChargeDecision.ARMED
+        // A 500ms blip (car ignition) is rejected. The replug reading is the realistic one — a phone
+        // that just got power back reports CHARGING, never a settled hold — so re-arming can only
+        // come from the basis the window carried.
+        charging(1_500) shouldBe QuickFullChargeDecision.ARMED
         disconnected(2_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
-        atLimit(5_000) shouldBe QuickFullChargeDecision.TRIGGER
+        charging(5_000) shouldBe QuickFullChargeDecision.TRIGGER
+    }
+
+    @Test
+    fun `a too-late replug does not carry the basis`() {
+        atLimit(1_000) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(2_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        // 15s later: the window is spent and the replug reading cannot re-derive a hold.
+        charging(17_000) shouldBe QuickFullChargeDecision.IDLE
+        // Without a basis there is nothing to open a window with, so a well-timed retry stays inert.
+        disconnected(18_000) shouldBe QuickFullChargeDecision.IDLE
+        charging(21_000) shouldBe QuickFullChargeDecision.IDLE
+    }
+
+    @Test
+    fun `the carried basis survives repeated rejected attempts`() {
+        atLimit(0) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(1_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        charging(1_500) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(2_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        charging(2_500) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(3_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        charging(3_500) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(4_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        charging(8_000) shouldBe QuickFullChargeDecision.TRIGGER
+    }
+
+    @Test
+    fun `a carried limit-hold basis reports a non any-level basis`() {
+        atLimit(0) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(1_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        charging(1_500) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(2_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        val output = gesture.update(
+            input(
+                now = 5_000,
+                plugged = true,
+                batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+                chargingStatus = 1,
+            ),
+        )
+        output.decision shouldBe QuickFullChargeDecision.TRIGGER
+        output.anyLevelBasis shouldBe false
+    }
+
+    @Test
+    fun `a rejected blip does not resurrect a revoked any-level basis`() {
+        anyLevelCharging(1_000) shouldBe QuickFullChargeDecision.ARMED
+        anyLevelUnplugged(2_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        // Opt-out mid-window revokes the basis; the carry-over must not hand it back.
+        step(
+            now = 3_000,
+            plugged = false,
+            percent = 15,
+            batteryStatus = BatteryManager.BATTERY_STATUS_DISCHARGING,
+            chargingStatus = 0,
+            anyLevel = false,
+            evidence = PolicyEvidence.PROTECTIVE,
+        ) shouldBe QuickFullChargeDecision.IDLE
+        val output = gesture.update(
+            input(
+                now = 3_500,
+                plugged = true,
+                percent = 15,
+                batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+                chargingStatus = 1,
+                anyLevel = false,
+                evidence = PolicyEvidence.PROTECTIVE,
+            ),
+        )
+        output.decision shouldBe QuickFullChargeDecision.IDLE
+        output.anyLevelBasis shouldBe false
+    }
+
+    @Test
+    fun `reset clears a carried basis`() {
+        atLimit(0) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(1_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        charging(1_500) shouldBe QuickFullChargeDecision.ARMED
+        gesture.reset()
+        // Fresh start: no basis to open a window with, so the next attempt cannot trigger.
+        disconnected(2_000) shouldBe QuickFullChargeDecision.IDLE
+        charging(5_000) shouldBe QuickFullChargeDecision.IDLE
+    }
+
+    @Test
+    fun `a rejected blip keeps the limit-hold basis while any level also qualifies`() {
+        // Both bases qualify at once: the hardware hold wins the latch and must survive the blip,
+        // even though the replug tick alone would only support the any-level basis.
+        step(
+            now = 0,
+            plugged = true,
+            batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+            chargingStatus = QuickFullChargeGesture.CHARGING_STATUS_POLICY,
+            anyLevel = true,
+            evidence = PolicyEvidence.PROTECTIVE,
+        ) shouldBe QuickFullChargeDecision.ARMED
+        step(
+            now = 1_000,
+            plugged = false,
+            batteryStatus = BatteryManager.BATTERY_STATUS_DISCHARGING,
+            chargingStatus = 0,
+            anyLevel = true,
+            evidence = PolicyEvidence.UNKNOWN,
+        ) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        step(
+            now = 1_500,
+            plugged = true,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            chargingStatus = 1,
+            anyLevel = true,
+            evidence = PolicyEvidence.PROTECTIVE,
+        ) shouldBe QuickFullChargeDecision.ARMED
+        step(
+            now = 2_000,
+            plugged = false,
+            batteryStatus = BatteryManager.BATTERY_STATUS_DISCHARGING,
+            chargingStatus = 0,
+            anyLevel = true,
+            evidence = PolicyEvidence.UNKNOWN,
+        ) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        val output = gesture.update(
+            input(
+                now = 5_000,
+                plugged = true,
+                batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+                chargingStatus = 1,
+                anyLevel = true,
+                evidence = PolicyEvidence.PROTECTIVE,
+            ),
+        )
+        output.decision shouldBe QuickFullChargeDecision.TRIGGER
+        output.anyLevelBasis shouldBe false
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/QuickFullChargeGestureTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/QuickFullChargeGestureTest.kt
@@ -235,6 +235,82 @@ class QuickFullChargeGestureTest {
         output.anyLevelBasis shouldBe false
     }
 
+    // Defence in depth for a pre-existing gap: the steady-plugged branch never dropped a latched
+    // basis, so a limit removed in system settings left the gesture armed while the battery climbed
+    // out of the arming band.
+    @Test
+    fun `a limit-hold basis is retired once the battery leaves the arming band`() {
+        atLimit(1_000) shouldBe QuickFullChargeDecision.ARMED
+        step(
+            now = 2_000,
+            plugged = true,
+            percent = 92,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            chargingStatus = 1,
+        ) shouldBe QuickFullChargeDecision.IDLE
+        step(
+            now = 3_000,
+            plugged = true,
+            percent = 92,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            chargingStatus = 1,
+        ) shouldBe QuickFullChargeDecision.IDLE
+        // Without a basis a perfectly timed gesture stays inert.
+        disconnected(4_000) shouldBe QuickFullChargeDecision.IDLE
+        charging(7_000) shouldBe QuickFullChargeDecision.IDLE
+    }
+
+    @Test
+    fun `an out-of-band reading does not retire an any-level basis`() {
+        // The any-level basis is percent-independent by design — 15% is far outside the band.
+        anyLevelCharging(1_000) shouldBe QuickFullChargeDecision.ARMED
+        anyLevelCharging(2_000) shouldBe QuickFullChargeDecision.ARMED
+        anyLevelUnplugged(3_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        val output = gesture.update(
+            input(
+                now = 6_000,
+                plugged = true,
+                percent = 15,
+                batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+                chargingStatus = 1,
+                anyLevel = true,
+                evidence = PolicyEvidence.PROTECTIVE,
+            ),
+        )
+        output.decision shouldBe QuickFullChargeDecision.TRIGGER
+        output.anyLevelBasis shouldBe true
+    }
+
+    @Test
+    fun `an unreadable percent does not retire a limit-hold basis`() {
+        atLimit(1_000) shouldBe QuickFullChargeDecision.ARMED
+        // A failed sticky-broadcast read must not disarm a healthy gesture.
+        step(
+            now = 2_000,
+            plugged = true,
+            percent = -1,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            chargingStatus = 1,
+        ) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(3_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        charging(6_000) shouldBe QuickFullChargeDecision.TRIGGER
+    }
+
+    @Test
+    fun `an out-of-band reading cancels an open limit-hold window`() {
+        atLimit(1_000) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(2_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        // The retirement runs before the plug edges, so it reaches an already-open window too.
+        step(
+            now = 3_000,
+            plugged = false,
+            percent = 95,
+            batteryStatus = BatteryManager.BATTERY_STATUS_DISCHARGING,
+            chargingStatus = 0,
+        ) shouldBe QuickFullChargeDecision.IDLE
+        charging(5_000) shouldBe QuickFullChargeDecision.IDLE
+    }
+
     @Test
     fun `window expires while staying unplugged`() {
         atLimit(0)


### PR DESCRIPTION
## What changed

The reconnect gesture could get stuck. If you unplugged and replugged slightly outside the 2–10 second window, the gesture silently lost its arming — and because a reconnect window only opens while the gesture is armed, every further attempt did nothing. It stayed dead until the charge limit settled back in on its own, which is why repeated tries felt like the feature was broken. Turning on "any charge level" hid the problem, so that looked like the only way to make the gesture work at all.

A mistimed attempt now keeps the arming, so retrying works.

Two further changes:

- Applying a charge policy from the dashboard now takes the same path as the widget's buttons, which adds the safety checks the dashboard was missing.
- The gesture no longer stays armed once the battery moves outside the 75–90% range, so a charge limit removed in system settings can no longer leave it armed while the battery keeps charging.

## Technical Context

**Root cause.** `QuickFullChargeGesture` latched the arming basis but discarded it on every replug edge and re-derived it from the instantaneous reading. A physically replugged phone at 80% reports `BATTERY_STATUS_CHARGING` while it tops back up, so a limit-hold basis can never be re-derived at that instant. The unplug edge only opens a reconnect window when a basis is latched, which is what produced the dead-gesture state. The any-level basis needs only `plugged && PROTECTIVE` — both true at that same tick — which is why enabling it masked the bug.

**Why it was never caught.** `QuickFullChargeGestureTest` fed a settled-hold reading (`NOT_CHARGING` + charging state 4) as the *replug* tick, which is physically impossible. The project's `dumpsys battery unplug` recipe freezes reported state and reproduces the same impossible reading, so the defect was invisible to both unit tests and simulated device runs, and surfaced only with a real cable.

**Approach.** `armedBy` + `disconnectedAtMillis` are replaced by a sealed `State` (`Idle` / `Armed(basis)` / `AwaitingReconnect(basis, sinceMillis)`). Every prior transition is preserved; the only behavioural change is that a replug shorter than `minReconnectMillis` returns to `Armed` with the carried basis instead of re-deriving. No existing test assertion changed.

**Deliberate non-bound.** The carried basis intentionally holds no timestamp. A bounded variant — expiring it 10 s after the original unplug — was considered and rejected: a human retry after a failed attempt is frequently slower than 10 s, so that bound would re-break the reported bug for exactly the people who hit it. The test `a retry long after the original unplug still triggers` pins this so a future change cannot quietly reintroduce it.

**Out-of-band retirement.** A `percent` outside 75–90 now retires a `LIMIT_HOLD` basis. This addresses a **pre-existing** gap, not this bug — the steady-plugged branch has never dropped a latched basis, so a limit removed in system settings left the gesture armed as the battery climbed. It deliberately does not touch an any-level basis (percent-independent by design) and ignores `percent < 0`, so a single failed sticky-broadcast read cannot disarm a healthy gesture. It runs before the plug edges, so it also cancels an already-open window.

**Dashboard policy path.** `DashboardViewModel.applyPolicy` now sends `ACTION_SET_PERSISTENT_POLICY` instead of calling `repository.applyPersistent` directly. Beyond resetting the gesture engine, this gains the `canApply` refusal guard, a recovery target persisted before the write, settings-observer suppression, `reapplyPersistent`'s forced re-write, and failure surfacing. `ChargeSessionManager` became unused in the ViewModel and was dropped from its constructor.

**Review guidance.** The state-machine rewrite is the risk surface. Worth checking transition equivalence against the previous `armedBy`/`disconnectedAtMillis` pair — in particular the any-level revocation guard (`disconnectedAtMillis == null` became `state !is AwaitingReconnect`) and the `statusOutput` mapping.

**Verification.** On a Pixel 8 holding at its 80% limit: after a rejected sub-2 s blip the notification stays on the armed copy (the previous build fell back to the idle copy), the retry then starts a session, and disconnecting restores the limit. Forcing level 95 confirmed the out-of-band retirement, and it re-armed on reset. Unit suite: 1574 tests green across both flavours.
