### PR TITLE
General: Enable the devtools plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "enabledPlugins": {
     "debugbadger@claude-code-cafe": true,
-    "jvm-tools@claude-code-cafe": true
+    "jvm-tools@claude-code-cafe": true,
+    "devtools@claude-code-cafe": true
   }
 }


### PR DESCRIPTION
**What changed**

No user-facing behavior change. Repo tooling only: the `devtools@claude-code-cafe` plugin is added to the project's enabled AI-assistant plugins in `.claude/settings.json`, alongside the existing `debugbadger` and `jvm-tools` entries.

**Technical Context**

Config-only diff (one line). It has no effect on the app, the build, or CI behavior — it only affects which assistant plugins load for contributors working in this checkout. Full CI still runs because the ruleset requires all checks on every PR.