### PR TITLE
Dashboard: Offer the metadata-only device report only where it names something

### DIFF
--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -83,6 +83,38 @@ data class ChargingState(
             writeRequiresShizuku -> access?.shizuku?.ready == true
             else -> access?.canControl == true
         }
+
+    /**
+     * True when an adapter — live or lab — recognized this device's family, i.e. Amply knows *what* it is looking
+     * at even when it cannot control it. Derived from [adapterId] rather than carried separately: [AdapterRegistry]
+     * returns an adapter exactly when some probe matched, and its catch-all is the only null-adapter selection, so a
+     * mirrored flag could only ever drift.
+     */
+    val adapterMatched: Boolean get() = adapterId != null
+
+    /**
+     * Whether the unprivileged device metadata alone gives a maintainer somewhere to start, which is what makes it
+     * worth a public device-support issue. Two independent sources, because neither covers the other:
+     *
+     * - a matched adapter, including a lab one. Those match on manufacturer or ROM marker, so "Samsung, One UI
+     *   unreadable" still says the feature exists and names the skin whose key mapping to check.
+     * - a ROM marker or a protection key/provider the probes found directly. [AdapterRegistry]'s family matchers are
+     *   manufacturer lists and property checks, so a rebranded Oplus device or a LineageOS derivative that ships the
+     *   settings provider without the Lineage property lands in the catch-all while still carrying a real lead.
+     *
+     * False means every probe came back empty: the report can only state that none of the known families matched,
+     * which no maintainer can act on. Those devices are pointed at the contribution wizard, which can discover a key
+     * Amply does not know yet, or at email, where a dead end costs one reply instead of a public issue.
+     */
+    val hasSupportLead: Boolean
+        get() = adapterMatched ||
+            device.hasProtectBattery ||
+            device.hasLineageSettingsProvider ||
+            device.hasChargingOptimization ||
+            device.oneUiVersion != null ||
+            device.hyperOsVersion != null ||
+            device.oplusRomVersion != null ||
+            device.lineageOsVersion != null
 }
 
 @Singleton

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -296,6 +296,7 @@ fun DashboardScreen(
                             UnsupportedDeviceCard(
                                 manufacturer = state.charging.device.manufacturer
                                     .ifBlank { stringResource(R.string.dashboard_manufacturer_fallback) },
+                                hasSupportLead = state.charging.hasSupportLead,
                                 reportPreview = state.deviceReport?.let(::formatReport),
                                 onOpenWizard = onOpenContribution,
                                 onPrepareReport = onPrepareSupportReport,
@@ -1431,6 +1432,9 @@ private fun DashboardScreenUnsupportedPreview() = PreviewWrapper {
             charging = ChargingState(
                 device = DeviceInfo("Samsung", "SM-S911B", 34, "preview", hasChargingOptimization = false),
                 adapterName = "Diagnostics only".toCaString(),
+                // A Samsung on an unverified One UI: the lab adapter matched, so the metadata-only report
+                // names a family to check and the card offers it alongside the wizard.
+                adapterId = "samsung-lab",
                 controlEnabled = false,
                 contributionWanted = true,
                 observation = ChargeObservation.Unsupported("This device is not a supported Pixel".toCaString()),

--- a/app/src/main/java/eu/darken/amply/main/ui/setup/UnsupportedDeviceCard.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/setup/UnsupportedDeviceCard.kt
@@ -46,6 +46,14 @@ import eu.darken.amply.common.compose.PreviewWrapper
 fun UnsupportedDeviceCard(
     modifier: Modifier = Modifier,
     manufacturer: String,
+    /**
+     * Whether the device metadata alone gives a maintainer somewhere to start (see
+     * [eu.darken.amply.charging.core.ChargingState.hasSupportLead]). Only then is the metadata-only GitHub
+     * path offered — it is the one contribution route that needs no Shizuku, but a report naming no family,
+     * ROM marker or key is a public issue nobody can act on. Without a lead the card offers the wizard,
+     * which can still discover a key Amply does not know, and email.
+     */
+    hasSupportLead: Boolean,
     reportPreview: String?,
     onOpenWizard: () -> Unit,
     onPrepareReport: () -> Unit,
@@ -86,15 +94,18 @@ fun UnsupportedDeviceCard(
                 Modifier.padding(start = 8.dp),
             )
         }
-        // Secondary: send just the non-privileged device metadata (no Shizuku needed).
-        OutlinedButton(
-            onClick = {
-                onPrepareReport()
-                showDialog = true
-            },
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(stringResource(R.string.setup_unsupported_request_action))
+        // Secondary: send just the non-privileged device metadata (no Shizuku needed). Offered only where
+        // that metadata identifies something — see [hasSupportLead].
+        if (hasSupportLead) {
+            OutlinedButton(
+                onClick = {
+                    onPrepareReport()
+                    showDialog = true
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.setup_unsupported_request_action))
+            }
         }
 
         HorizontalDivider(Modifier.padding(vertical = 4.dp))
@@ -119,7 +130,9 @@ fun UnsupportedDeviceCard(
         }
     }
 
-    if (showDialog) {
+    // Also gated, not just its launcher: a lead that disappears under an open dialog must take the
+    // confirmation with it rather than leaving an Open-GitHub button behind.
+    if (showDialog && hasSupportLead) {
         AlertDialog(
             onDismissRequest = { showDialog = false },
             title = { Text(stringResource(R.string.setup_unsupported_dialog_title)) },
@@ -174,7 +187,26 @@ private fun UnsupportedDeviceCardPreview() = PreviewWrapper {
     UnsupportedDeviceCard(
         modifier = Modifier.padding(16.dp),
         manufacturer = "Samsung",
+        hasSupportLead = true,
         reportPreview = PREVIEW_REPORT,
+        onOpenWizard = {},
+        onPrepareReport = {},
+        onCopyReport = {},
+        onOpenIssue = {},
+        onEmail = {},
+        onHelp = {},
+    )
+}
+
+/** A device whose metadata carries no lead at all: the metadata-only GitHub path is not offered. */
+@AmplyPreview
+@Composable
+private fun UnsupportedDeviceCardNoLeadPreview() = PreviewWrapper {
+    UnsupportedDeviceCard(
+        modifier = Modifier.padding(16.dp),
+        manufacturer = "BLU",
+        hasSupportLead = false,
+        reportPreview = null,
         onOpenWizard = {},
         onPrepareReport = {},
         onCopyReport = {},

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingStateSupportLeadTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingStateSupportLeadTest.kt
@@ -1,0 +1,73 @@
+package eu.darken.amply.charging.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * The predicate deciding whether unprivileged device metadata is worth a public device-support issue. It must stay
+ * wider than "an adapter matched": the family matchers are manufacturer lists and property checks, so a device can
+ * carry a real lead and still land in the registry's catch-all.
+ */
+class ChargingStateSupportLeadTest {
+
+    private fun device(
+        manufacturer: String = "BLU",
+        hasChargingOptimization: Boolean = false,
+        oneUiVersion: Int? = null,
+        hyperOsVersion: Int? = null,
+        oplusRomVersion: Int? = null,
+        lineageOsVersion: String? = null,
+        hasProtectBattery: Boolean = false,
+        hasLineageSettingsProvider: Boolean = false,
+    ) = DeviceInfo(
+        manufacturer = manufacturer,
+        model = "B1660V",
+        sdk = 35,
+        fingerprint = "test",
+        hasChargingOptimization = hasChargingOptimization,
+        oneUiVersion = oneUiVersion,
+        hyperOsVersion = hyperOsVersion,
+        oplusRomVersion = oplusRomVersion,
+        lineageOsVersion = lineageOsVersion,
+        hasProtectBattery = hasProtectBattery,
+        hasLineageSettingsProvider = hasLineageSettingsProvider,
+    )
+
+    @Test
+    fun `a device whose every probe came back empty has no lead`() {
+        // The BLU B1660V of issue #42: stock Android, no marker, no key, no adapter.
+        ChargingState(device = device(), adapterId = null).hasSupportLead shouldBe false
+    }
+
+    @Test
+    fun `a matched adapter is a lead even when no marker was readable`() {
+        // Samsung whose One UI version won't parse: the lab adapter still names the skin to check.
+        ChargingState(device = device(manufacturer = "samsung"), adapterId = "samsung-lab")
+            .hasSupportLead shouldBe true
+    }
+
+    @Test
+    fun `adapterMatched follows the selected adapter`() {
+        ChargingState(adapterId = "xiaomi-lab").adapterMatched shouldBe true
+        ChargingState(adapterId = null).adapterMatched shouldBe false
+    }
+
+    @Test
+    fun `a ROM marker is a lead even when no adapter matched`() {
+        // Rebranded Oplus-family hardware: the ROM property is read globally, the matcher is a
+        // manufacturer list, so this combination reaches the registry's catch-all.
+        ChargingState(device = device(oplusRomVersion = 16), adapterId = null).hasSupportLead shouldBe true
+        ChargingState(device = device(oneUiVersion = 9), adapterId = null).hasSupportLead shouldBe true
+        ChargingState(device = device(hyperOsVersion = 3), adapterId = null).hasSupportLead shouldBe true
+        ChargingState(device = device(lineageOsVersion = "23.0"), adapterId = null).hasSupportLead shouldBe true
+    }
+
+    @Test
+    fun `a present protection key or provider is a lead even when no adapter matched`() {
+        // A LineageOS derivative that ships the settings provider without the Lineage build property.
+        ChargingState(device = device(hasLineageSettingsProvider = true), adapterId = null)
+            .hasSupportLead shouldBe true
+        ChargingState(device = device(hasProtectBattery = true), adapterId = null).hasSupportLead shouldBe true
+        ChargingState(device = device(hasChargingOptimization = true), adapterId = null).hasSupportLead shouldBe true
+    }
+}

--- a/app/src/test/java/eu/darken/amply/main/ui/setup/UnsupportedDeviceCardTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/setup/UnsupportedDeviceCardTest.kt
@@ -1,0 +1,104 @@
+package eu.darken.amply.main.ui.setup
+
+import android.app.Application
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.R
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Guards which contribution paths an unsupported device is offered. The metadata-only GitHub path is worth a public
+ * issue only where the metadata names something to chase; for a device whose every probe came back empty it would
+ * name no family, marker or key at all.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class UnsupportedDeviceCardTest {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    private fun string(res: Int): String =
+        ApplicationProvider.getApplicationContext<Application>().getString(res)
+
+    private fun render(
+        hasSupportLead: Boolean,
+        reportPreview: String? = "manufacturer=samsung\nadapter=samsung-lab",
+        onPrepareReport: () -> Unit = {},
+    ) {
+        compose.setContent {
+            Column(Modifier.verticalScroll(rememberScrollState())) {
+                UnsupportedDeviceCard(
+                    manufacturer = "Samsung",
+                    hasSupportLead = hasSupportLead,
+                    reportPreview = reportPreview,
+                    onOpenWizard = {},
+                    onPrepareReport = onPrepareReport,
+                    onCopyReport = {},
+                    onOpenIssue = {},
+                    onEmail = {},
+                    onHelp = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a device with a lead is offered the metadata-only report`() {
+        render(hasSupportLead = true)
+
+        compose.onNodeWithText(string(R.string.setup_unsupported_request_action)).assertExists()
+    }
+
+    @Test
+    fun `a device without a lead is not offered the metadata-only report`() {
+        render(hasSupportLead = false)
+
+        compose.onNodeWithText(string(R.string.setup_unsupported_request_action)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the wizard and email paths stay available without a lead`() {
+        render(hasSupportLead = false)
+
+        compose.onNodeWithText(string(R.string.setup_unsupported_wizard_action)).assertExists()
+        compose.onNodeWithText(string(R.string.setup_unsupported_email_action)).assertExists()
+    }
+
+    @Test
+    fun `opening the metadata path requests the report and confirms first`() {
+        var prepared = false
+        render(hasSupportLead = true, onPrepareReport = { prepared = true })
+
+        compose.onNodeWithText(string(R.string.setup_unsupported_request_action)).performClick()
+
+        prepared shouldBe true
+        // Confirmation, not a direct hand-off: nothing reaches GitHub until the user sees the exact report.
+        compose.onNodeWithText(string(R.string.setup_unsupported_dialog_title)).assertExists()
+        compose.onNodeWithText(string(R.string.setup_unsupported_dialog_open)).assertIsEnabled()
+    }
+
+    @Test
+    fun `the confirmation cannot be accepted until the report snapshot has arrived`() {
+        // Collection is async: until it lands, what GitHub would receive isn't the previewed text yet.
+        render(hasSupportLead = true, reportPreview = null)
+
+        compose.onNodeWithText(string(R.string.setup_unsupported_request_action)).performClick()
+
+        compose.onNodeWithText(string(R.string.setup_unsupported_dialog_open)).assertIsNotEnabled()
+        compose.onNodeWithText(string(R.string.setup_unsupported_dialog_copy)).assertIsNotEnabled()
+    }
+}


### PR DESCRIPTION
## What changed

The unsupported-device card offered two ways to contribute: the guided wizard, and a "Just send device info" button that opens a prefilled public issue with the device's non-privileged details and needs no Shizuku.

That second button is now shown only when those details actually name something — a known manufacturer family, a ROM marker, or a battery-protection setting the app could see. On a phone where none of that is present, the report would say nothing beyond "this isn't one of the families I know", which can't be acted on, so the card offers the guided wizard (which can still discover a setting the app doesn't know yet) and email instead.

Closes the gap behind #42.

## Technical Context

**Why this path was open.** #36 gated the *wizard's* delivery on a report carrying at least one setting. Issue #42 came from the other entry point — `UnsupportedDeviceCard`'s secondary button → `DeviceSupportReporter` → prefilled `issues/new` URL — which is metadata-only by design and had no such gate. `AdapterRegistry.select()`'s catch-all sets `contributionWanted = true` for *any* unmatched device, so the card appears identically for a Samsung on an unverified One UI (report is actionable) and for stock-Android hardware with no protection feature at all (report is not).

**Why the predicate is wider than `matched`.** The first cut gated on the adapter having matched. That both under- and over-shoots: lab adapters match on manufacturer or a single ROM property, so a rebranded Oplus device with `oplusRomVersion` set, or a LineageOS derivative that ships the `lineagesettings` provider without `ro.lineage.build.version`, lands in the catch-all while still carrying a real lead. `ChargingState.hasSupportLead` therefore ORs the matched adapter with the marker/key probes themselves. Its truth table is pinned in `ChargingStateSupportLeadTest`.

**No new state field.** `adapterMatched` is a computed `adapterId != null` rather than a value mirrored from `AdapterSupport.matched` — the registry returns an adapter exactly when a probe matched and its catch-all is the only null-adapter selection, so a carried flag could only drift. The unsupported dashboard preview gains the `adapterId` that its `contributionWanted = true` always implied.

**Unchanged:** the report format and `DeviceSupportReporter` itself, the wizard, the email path (a non-actionable report there costs one private reply, not a permanent public issue), and per-row disclosure.

**Review guidance:** the interesting file is `ChargingRepository.kt` (the predicate + its rationale); the Compose change is a visibility gate on the button and its dialog.

## Verification

`testFossDebugUnitTest` (797 pass, incl. 10 new across the two suites), `assembleGplayDebug`, `lintVitalFossRelease` — all green locally. Reviewed by Codex; its findings on the predicate's width, the ungated dialog, the redundant state field, and an overclaiming KDoc are folded into this commit. Not device-tested: the change is UI visibility driven by pure state, covered by the Robolectric card tests.