### PR TITLE
FullCharge: Arm the reconnect gesture at the limit without waiting for the battery status

### DIFF
--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -378,6 +378,10 @@ class ChargeSessionService : Service() {
         } else {
             PolicyEvidence.UNKNOWN
         }
+        // Verified readback only, deliberately not GestureBasis.evidence()'s journal fallback: this
+        // feeds the *default* limit-hold basis, which must never arm off a limit Amply merely
+        // remembers writing. The same value names the limit in the notification below.
+        val verifiedLimitPercent = GestureBasis.limitPercent(hardware)
         val output = quickGesture.update(
             QuickFullChargeGesture.Input(
                 nowMillis = observedAtElapsed,
@@ -387,6 +391,7 @@ class ChargeSessionService : Service() {
                 chargingStatus = chargingStatus,
                 anyLevelEnabled = anyLevel,
                 policyEvidence = policyEvidence,
+                verifiedLimitPercent = verifiedLimitPercent,
             ),
         )
         val decision = output.decision
@@ -438,7 +443,7 @@ class ChargeSessionService : Service() {
                     // Verified evidence only, never Amply's write journal: naming a number is a
                     // user-facing claim, and a limit removed natively must not keep being claimed.
                     // Unverified state falls back to the generic "charge limit is holding" copy.
-                    limitPercent = GestureBasis.limitPercent(hardware),
+                    limitPercent = verifiedLimitPercent,
                 ),
             )
             // Expiry isn't broadcast-driven: without a nudge the "reconnect now" copy could linger

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/GestureBasis.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/GestureBasis.kt
@@ -60,6 +60,11 @@ object GestureBasis {
      * one. Only a verified observation answers: the journal records Amply's last write, not the
      * current configuration, so falling through to it would keep claiming "your 80 % limit" after
      * the user removed that limit natively.
+     *
+     * This is also the limit-hold gesture's *settled at the limit* arming input
+     * (`QuickFullChargeGesture.Input.verifiedLimitPercent`), which is why the no-journal rule is
+     * load-bearing beyond copy: [evidence]'s journal fallback would arm the default basis off a
+     * limit Amply merely remembers writing. Keep this function journal-free.
      */
     fun limitPercent(hardware: ChargeObservation?): Int? =
         (hardware as? ChargeObservation.Verified)?.policy?.limitPercentOrNull()

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/QuickFullChargeGesture.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/QuickFullChargeGesture.kt
@@ -30,8 +30,23 @@ enum class PolicyEvidence { PROTECTIVE, UNRESTRICTED, UNKNOWN }
  * the original unplug still triggers`).
  *
  * Two arming bases exist:
- * - Limit hold (default): Android's charging-policy hardware state reports the Pixel policy actively
- *   holding near its limit. Only the hardware signal is trusted, never Amply's cached request.
+ * - Limit hold (default): the charge limit is established as active by either of two paths, both
+ *   requiring Android's charging-policy hardware state, never Amply's cached request. *Held* adds a
+ *   battery status other than `CHARGING`. *Settled at the limit* instead requires that the battery
+ *   has already reached the verified limit ([Input.verifiedLimitPercent]), and deliberately does
+ *   **not** wait for the battery status. That wait is the problem it exists to solve: for the
+ *   ~10–12 s the Pixel HAL takes to act on a freshly written limit the phone is physically topping
+ *   back up and reports `CHARGING`, so every path that writes the limit while already in the arming
+ *   band — a session restore, boot recovery, the widget's persistent-policy buttons — left the
+ *   gesture unable to arm at all, and an unplug in that window opened no reconnect window. Neither
+ *   path subsumes the other: ordinary drift to 79 % under an 80 % limit is *held* but not *settled*,
+ *   and the window after a write is *settled* but not *held*. Reaching the limit is what carries the
+ *   intent the dropped battery status used to carry — it separates sitting at the limit from
+ *   climbing through the band, so a replug at 76 % under an 80 % limit still arms nothing.
+ *   Accepting `CHARGING` is what makes the steady-plugged drop below load-bearing, because the
+ *   hardware state lags a policy change in both directions. Since both paths require the
+ *   charging-policy state, a policy that reports a *different* hardware state — Pixel's adaptive
+ *   charging — never arms this basis at all; the any-level basis is the only one that covers it.
  * - Any level (opt-in): the user enabled the any-level option and the current charge configuration
  *   is conclusively protective ([PolicyEvidence.PROTECTIVE]); percent, battery status, and the
  *   hardware hold are deliberately ignored. This basis is revoked — including an already-open
@@ -84,6 +99,12 @@ class QuickFullChargeGesture(
         val chargingStatus: Int,
         val anyLevelEnabled: Boolean,
         val policyEvidence: PolicyEvidence,
+        /**
+         * Percent of a *verified* active fixed limit, null when nothing verified names one. Must come
+         * from the live hardware/settings readback only — never from Amply's write journal, which
+         * still reports a limit the user has since removed natively.
+         */
+        val verifiedLimitPercent: Int? = null,
     )
 
     data class Output(
@@ -111,10 +132,21 @@ class QuickFullChargeGesture(
     private var state: State = State.Idle
 
     fun update(input: Input): Output {
-        val heldAtLimit = input.plugged &&
-            input.chargingStatus == CHARGING_STATUS_POLICY &&
+        val inArmingBand = input.percent in MIN_ARM_PERCENT..MAX_ARM_PERCENT
+        val policyActive = input.plugged && input.chargingStatus == CHARGING_STATUS_POLICY
+        // Anything but CHARGING — NOT_CHARGING at a settled hold, but also FULL/DISCHARGING/UNKNOWN,
+        // all of which equally mean the battery is not being driven up right now.
+        val heldAtLimit = policyActive &&
             input.batteryStatus != BatteryManager.BATTERY_STATUS_CHARGING &&
-            input.percent in MIN_ARM_PERCENT..MAX_ARM_PERCENT
+            inArmingBand
+        // The battery already reached the verified limit, so the limit is established without
+        // waiting out the HAL transition that keeps the battery status at CHARGING right after a
+        // write. Reaching the limit is what the dropped battery status is traded for.
+        val settledAtLimit = policyActive &&
+            inArmingBand &&
+            input.verifiedLimitPercent != null &&
+            input.percent >= input.verifiedLimitPercent
+        val limitBasis = heldAtLimit || settledAtLimit
         val anyLevelHeld = input.anyLevelEnabled &&
             input.plugged &&
             input.policyEvidence == PolicyEvidence.PROTECTIVE
@@ -154,7 +186,7 @@ class QuickFullChargeGesture(
         previousPlugged = input.plugged
 
         if (previous == null) {
-            state = armFrom(heldAtLimit, anyLevelHeld)
+            state = armFrom(limitBasis, anyLevelHeld)
             return statusOutput(input)
         }
 
@@ -186,20 +218,35 @@ class QuickFullChargeGesture(
                     // Too late: the window is spent, but the fresh plugged state may already
                     // qualify again — re-arm immediately instead of waiting for another broadcast.
                     else -> {
-                        state = armFrom(heldAtLimit, anyLevelHeld)
+                        state = armFrom(limitBasis, anyLevelHeld)
                         statusOutput(input)
                     }
                 }
             }
-            state = armFrom(heldAtLimit, anyLevelHeld)
+            state = armFrom(limitBasis, anyLevelHeld)
             return statusOutput(input)
         }
 
         if (input.plugged) {
             when {
                 // Latch the hold: at the later unplug tick the hardware evidence is already gone.
-                heldAtLimit -> state = State.Armed(ArmedBy.LIMIT_HOLD)
+                limitBasis -> state = State.Armed(ArmedBy.LIMIT_HOLD)
                 state is State.Idle && anyLevelHeld -> state = State.Armed(ArmedBy.ANY_LEVEL)
+                // Positive proof the limit is not holding: current is flowing while the hardware
+                // reports no charging policy at all. Required because the settled path accepts a
+                // `CHARGING` reading, and the hardware state lags a policy change in *both*
+                // directions — leaving an 80% limit at 80% briefly still reports state 4, which
+                // would otherwise latch a limit hold that no longer exists and survive (this
+                // branch has never dropped a latch) until the battery left the band. Confined to
+                // the steady-plugged branch on purpose: a replug tick legitimately reads
+                // `CHARGING` with no policy state yet, and dropping there would destroy exactly
+                // the carried basis the reconnect window exists to preserve.
+                // An unreadable percent (`< 0`) marks the whole reading as a failed sticky-broadcast
+                // read, so its charging status is no proof of anything either.
+                state.armingBasis == ArmedBy.LIMIT_HOLD &&
+                    input.percent >= 0 &&
+                    input.batteryStatus == BatteryManager.BATTERY_STATUS_CHARGING &&
+                    !policyActive -> state = State.Idle
             }
         } else {
             val awaiting = state as? State.AwaitingReconnect
@@ -215,8 +262,8 @@ class QuickFullChargeGesture(
         state = State.Idle
     }
 
-    private fun armFrom(heldAtLimit: Boolean, anyLevelHeld: Boolean): State = when {
-        heldAtLimit -> State.Armed(ArmedBy.LIMIT_HOLD)
+    private fun armFrom(limitBasis: Boolean, anyLevelHeld: Boolean): State = when {
+        limitBasis -> State.Armed(ArmedBy.LIMIT_HOLD)
         anyLevelHeld -> State.Armed(ArmedBy.ANY_LEVEL)
         else -> State.Idle
     }

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/QuickFullChargeGestureTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/QuickFullChargeGestureTest.kt
@@ -54,6 +54,121 @@ class QuickFullChargeGestureTest {
     }
 
     @Test
+    fun `reconnect right after the limit is written triggers before the battery status settles`() {
+        // The regression: a restore re-applies the limit, the phone tops back up and still reports
+        // CHARGING for the ~10s HAL transition. Reaching the verified limit arms regardless.
+        freshlyLimited(1_000) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(2_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        charging(5_000) shouldBe QuickFullChargeDecision.TRIGGER
+    }
+
+    @Test
+    fun `climbing through the arming band below the limit does not arm`() {
+        freshlyLimited(1_000, percent = 76) shouldBe QuickFullChargeDecision.IDLE
+        step(
+            now = 2_000,
+            plugged = false,
+            percent = 76,
+            batteryStatus = BatteryManager.BATTERY_STATUS_DISCHARGING,
+        ) shouldBe QuickFullChargeDecision.IDLE
+        freshlyLimited(5_000, percent = 76) shouldBe QuickFullChargeDecision.IDLE
+    }
+
+    @Test
+    fun `reaching the limit above the arming band does not arm`() {
+        freshlyLimited(1_000, percent = 95) shouldBe QuickFullChargeDecision.IDLE
+    }
+
+    @Test
+    fun `an unverified limit does not arm while the battery is still charging`() {
+        step(
+            now = 1_000,
+            plugged = true,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            chargingStatus = QuickFullChargeGesture.CHARGING_STATUS_POLICY,
+            verifiedLimit = null,
+        ) shouldBe QuickFullChargeDecision.IDLE
+    }
+
+    @Test
+    fun `an adaptive policy never arms the limit-hold basis`() {
+        // Adaptive reports hardware state 5, and both limit-hold paths require state 4 — so it
+        // arms through neither, whatever the battery status says.
+        step(
+            now = 1_000,
+            plugged = true,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            chargingStatus = 5,
+            verifiedLimit = null,
+        ) shouldBe QuickFullChargeDecision.IDLE
+        step(
+            now = 2_000,
+            plugged = true,
+            batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+            chargingStatus = 5,
+            verifiedLimit = null,
+        ) shouldBe QuickFullChargeDecision.IDLE
+    }
+
+    @Test
+    fun `a stale policy state while leaving the limit does not leave the gesture armed`() {
+        // The hardware state lags a policy change in both directions, so switching away from the
+        // limit at 80% is briefly indistinguishable from having just written it. Once current
+        // flows with no policy state, the latch must go — it used to survive until the battery
+        // left the 75-90% band, so a replug during the climb started an unwanted full charge.
+        freshlyLimited(1_000) shouldBe QuickFullChargeDecision.ARMED
+        step(
+            now = 4_000,
+            plugged = true,
+            percent = 82,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            chargingStatus = 5,
+        ) shouldBe QuickFullChargeDecision.IDLE
+        step(
+            now = 6_000,
+            plugged = false,
+            percent = 82,
+            batteryStatus = BatteryManager.BATTERY_STATUS_DISCHARGING,
+        ) shouldBe QuickFullChargeDecision.IDLE
+        step(
+            now = 9_000,
+            plugged = true,
+            percent = 82,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            chargingStatus = 5,
+        ) shouldBe QuickFullChargeDecision.IDLE
+    }
+
+    @Test
+    fun `a replug still reconstructs the carried basis despite no policy state yet`() {
+        // The drop above must not reach the reconnect path: a replugged phone legitimately reads
+        // CHARGING with the policy state not yet re-reported, which is precisely why the basis is
+        // carried across the gap rather than re-derived.
+        atLimit(1_000) shouldBe QuickFullChargeDecision.ARMED
+        disconnected(2_000) shouldBe QuickFullChargeDecision.WAITING_FOR_RECONNECT
+        step(
+            now = 5_000,
+            plugged = true,
+            batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+            chargingStatus = 1,
+        ) shouldBe QuickFullChargeDecision.TRIGGER
+    }
+
+    @Test
+    fun `drift below the limit still arms through the settled hold`() {
+        // 79% under an 80% limit is not "at the limit", but current is visibly cut — the original
+        // path must keep arming on its own.
+        step(
+            now = 1_000,
+            plugged = true,
+            percent = 79,
+            batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+            chargingStatus = QuickFullChargeGesture.CHARGING_STATUS_POLICY,
+            verifiedLimit = 80,
+        ) shouldBe QuickFullChargeDecision.ARMED
+    }
+
+    @Test
     fun `reconnect window boundaries`() {
         // Debounce floor: exactly the minimum triggers, one millisecond less does not.
         atLimit(0)
@@ -670,6 +785,7 @@ class QuickFullChargeGestureTest {
         chargingStatus: Int = 0,
         anyLevel: Boolean = false,
         evidence: PolicyEvidence = PolicyEvidence.UNKNOWN,
+        verifiedLimit: Int? = null,
     ) = QuickFullChargeGesture.Input(
         nowMillis = now,
         plugged = plugged,
@@ -678,6 +794,7 @@ class QuickFullChargeGestureTest {
         chargingStatus = chargingStatus,
         anyLevelEnabled = anyLevel,
         policyEvidence = evidence,
+        verifiedLimitPercent = verifiedLimit,
     )
 
     private fun step(
@@ -688,15 +805,31 @@ class QuickFullChargeGestureTest {
         chargingStatus: Int = 0,
         anyLevel: Boolean = false,
         evidence: PolicyEvidence = PolicyEvidence.UNKNOWN,
+        verifiedLimit: Int? = null,
     ) = gesture.update(
-        input(now, plugged, percent, batteryStatus, chargingStatus, anyLevel, evidence),
+        input(now, plugged, percent, batteryStatus, chargingStatus, anyLevel, evidence, verifiedLimit),
     ).decision
 
+    /** The settled hold: policy state 4 with current already cut. Mirrors what the Pixel adapter supplies. */
     private fun atLimit(now: Long) = step(
         now = now,
         plugged = true,
         batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
         chargingStatus = QuickFullChargeGesture.CHARGING_STATUS_POLICY,
+        verifiedLimit = 80,
+    )
+
+    /**
+     * The window right after the limit is written: policy state 4 is already reported while the
+     * phone is still topping back up, so the battery status has not settled yet.
+     */
+    private fun freshlyLimited(now: Long, percent: Int = 80) = step(
+        now = now,
+        plugged = true,
+        percent = percent,
+        batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+        chargingStatus = QuickFullChargeGesture.CHARGING_STATUS_POLICY,
+        verifiedLimit = 80,
     )
 
     private fun charging(now: Long) = step(


### PR DESCRIPTION
## What changed

The reconnect gesture no longer goes blind for ~10 seconds after your charge limit is written.

Previously, tapping **Restore now** and then immediately performing the gesture again did nothing — the phone is physically topping back up right after the limit is re-applied, and the gesture waited for charging to visibly stop before it would arm. On a Pixel 9 Pro that wait was ~10.5 seconds, which reads as the gesture simply being broken.

The gesture now arms as soon as the hardware confirms the limit is active and the battery has reached it. Re-arming after a restore is effectively immediate.

This affected every path that writes the limit while the battery is already near it — restoring a session, boot recovery, and the widget's persistent-policy buttons — not just "Restore now".

Unchanged: an accidental unplug/replug while the battery is still climbing below your limit still does nothing.

## Technical Context

**Root cause.** `QuickFullChargeGesture` armed only when `plugged`, `chargingStatus == 4`, `batteryStatus != CHARGING` and `percent in 75..90` held simultaneously. After a limit write the battery status stays `CHARGING` for the ~10–12 s Pixel HAL transition, so nothing armed; the unplug edge then went to `Idle` instead of `AwaitingReconnect` and the replug had no window to consume.

From the reported logcat:

```
13:49:07.937  restore applied fixed:80
13:49:07.983  plugged=true percent=80 chargingStatus=4 batteryStatus=2  → IDLE
13:49:10.063  unplug (~2.1s after restore)                              → IDLE
13:49:13.091  replug                                                    → IDLE   (no trigger)
```

**Fix.** A second arming path for the same `LIMIT_HOLD` basis: policy state reported, percent in band, and `percent >= verifiedLimitPercent`. Reaching the verified limit is what replaces the dropped battery-status check — it is what distinguishes *sitting at the limit* from *climbing through the band*. Both paths are kept; neither subsumes the other (drift to 79 % under an 80 % limit is *held* but not *settled*; the window after a write is *settled* but not *held*).

**Why not `GestureBasis.evidence()`.** It falls back to `lastPersistentPolicy` when the hardware reading is inconclusive, which would arm the *default* basis off a limit Amply merely remembers writing — the class of bug #28 fixed for the opt-in any-level basis. `GestureBasis.limitPercent()` has no journal fallback by construction; its KDoc now records that it is an arming input, not just notification copy.

**The counterweight (review focus).** Accepting a `CHARGING` reading is not free: the hardware state lags a policy change in *both* directions. Switching away from an 80 % limit at 80 % briefly still reports the old policy state, which would latch a hold that no longer exists — and the steady-plugged branch has never dropped a latch, so it survived until the battery left the 75–90 % band. `setPersistentPolicy()` resets the gesture and immediately re-evaluates against exactly that stale reading. The steady-plugged branch now retires a limit-hold basis on positive proof: current flowing while no policy state is reported, from a readable broadcast.

Two guards on that rule, both load-bearing:
- **Steady-plugged only.** A replug legitimately reads `CHARGING` before the policy state is re-reported; dropping there would destroy the carried basis the reconnect window exists to preserve.
- **`percent >= 0`.** An unreadable percent marks the whole broadcast read as failed, so its charging status proves nothing either. Caught by the pre-existing `an unreadable percent does not retire a limit-hold basis` test.

**Verification.** 795 unit tests pass on both flavors; the gesture suite went 43 → 45 cases, covering the logged regression, the climbing case, out-of-band, unverified limit, adaptive, drift, the stale-policy-state transition, and the replug carry-over.

Device-verified on two devices.

**Pixel 9 Pro** (caiman, Android 16) — the reported scenario end to end:

```
16:38:13.270  replug                     → TRIGGER   session 1
16:38:15.987  RESTORE_CHARGE_LIMIT
16:38:16.095  batteryStatus=2 chStatus=4 → ARMED     (108ms, was ~10.5s)
16:38:19.353  unplug                     → WAITING_FOR_RECONNECT
16:38:23.093  replug                     → TRIGGER   session 2
```

The negative case was checked with a simulated level: from a cleared latch, 76 % still charging under an 80 % limit stays `IDLE`.

**Pixel 8** (shiba, Android 17 / API 37) — covers the drop rule, which the 9 Pro run predates. Switching the persistent policy to Adaptive reproduced the whole mechanism on hardware:

```
18:41:46.763  Applied adaptive (persistent)
18:41:57.350  batteryStatus=4 chStatus=1 → ARMED   stale latch, no current yet: correctly kept
18:42:08.488  batteryStatus=2 chStatus=1 → IDLE    current flows, no policy state: latch dropped
```

Without the rule that latch would have survived until the battery left the 75–90 % band. The basic gesture still triggers normally there (unplug → replug at Δ3.58 s → `TRIGGER`), and after a restore the gesture stayed armed for over a minute while `batteryStatus` was still `CHARGING` — armed solely via the new path.

Which of the two signals lags varies per transition rather than per device: when the battery status settles first, the settled path gives no advantage, because the verified limit percent is itself derived from the policy state. The fix removes the wait whenever the policy state arrives first, and never arms on anything weaker.
