### PR TITLE
Shrink issue screenshots into clickable thumbnails

### DIFF
--- a/.github/workflows/thumbnail-images.yml
+++ b/.github/workflows/thumbnail-images.yml
@@ -1,0 +1,26 @@
+name: Thumbnail images
+
+# Shrinks oversized screenshots in issues and comments into clickable
+# thumbnails. The logic lives in d4rken-org/.github so every app repo shares
+# one copy; this stub only supplies the triggers, because workflow_call cannot
+# be triggered by issue_comment directly.
+#
+# The shared workflow splits into an unprivileged parsing job and a privileged
+# job that only makes the API call, so issues:write below is the ceiling, not
+# what the parsing half receives.
+#
+# Add <!-- no-thumbnail --> to a body to opt it out.
+
+on:
+  issue_comment:
+    types: [created, edited]
+  issues:
+    types: [opened, edited]
+
+permissions: {}
+
+jobs:
+  thumbnail:
+    permissions:
+      issues: write
+    uses: d4rken-org/.github/.github/workflows/thumbnail-images.yml@94e36d9a67a887e24338f95fd0429925cea21c98


### PR DESCRIPTION
## What changed

Screenshots attached to GitHub issues and comments get shrunk into small clickable thumbnails, instead of filling the whole thread at full size. Covers both Markdown-style images and the HTML image tags GitHub's uploader emits today.

## Technical Context

- Adds the small trigger stub for the shared thumbnail workflow in `d4rken-org/.github` (the same setup already live in sdmaid-se, capod, permission-pilot, octi, bluemusic and airplanes-live-app), pinned at `94e36d9`.
- The workflow splits privilege: the half that parses attacker-controlled text runs with zero token scopes; only a parse-free apply job holds `issues: write`. HTML tags carry their dimensions, so they trigger no outbound requests.
- `<!-- no-thumbnail -->` in a body opts it out.
