### PR TITLE
General: Enable the support-investigator plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "enabledPlugins": {
     "debugbadger@claude-code-cafe": true,
     "jvm-tools@claude-code-cafe": true,
-    "devtools@claude-code-cafe": true
+    "devtools@claude-code-cafe": true,
+    "support-investigator@claude-code-cafe": true
   }
 }


### PR DESCRIPTION
## What changed

No user-facing behavior change. Adds the `support-investigator` plugin to the checked-in enabled-plugins list in `.claude/settings.json`, alongside the existing entries.

## Technical Context

- The plugin backs the support-mail investigation workflow (`/support-investigator:investigate`); enabling it in project settings makes it active for future agent sessions in this repo.