### PR TITLE
Dashboard: Show charging speed and wattage in more places

### DIFF
--- a/app/src/main/java/eu/darken/amply/battery/core/BatteryReader.kt
+++ b/app/src/main/java/eu/darken/amply/battery/core/BatteryReader.kt
@@ -51,6 +51,8 @@ class BatteryReader @Inject constructor(
             currentNowMicroamps = manager.propertyOrAbsent(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW),
             chargeCounterMicroampHours = manager.propertyOrAbsent(BatteryManager.BATTERY_PROPERTY_CHARGE_COUNTER),
             cycleCount = cycleCount(battery),
+            maxChargingCurrentMicroamps = battery.getIntExtra(BatteryManager.EXTRA_MAX_CHARGING_CURRENT, ABSENT),
+            maxChargingVoltageMicrovolts = battery.getIntExtra(BatteryManager.EXTRA_MAX_CHARGING_VOLTAGE, ABSENT),
         )
     }
 

--- a/app/src/main/java/eu/darken/amply/battery/core/BatteryReader.kt
+++ b/app/src/main/java/eu/darken/amply/battery/core/BatteryReader.kt
@@ -51,8 +51,8 @@ class BatteryReader @Inject constructor(
             currentNowMicroamps = manager.propertyOrAbsent(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW),
             chargeCounterMicroampHours = manager.propertyOrAbsent(BatteryManager.BATTERY_PROPERTY_CHARGE_COUNTER),
             cycleCount = cycleCount(battery),
-            maxChargingCurrentMicroamps = battery.getIntExtra(BatteryManager.EXTRA_MAX_CHARGING_CURRENT, ABSENT),
-            maxChargingVoltageMicrovolts = battery.getIntExtra(BatteryManager.EXTRA_MAX_CHARGING_VOLTAGE, ABSENT),
+            maxChargingCurrentMicroamps = battery.getIntExtra(EXTRA_MAX_CHARGING_CURRENT, ABSENT),
+            maxChargingVoltageMicrovolts = battery.getIntExtra(EXTRA_MAX_CHARGING_VOLTAGE, ABSENT),
         )
     }
 
@@ -68,5 +68,11 @@ class BatteryReader @Inject constructor(
 
         // BatteryManager.EXTRA_CYCLE_COUNT — inlined to avoid a hard API-34 symbol reference.
         const val EXTRA_CYCLE_COUNT = "android.os.extra.CYCLE_COUNT"
+
+        // BatteryManager.EXTRA_MAX_CHARGING_CURRENT/VOLTAGE are @hide: BatteryService puts them into
+        // ACTION_BATTERY_CHANGED, but the constants are absent from the public SDK. The literal keys
+        // are stable AOSP identifiers.
+        const val EXTRA_MAX_CHARGING_CURRENT = "max_charging_current"
+        const val EXTRA_MAX_CHARGING_VOLTAGE = "max_charging_voltage"
     }
 }

--- a/app/src/main/java/eu/darken/amply/battery/core/BatteryReadout.kt
+++ b/app/src/main/java/eu/darken/amply/battery/core/BatteryReadout.kt
@@ -24,9 +24,13 @@ data class BatteryReadout(
     val chargeCounterMicroampHours: Int? = null,
     val cycleCount: Int? = null,
     /**
-     * Charger-advertised maximum, not a measurement: what the connected supply says it can deliver
-     * ([android.os.BatteryManager.EXTRA_MAX_CHARGING_CURRENT] / `EXTRA_MAX_CHARGING_VOLTAGE`). Only
-     * meaningful while something is connected, and never a substitute for the measured draw.
+     * Charger-advertised maximum, not a measurement: what the connected supply says it can deliver.
+     * Only meaningful while something is connected, and never a substitute for the measured draw.
+     *
+     * Sourced from the `max_charging_current` / `max_charging_voltage` extras of
+     * [android.content.Intent.ACTION_BATTERY_CHANGED]. The framework populates them, but their
+     * `BatteryManager` constants are `@hide` and absent from the public SDK, so `BatteryReader` reads
+     * the literal AOSP keys.
      */
     val maxChargingCurrentMicroamps: Int? = null,
     val maxChargingVoltageMicrovolts: Int? = null,

--- a/app/src/main/java/eu/darken/amply/battery/core/BatteryReadout.kt
+++ b/app/src/main/java/eu/darken/amply/battery/core/BatteryReadout.kt
@@ -23,6 +23,13 @@ data class BatteryReadout(
     val currentNowMicroamps: Int? = null,
     val chargeCounterMicroampHours: Int? = null,
     val cycleCount: Int? = null,
+    /**
+     * Charger-advertised maximum, not a measurement: what the connected supply says it can deliver
+     * ([android.os.BatteryManager.EXTRA_MAX_CHARGING_CURRENT] / `EXTRA_MAX_CHARGING_VOLTAGE`). Only
+     * meaningful while something is connected, and never a substitute for the measured draw.
+     */
+    val maxChargingCurrentMicroamps: Int? = null,
+    val maxChargingVoltageMicrovolts: Int? = null,
 ) {
     /**
      * External power is reported. A null (not reported) [plugged] collapses conservatively to false —

--- a/app/src/main/java/eu/darken/amply/battery/core/BatteryReadoutFactory.kt
+++ b/app/src/main/java/eu/darken/amply/battery/core/BatteryReadoutFactory.kt
@@ -29,6 +29,8 @@ object BatteryReadoutFactory {
         currentNowMicroamps: Int = ABSENT,
         chargeCounterMicroampHours: Int = ABSENT,
         cycleCount: Int = ABSENT,
+        maxChargingCurrentMicroamps: Int = ABSENT,
+        maxChargingVoltageMicrovolts: Int = ABSENT,
     ): BatteryReadout = BatteryReadout(
         levelPercent = percentOf(level, scale),
         status = status.orNull(),
@@ -42,6 +44,10 @@ object BatteryReadoutFactory {
         currentNowMicroamps = currentNowMicroamps.orNull(),
         chargeCounterMicroampHours = chargeCounterMicroampHours.orNull(),
         cycleCount = cycleCount.orNull(),
+        // The charger extras are advertised capabilities: a device that reports them while nothing is
+        // connected reports 0, which is "no charger" rather than "a 0 W charger".
+        maxChargingCurrentMicroamps = maxChargingCurrentMicroamps.positiveOrNull(),
+        maxChargingVoltageMicrovolts = maxChargingVoltageMicrovolts.positiveOrNull(),
     )
 
     /** Percent only when the level/scale pair is internally consistent; otherwise `null`. */
@@ -51,4 +57,6 @@ object BatteryReadoutFactory {
     }
 
     private fun Int.orNull(): Int? = if (this == ABSENT) null else this
+
+    private fun Int.positiveOrNull(): Int? = if (this == ABSENT || this <= 0) null else this
 }

--- a/app/src/main/java/eu/darken/amply/battery/ui/BatteryEffect.kt
+++ b/app/src/main/java/eu/darken/amply/battery/ui/BatteryEffect.kt
@@ -1,6 +1,8 @@
-package eu.darken.amply.main.ui.dashboard
+package eu.darken.amply.battery.ui
 
 import android.os.BatteryManager
+import androidx.annotation.StringRes
+import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.stats.core.StatsPowerCalculator
 
@@ -76,15 +78,31 @@ sealed interface BatteryEffect {
 }
 
 /**
- * Charge power for the charging card's reading line, or `null` when no figure may be shown.
+ * Charge power for a live reading line, or `null` when no figure may be shown.
  *
  * Delegates to [StatsPowerCalculator.chargeMilliwatts] rather than re-deriving the rule, so the
  * live headline and the recorded curve/peak/average can never disagree about what counts as charge
  * power.
  */
-fun chargePowerMilliwatts(readout: BatteryReadout): Int? = StatsPowerCalculator.chargeMilliwatts(
-    batteryStatus = readout.status,
-    plugged = readout.onCharger,
-    voltageMillivolts = readout.voltageMillivolts,
-    currentNowMicroamps = readout.currentNowMicroamps,
-)
+fun chargePowerMilliwatts(readout: BatteryReadout): Int? = StatsPowerCalculator.chargeMilliwatts(readout)
+
+/**
+ * What to show in place of a withheld charge power, as a string resource.
+ *
+ * "Not charging" is only used where the battery *positively* reported that it isn't taking charge
+ * (unplugged, held at a limit, full). Everywhere else the figure is missing rather than zero — a
+ * connected device with no usable status has not told us it isn't charging — so it falls back to the
+ * shared "Not reported".
+ */
+@StringRes
+fun chargePowerFallbackRes(effect: BatteryEffect): Int = when (effect) {
+    is BatteryEffect.OnBattery,
+    is BatteryEffect.ConnectedNotCharging,
+    is BatteryEffect.Full,
+    -> R.string.battery_value_not_charging
+
+    is BatteryEffect.Charging,
+    is BatteryEffect.Connected,
+    BatteryEffect.Unknown,
+    -> R.string.battery_value_not_reported
+}

--- a/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
@@ -430,6 +430,14 @@ class MainActivity : ComponentActivity() {
                             val statsDetail by statsViewModel.detailState.collectAsState()
                             StatsSessionDetailScreen(
                                 state = statsDetail,
+                                // Live wattage only for the session that is actually charging now. The
+                                // detail query is by id and unrestricted, so it can resolve a dangling
+                                // open row from an earlier boot that the boot-scoped live query rejects
+                                // — attributing the current draw to it would be a fabrication.
+                                readout = state.batteryReadout.takeIf {
+                                    val live = state.stats.live
+                                    live != null && statsDetail?.summary?.id == live.id
+                                },
                                 onBack = {
                                     statsViewModel.closeSession()
                                     destination = detailOrigin

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
@@ -27,9 +27,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.battery.ui.BatteryEffect
 import eu.darken.amply.battery.ui.batteryHealthLabel
 import eu.darken.amply.battery.ui.batteryPlugLabel
 import eu.darken.amply.battery.ui.batteryStatusLabel
+import eu.darken.amply.battery.ui.chargePowerFallbackRes
 import eu.darken.amply.battery.ui.formatChargeCounter
 import eu.darken.amply.battery.ui.formatCurrent
 import eu.darken.amply.battery.ui.formatTemperature
@@ -38,6 +40,8 @@ import eu.darken.amply.common.compose.AmplyCard
 import eu.darken.amply.common.compose.AmplyCardDefaults
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
+import eu.darken.amply.stats.core.StatsPowerCalculator
+import eu.darken.amply.stats.ui.StatsFormat
 
 /**
  * The single battery/charging destination: the current or last charge and the full live readout, led
@@ -185,6 +189,21 @@ private fun ElectricalSection(readout: BatteryReadout) {
             stringResource(R.string.battery_detail_current),
             formatCurrent(readout.currentNowMicroamps) ?: notReported,
         )
+        // Voltage × current above is a magnitude in either direction; this row is the gated charge
+        // power, so a discharge draw can never be read here as charge power.
+        DetailRow(
+            stringResource(R.string.battery_detail_power),
+            StatsFormat.power(StatsPowerCalculator.chargeMilliwatts(readout))
+                ?: stringResource(chargePowerFallbackRes(BatteryEffect.from(readout))),
+        )
+        // Advertised, not measured: what the connected supply claims. Nothing connected means nothing
+        // to claim, so the extras are only read through while on a charger.
+        DetailRow(
+            stringResource(R.string.battery_detail_charger_max),
+            readout.takeIf { it.onCharger }
+                ?.let { StatsFormat.power(StatsPowerCalculator.advertisedMaxMilliwatts(it)) }
+                ?: notReported,
+        )
         DetailRow(
             stringResource(R.string.battery_detail_charge_counter),
             formatChargeCounter(readout.chargeCounterMicroampHours) ?: notReported,
@@ -251,6 +270,9 @@ private val previewCharging = BatteryReadout(
     currentNowMicroamps = 1_250_000,
     chargeCounterMicroampHours = 3_800_000,
     cycleCount = 142,
+    // A 9 V / 2 A charger advertising itself while the battery measures ~5.2 W.
+    maxChargingCurrentMicroamps = 2_000_000,
+    maxChargingVoltageMicrovolts = 9_000_000,
 )
 
 @AmplyPreview

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/ChargingCard.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/ChargingCard.kt
@@ -2,6 +2,7 @@ package eu.darken.amply.main.ui.dashboard
 
 import android.os.BatteryManager
 import android.os.SystemClock
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -22,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.battery.ui.batteryStatusLabel
+import eu.darken.amply.battery.ui.chargePowerMilliwatts
 import eu.darken.amply.battery.ui.formatTemperature
 import eu.darken.amply.common.compose.AmplyNavigationCard
 import eu.darken.amply.common.compose.AmplyPreview
@@ -87,7 +89,7 @@ fun ChargingCard(
         onClickLabel = stringResource(R.string.dashboard_charging_open_action),
         title = stringResource(
             when {
-                charging -> R.string.dashboard_charging_title_charging
+                charging -> chargingTitle(chargingSpeed(chargePowerMilliwatts(battery)))
                 onCharger -> R.string.dashboard_charging_title_connected
                 else -> R.string.dashboard_charging_title_idle
             },
@@ -112,6 +114,18 @@ fun ChargingCard(
             is ChargingCardPresentation.Idle -> IdleBody(presentation)
         }
     }
+}
+
+/**
+ * The headline while charging. An unclassifiable draw (no figure, or a device that reports none)
+ * stays at the plain "Charging" — the card never guesses a speed it can't measure.
+ */
+@StringRes
+private fun chargingTitle(speed: ChargingSpeed?): Int = when (speed) {
+    ChargingSpeed.VERY_FAST -> R.string.dashboard_charging_title_very_fast
+    ChargingSpeed.FAST -> R.string.dashboard_charging_title_fast
+    ChargingSpeed.SLOW -> R.string.dashboard_charging_title_slow
+    ChargingSpeed.NORMAL, null -> R.string.dashboard_charging_title_charging
 }
 
 /**
@@ -242,6 +256,19 @@ private val previewCharging = BatteryReadout(
     currentNowMicroamps = 2_050_000,
 )
 
+// ~0.6 W — a trickle from a weak supply.
+private val previewChargingSlow = previewCharging.copy(
+    levelPercent = 41,
+    currentNowMicroamps = 150_000,
+)
+
+// ~19.8 W — a dual-cell pack reporting its own voltage on a high-power charger.
+private val previewChargingVeryFast = previewCharging.copy(
+    levelPercent = 22,
+    voltageMillivolts = 9_000,
+    currentNowMicroamps = 2_200_000,
+)
+
 private val previewHolding = previewCharging.copy(
     levelPercent = 80,
     status = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
@@ -290,6 +317,36 @@ private fun ChargingCardLivePreview() = PreviewWrapper {
         ChargingCard(
             presentation = ChargingCardPresentation.Live(session = previewLiveSession),
             readout = previewHolding,
+            onOpenHub = {},
+            onRetryCapture = {},
+            nowElapsedRealtimeMillis = 4_320_000L,
+        )
+    }
+}
+
+@AmplyPreview
+@Composable
+private fun ChargingCardSpeedPreview() = PreviewWrapper {
+    // The headline follows the measured draw: trickle, fast (the default fixture), and a high-power
+    // charger. A device that reports no draw keeps the plain "Charging".
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        ChargingCard(
+            presentation = ChargingCardPresentation.Live(session = previewLiveSession),
+            readout = previewChargingSlow,
+            onOpenHub = {},
+            onRetryCapture = {},
+            nowElapsedRealtimeMillis = 4_320_000L,
+        )
+        ChargingCard(
+            presentation = ChargingCardPresentation.Live(session = previewLiveSession),
+            readout = previewChargingVeryFast,
+            onOpenHub = {},
+            onRetryCapture = {},
+            nowElapsedRealtimeMillis = 4_320_000L,
+        )
+        ChargingCard(
+            presentation = ChargingCardPresentation.Live(session = previewLiveSession),
+            readout = previewCharging.copy(currentNowMicroamps = null),
             onOpenHub = {},
             onRetryCapture = {},
             nowElapsedRealtimeMillis = 4_320_000L,

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/ChargingCardPresentation.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/ChargingCardPresentation.kt
@@ -103,3 +103,31 @@ sealed interface ChargingCardPresentation {
         }
     }
 }
+
+/** How fast the battery is being charged, for the card's headline. */
+enum class ChargingSpeed {
+    SLOW,
+    NORMAL,
+    FAST,
+    VERY_FAST,
+}
+
+/**
+ * Buckets a measured charge power, or `null` when there is no figure to classify — an unknown speed
+ * is not a normal one, and the caller falls back to the plain "Charging" headline.
+ *
+ * The SLOW and FAST bars are AOSP SettingsLib's own bucket values (`config_chargingSlowlyThreshold`
+ * 5 W / `config_chargingFastThreshold` 7.5 W), applied here to the *measured* draw rather than to the
+ * charger-advertised maximum AOSP uses — the measurement is what the battery actually receives, and it
+ * is the number shown one line below the headline. VERY_FAST at 15 W is Amply's own, twice the AOSP
+ * fast bar, so the modern 20 W+ chargers that would otherwise all read "fast" are distinguishable.
+ */
+fun chargingSpeed(milliwatts: Int?): ChargingSpeed? {
+    if (milliwatts == null || milliwatts <= 0) return null
+    return when {
+        milliwatts < 5_000 -> ChargingSpeed.SLOW
+        milliwatts > 15_000 -> ChargingSpeed.VERY_FAST
+        milliwatts > 7_500 -> ChargingSpeed.FAST
+        else -> ChargingSpeed.NORMAL
+    }
+}

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -84,6 +84,7 @@ import eu.darken.amply.fullcharge.core.InterruptionReason
 import eu.darken.amply.fullcharge.core.policyOrNull
 import eu.darken.amply.main.core.formatReport
 import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.battery.ui.BatteryEffect
 import eu.darken.amply.main.ui.setup.AccessSetupGuide
 import eu.darken.amply.main.ui.setup.OemGuideCard
 import eu.darken.amply.main.ui.setup.UnsupportedDeviceCard

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsPowerCalculator.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsPowerCalculator.kt
@@ -1,6 +1,7 @@
 package eu.darken.amply.stats.core
 
 import android.os.BatteryManager
+import eu.darken.amply.battery.core.BatteryReadout
 import kotlin.math.abs
 
 /**
@@ -17,6 +18,9 @@ object StatsPowerCalculator {
 
     /** 250 W — generously above any phone/tablet charger; anything larger is a bad OEM reading. */
     const val MAX_PLAUSIBLE_MILLIWATTS = 250_000
+
+    /** AOSP's assumed charging voltage when a charger advertises a current but no voltage. */
+    private const val DEFAULT_CHARGING_VOLTAGE_MICROVOLTS = 5_000_000
 
     fun milliwatts(voltageMillivolts: Int?, currentNowMicroamps: Int?): Int? {
         if (voltageMillivolts == null || currentNowMicroamps == null) return null
@@ -48,5 +52,40 @@ object StatsPowerCalculator {
         if (!plugged) return null
         if (batteryStatus != BatteryManager.BATTERY_STATUS_CHARGING) return null
         return milliwatts(voltageMillivolts, currentNowMicroamps)
+    }
+
+    /** [chargeMilliwatts] straight off a readout; `null` readout (nothing observed) yields `null`. */
+    fun chargeMilliwatts(readout: BatteryReadout?): Int? {
+        if (readout == null) return null
+        return chargeMilliwatts(
+            batteryStatus = readout.status,
+            plugged = readout.onCharger,
+            voltageMillivolts = readout.voltageMillivolts,
+            currentNowMicroamps = readout.currentNowMicroamps,
+        )
+    }
+
+    /**
+     * What the connected charger *advertises* it can deliver, in milliwatts — not a measurement, and
+     * never a stand-in for [chargeMilliwatts].
+     *
+     * A missing/non-positive voltage falls back to 5 V, matching AOSP's own `BatteryStatus`: chargers
+     * that report a current but no voltage are USB-spec 5 V supplies, and dropping the figure entirely
+     * would hide the more commonly reported half of the pair.
+     */
+    fun advertisedMaxMilliwatts(maxCurrentMicroamps: Int?, maxVoltageMicrovolts: Int?): Int? {
+        if (maxCurrentMicroamps == null || maxCurrentMicroamps <= 0) return null
+        val microvolts = maxVoltageMicrovolts?.takeIf { it > 0 } ?: DEFAULT_CHARGING_VOLTAGE_MICROVOLTS
+        val mw = (maxCurrentMicroamps.toLong() / 1000L) * (microvolts.toLong() / 1000L) / 1000L
+        if (mw <= 0 || mw > MAX_PLAUSIBLE_MILLIWATTS) return null
+        return mw.toInt()
+    }
+
+    fun advertisedMaxMilliwatts(readout: BatteryReadout?): Int? {
+        if (readout == null) return null
+        return advertisedMaxMilliwatts(
+            maxCurrentMicroamps = readout.maxChargingCurrentMicroamps,
+            maxVoltageMicrovolts = readout.maxChargingVoltageMicrovolts,
+        )
     }
 }

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsSessionDetailScreen.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsSessionDetailScreen.kt
@@ -26,6 +26,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import eu.darken.amply.R
+import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.battery.ui.BatteryEffect
+import eu.darken.amply.battery.ui.chargePowerFallbackRes
 import eu.darken.amply.common.compose.AmplyCard
 import eu.darken.amply.common.compose.AmplyCardDefaults
 import eu.darken.amply.common.compose.AmplyPreview
@@ -33,6 +36,7 @@ import eu.darken.amply.common.compose.PreviewWrapper
 import eu.darken.amply.stats.core.ChargeCurvePoint
 import eu.darken.amply.stats.core.ChargeSessionSummary
 import eu.darken.amply.stats.core.ChargingType
+import eu.darken.amply.stats.core.StatsPowerCalculator
 import eu.darken.amply.stats.core.StatsSealReason
 
 /**
@@ -40,11 +44,16 @@ import eu.darken.amply.stats.core.StatsSealReason
  * State-hoisted; a null [state] shows a spinner while the ViewModel resolves the selection, and a
  * resolved state without a summary means the session no longer exists (discarded or cleared) — a
  * notice, never an eternal spinner. An open session's curve/summary keep updating live.
+ *
+ * [readout] is the *live* battery reading, and only the caller can say whether it belongs to the
+ * session being viewed — pass null for any session that isn't the one currently charging, or the
+ * current charge's wattage would be attributed to someone else's history.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StatsSessionDetailScreen(
     state: StatsDetailState?,
+    readout: BatteryReadout?,
     onBack: () -> Unit,
 ) {
     Scaffold(
@@ -98,7 +107,7 @@ fun StatsSessionDetailScreen(
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             item { CurveCard(state.curve) }
-            item { SummaryCard(summary) }
+            item { SummaryCard(summary, readout) }
             if (summary.partial) {
                 item {
                     Text(
@@ -127,7 +136,7 @@ private fun CurveCard(curve: List<ChargeCurvePoint>) {
 }
 
 @Composable
-private fun SummaryCard(summary: ChargeSessionSummary) {
+private fun SummaryCard(summary: ChargeSessionSummary, readout: BatteryReadout?) {
     val notReported = stringResource(R.string.battery_value_not_reported)
     AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
         DetailRow(stringResource(R.string.stats_detail_started), StatsFormat.dateTime(summary.startedAtWallMillis))
@@ -137,6 +146,15 @@ private fun SummaryCard(summary: ChargeSessionSummary) {
         DetailRow(stringResource(R.string.stats_detail_level), StatsFormat.percentRange(summary.startPercent, summary.endPercent))
         DetailRow(stringResource(R.string.stats_detail_duration), StatsFormat.duration(summary.durationMillis) ?: notReported)
         DetailRow(stringResource(R.string.stats_detail_charging_type), stringResource(chargingTypeLabel(summary.chargingType)))
+        // Live, and only for the still-open session the caller vouched for: a closed session's numbers
+        // are all history, and a "now" row beside them would belong to a different charge.
+        if (readout != null && summary.endedAtWallMillis == null) {
+            DetailRow(
+                stringResource(R.string.stats_detail_power_now),
+                StatsFormat.power(StatsPowerCalculator.chargeMilliwatts(readout))
+                    ?: stringResource(chargePowerFallbackRes(BatteryEffect.from(readout))),
+            )
+        }
         DetailRow(stringResource(R.string.stats_detail_avg_power), StatsFormat.power(summary.avgPowerMilliwatts) ?: notReported)
         DetailRow(stringResource(R.string.stats_detail_peak_power), StatsFormat.power(summary.peakPowerMilliwatts) ?: notReported)
         DetailRow(
@@ -174,39 +192,64 @@ private fun DetailRow(label: String, value: String) {
     }
 }
 
+private val previewCurve = (0..20).map { i ->
+    ChargeCurvePoint(
+        elapsedFromStartMillis = i * 180_000L,
+        percent = (42 + i * 3).coerceAtMost(100),
+        powerMilliwatts = (25_000 - i * 900).coerceAtLeast(1_500),
+        temperatureTenthsC = 300 + i * 2,
+    )
+}
+
+private val previewSummary = ChargeSessionSummary(
+    id = 1,
+    startedAtWallMillis = System.currentTimeMillis() - 3_600_000,
+    endedAtWallMillis = System.currentTimeMillis(),
+    durationMillis = 3_600_000,
+    startPercent = 42,
+    endPercent = 100,
+    chargingType = ChargingType.AC,
+    avgPowerMilliwatts = 12_000,
+    peakPowerMilliwatts = 25_000,
+    minTemperatureTenthsC = 300,
+    avgTemperatureTenthsC = 320,
+    maxTemperatureTenthsC = 340,
+    limitHit = false,
+    partial = false,
+    fullReachedAtWallMillis = System.currentTimeMillis() - 60_000,
+    sealReason = StatsSealReason.UNPLUGGED,
+)
+
 @AmplyPreview
 @Composable
 private fun StatsSessionDetailScreenPreview() = PreviewWrapper {
-    val start = 0L
-    val curve = (0..20).map { i ->
-        ChargeCurvePoint(
-            elapsedFromStartMillis = start + i * 180_000L,
-            percent = (42 + i * 3).coerceAtMost(100),
-            powerMilliwatts = (25_000 - i * 900).coerceAtLeast(1_500),
-            temperatureTenthsC = 300 + i * 2,
-        )
-    }
+    StatsSessionDetailScreen(
+        state = StatsDetailState(summary = previewSummary, curve = previewCurve),
+        readout = null,
+        onBack = {},
+    )
+}
+
+@AmplyPreview
+@Composable
+private fun StatsSessionDetailScreenLivePreview() = PreviewWrapper {
+    // The open session that is charging right now: only here does the summary carry a "Power now".
     StatsSessionDetailScreen(
         state = StatsDetailState(
-            summary = ChargeSessionSummary(
-                id = 1,
-                startedAtWallMillis = System.currentTimeMillis() - 3_600_000,
-                endedAtWallMillis = System.currentTimeMillis(),
-                durationMillis = 3_600_000,
-                startPercent = 42,
-                endPercent = 100,
-                chargingType = ChargingType.AC,
-                avgPowerMilliwatts = 12_000,
-                peakPowerMilliwatts = 25_000,
-                minTemperatureTenthsC = 300,
-                avgTemperatureTenthsC = 320,
-                maxTemperatureTenthsC = 340,
-                limitHit = false,
-                partial = false,
-                fullReachedAtWallMillis = System.currentTimeMillis() - 60_000,
-                sealReason = StatsSealReason.UNPLUGGED,
+            summary = previewSummary.copy(
+                endedAtWallMillis = null,
+                endPercent = 78,
+                fullReachedAtWallMillis = null,
+                sealReason = null,
             ),
-            curve = curve,
+            curve = previewCurve,
+        ),
+        readout = BatteryReadout(
+            levelPercent = 78,
+            status = android.os.BatteryManager.BATTERY_STATUS_CHARGING,
+            plugged = android.os.BatteryManager.BATTERY_PLUGGED_AC,
+            voltageMillivolts = 4_100,
+            currentNowMicroamps = 2_050_000,
         ),
         onBack = {},
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -461,6 +461,7 @@
     <string name="battery_info_summary_power">%1$s · %2$s · %3$s · %4$s</string>
     <string name="battery_value_not_reported">Not reported</string>
     <string name="battery_value_unknown">Unknown</string>
+    <string name="battery_value_not_charging">Not charging</string>
     <string name="battery_hub_title">Battery &amp; charging</string>
     <string name="battery_hub_history_action">Charge history</string>
     <string name="battery_hub_section_now">Now</string>
@@ -484,6 +485,8 @@
     <string name="battery_detail_cycle_count">Charge cycles</string>
     <string name="battery_detail_voltage">Voltage</string>
     <string name="battery_detail_current">Current now</string>
+    <string name="battery_detail_power">Charge power</string>
+    <string name="battery_detail_charger_max">Charger max</string>
     <string name="battery_detail_charge_counter">Charge counter</string>
     <string name="battery_detail_temperature">Temperature</string>
     <string name="battery_status_charging">Charging</string>
@@ -531,6 +534,9 @@
 
     <!-- Battery statistics -->
     <string name="dashboard_charging_title_charging">Charging</string>
+    <string name="dashboard_charging_title_slow">Charging slowly</string>
+    <string name="dashboard_charging_title_fast">Charging fast</string>
+    <string name="dashboard_charging_title_very_fast">Charging very fast</string>
     <string name="dashboard_charging_title_connected">Connected</string>
     <string name="dashboard_charging_title_idle">Battery</string>
     <string name="dashboard_charging_open_action">Open battery &amp; charging</string>
@@ -580,6 +586,7 @@
     <string name="stats_detail_level">Level</string>
     <string name="stats_detail_duration">Duration</string>
     <string name="stats_detail_charging_type">Connection</string>
+    <string name="stats_detail_power_now">Power now</string>
     <string name="stats_detail_avg_power">Average power</string>
     <string name="stats_detail_peak_power">Peak power</string>
     <string name="stats_detail_temperature">Temperature range</string>

--- a/app/src/test/java/eu/darken/amply/battery/ui/BatteryEffectTest.kt
+++ b/app/src/test/java/eu/darken/amply/battery/ui/BatteryEffectTest.kt
@@ -1,4 +1,4 @@
-package eu.darken.amply.main.ui.dashboard
+package eu.darken.amply.battery.ui
 
 import android.os.BatteryManager
 import eu.darken.amply.battery.core.BatteryReadout

--- a/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
@@ -1,0 +1,115 @@
+package eu.darken.amply.main.ui.battery
+
+import android.app.Application
+import android.os.BatteryManager
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.R
+import eu.darken.amply.battery.core.BatteryReadout
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The electrical section's two wattage rows. The tall qualifier renders the whole list, so a missing
+ * row is a missing row rather than one scrolled out of the viewport.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "+h2400dp")
+class BatteryHubScreenTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    private fun string(res: Int): String = context.getString(res)
+
+    // Every field reported, so a "Not reported" anywhere on the screen belongs to the row under test.
+    private val charging = BatteryReadout(
+        levelPercent = 82,
+        status = BatteryManager.BATTERY_STATUS_CHARGING,
+        plugged = BatteryManager.BATTERY_PLUGGED_AC,
+        health = BatteryManager.BATTERY_HEALTH_GOOD,
+        technology = "Li-ion",
+        temperatureTenthsC = 314,
+        voltageMillivolts = 4_000,
+        currentNowMicroamps = 2_000_000,
+        chargeCounterMicroampHours = 3_800_000,
+        cycleCount = 142,
+        maxChargingCurrentMicroamps = 2_000_000,
+        maxChargingVoltageMicrovolts = 9_000_000,
+    )
+
+    private fun render(readout: BatteryReadout?) {
+        compose.setContent {
+            BatteryHubScreen(
+                readout = readout,
+                captureEnabled = true,
+                teaser = ChargeTeaserState.None,
+                onBack = {},
+                onOpenHistory = {},
+                onEnableCapture = {},
+                onOpenSession = {},
+            )
+        }
+    }
+
+    @Test
+    fun `the measured charge power and the advertised maximum are both shown`() {
+        render(charging)
+        compose.onNodeWithText(string(R.string.battery_detail_power)).assertExists()
+        // 4.0 V x 2.0 A measured at the battery...
+        compose.onNodeWithText("8.0 W").assertExists()
+        // ...against the 9 V / 2 A the charger claims it could deliver.
+        compose.onNodeWithText(string(R.string.battery_detail_charger_max)).assertExists()
+        compose.onNodeWithText("18.0 W").assertExists()
+    }
+
+    @Test
+    fun `a limit hold says the battery is not charging, not that nothing was reported`() {
+        render(charging.copy(status = BatteryManager.BATTERY_STATUS_NOT_CHARGING))
+        // The status row spells this out as "Plugged in, not charging", so this is the power row.
+        compose.onNodeWithText(string(R.string.battery_value_not_charging)).assertExists()
+    }
+
+    @Test
+    fun `unplugged there is no charge power and nothing advertised`() {
+        render(
+            charging.copy(
+                status = BatteryManager.BATTERY_STATUS_DISCHARGING,
+                plugged = 0,
+                currentNowMicroamps = -500_000,
+            ),
+        )
+        compose.onNodeWithText(string(R.string.battery_value_not_charging)).assertExists()
+        // Nothing is connected, so the advertised maximum is the screen's only "Not reported" — the
+        // extras are not read through while off the charger even when the platform left them set.
+        compose.onNodeWithText(string(R.string.battery_value_not_reported)).assertExists()
+    }
+
+    @Test
+    fun `a charger advertising nothing reports nothing rather than claiming zero`() {
+        render(
+            charging.copy(
+                maxChargingCurrentMicroamps = null,
+                maxChargingVoltageMicrovolts = null,
+            ),
+        )
+        compose.onNodeWithText("8.0 W").assertExists()
+        compose.onNodeWithText(string(R.string.battery_value_not_reported)).assertExists()
+    }
+
+    @Test
+    fun `an unreadable battery never claims the battery is not charging`() {
+        render(null)
+        compose.onNodeWithText(string(R.string.battery_detail_power)).assertExists()
+        compose.onAllNodesWithText(string(R.string.battery_value_not_charging)).assertCountEquals(0)
+    }
+}

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/ChargingCardPresentationTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/ChargingCardPresentationTest.kt
@@ -140,4 +140,36 @@ class ChargingCardPresentationTest {
         ChargingCardPresentation.from(stats(), unplugged) shouldBe
             ChargingCardPresentation.Idle(lastSession = null, sessionCount = 0)
     }
+
+    // Speed buckets. An unknown draw is not a normal one — the headline falls back to plain "Charging".
+
+    @Test
+    fun `no measurable draw has no speed`() {
+        chargingSpeed(null) shouldBe null
+        chargingSpeed(0) shouldBe null
+        chargingSpeed(-1) shouldBe null
+    }
+
+    @Test
+    fun `anything under the AOSP slow bar is slow`() {
+        chargingSpeed(1) shouldBe ChargingSpeed.SLOW
+        chargingSpeed(4_999) shouldBe ChargingSpeed.SLOW
+    }
+
+    @Test
+    fun `between the slow and fast bars is normal`() {
+        chargingSpeed(5_000) shouldBe ChargingSpeed.NORMAL
+        chargingSpeed(7_500) shouldBe ChargingSpeed.NORMAL
+    }
+
+    @Test
+    fun `above the AOSP fast bar is fast`() {
+        chargingSpeed(7_501) shouldBe ChargingSpeed.FAST
+        chargingSpeed(15_000) shouldBe ChargingSpeed.FAST
+    }
+
+    @Test
+    fun `above twice the fast bar is very fast`() {
+        chargingSpeed(15_001) shouldBe ChargingSpeed.VERY_FAST
+    }
 }

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/ChargingCardTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/ChargingCardTest.kt
@@ -160,7 +160,48 @@ class ChargingCardTest {
 
     @Test
     fun `the title follows the charger, not the capture state`() {
+        // 8 W measured, so the headline is the speed-classified one even with capture off.
         render(ChargingCardPresentation.Promo, readout = charging)
+        compose.onNodeWithText(string(R.string.dashboard_charging_title_fast)).assertExists()
+    }
+
+    // The headline classifies the measured draw, so the card says how the charge is going rather than
+    // only that it is happening.
+
+    @Test
+    fun `a high-power charger is titled very fast`() {
+        render(
+            ChargingCardPresentation.Live(session = liveSession),
+            readout = charging.copy(voltageMillivolts = 9_000, currentNowMicroamps = 2_200_000),
+        )
+        compose.onNodeWithText(string(R.string.dashboard_charging_title_very_fast)).assertExists()
+    }
+
+    @Test
+    fun `a trickle is titled slowly`() {
+        render(
+            ChargingCardPresentation.Live(session = liveSession),
+            readout = charging.copy(currentNowMicroamps = 150_000),
+        )
+        compose.onNodeWithText(string(R.string.dashboard_charging_title_slow)).assertExists()
+    }
+
+    @Test
+    fun `an ordinary draw keeps the plain title`() {
+        // 4000 mV * 1_500_000 uA = 6 W — between the slow and fast bars.
+        render(
+            ChargingCardPresentation.Live(session = liveSession),
+            readout = charging.copy(currentNowMicroamps = 1_500_000),
+        )
+        compose.onNodeWithText(string(R.string.dashboard_charging_title_charging)).assertExists()
+    }
+
+    @Test
+    fun `an unmeasurable draw never guesses a speed`() {
+        render(
+            ChargingCardPresentation.Live(session = liveSession),
+            readout = charging.copy(currentNowMicroamps = null),
+        )
         compose.onNodeWithText(string(R.string.dashboard_charging_title_charging)).assertExists()
     }
 

--- a/app/src/test/java/eu/darken/amply/stats/core/StatsPowerCalculatorTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/StatsPowerCalculatorTest.kt
@@ -134,4 +134,30 @@ class StatsPowerCalculatorTest {
             currentNowMicroamps = 100_000_000,
         ) shouldBe null
     }
+
+    // The charger-advertised maximum: a capability the supply claims, not a measurement.
+
+    @Test
+    fun `an advertised maximum without a current is nothing to report`() {
+        StatsPowerCalculator.advertisedMaxMilliwatts(null, 9_000_000) shouldBe null
+        StatsPowerCalculator.advertisedMaxMilliwatts(0, 9_000_000) shouldBe null
+        StatsPowerCalculator.advertisedMaxMilliwatts(-1, 9_000_000) shouldBe null
+    }
+
+    @Test
+    fun `a missing advertised voltage falls back to the USB-spec 5 V`() {
+        StatsPowerCalculator.advertisedMaxMilliwatts(3_000_000, null) shouldBe 15_000
+        StatsPowerCalculator.advertisedMaxMilliwatts(3_000_000, 0) shouldBe 15_000
+    }
+
+    @Test
+    fun `both halves advertised multiply out`() {
+        StatsPowerCalculator.advertisedMaxMilliwatts(2_000_000, 9_000_000) shouldBe 18_000
+    }
+
+    @Test
+    fun `an implausible advertised maximum is rejected like a measured one`() {
+        // 30 A × 20 V = 600 W — bad units, not a phone charger.
+        StatsPowerCalculator.advertisedMaxMilliwatts(30_000_000, 20_000_000) shouldBe null
+    }
 }

--- a/app/src/test/java/eu/darken/amply/stats/ui/StatsSessionDetailScreenTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/ui/StatsSessionDetailScreenTest.kt
@@ -1,0 +1,105 @@
+package eu.darken.amply.stats.ui
+
+import android.app.Application
+import android.os.BatteryManager
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.R
+import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.stats.core.ChargeSessionSummary
+import eu.darken.amply.stats.core.ChargingType
+import eu.darken.amply.stats.core.StatsSealReason
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The live "Power now" row. Everything else on this screen is history; this one value is the present,
+ * so it exists only while the viewed session is the open one the caller vouched for.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "+h2400dp")
+class StatsSessionDetailScreenTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    private fun string(res: Int): String = context.getString(res)
+
+    private val closed = ChargeSessionSummary(
+        id = 1,
+        startedAtWallMillis = 0L,
+        endedAtWallMillis = 3_600_000L,
+        durationMillis = 3_600_000L,
+        startPercent = 42,
+        endPercent = 100,
+        chargingType = ChargingType.AC,
+        avgPowerMilliwatts = 12_000,
+        peakPowerMilliwatts = 25_000,
+        minTemperatureTenthsC = 300,
+        avgTemperatureTenthsC = 320,
+        maxTemperatureTenthsC = 340,
+        limitHit = false,
+        partial = false,
+        fullReachedAtWallMillis = null,
+        sealReason = StatsSealReason.UNPLUGGED,
+    )
+
+    private val open = closed.copy(
+        endedAtWallMillis = null,
+        endPercent = 78,
+        sealReason = null,
+    )
+
+    private val charging = BatteryReadout(
+        levelPercent = 78,
+        status = BatteryManager.BATTERY_STATUS_CHARGING,
+        plugged = BatteryManager.BATTERY_PLUGGED_AC,
+        voltageMillivolts = 4_000,
+        currentNowMicroamps = 2_000_000,
+    )
+
+    private fun render(summary: ChargeSessionSummary, readout: BatteryReadout?) {
+        compose.setContent {
+            StatsSessionDetailScreen(
+                state = StatsDetailState(summary = summary, curve = emptyList()),
+                readout = readout,
+                onBack = {},
+            )
+        }
+    }
+
+    @Test
+    fun `an open session shows the live draw beside its recorded averages`() {
+        render(open, charging)
+        compose.onNodeWithText(string(R.string.stats_detail_power_now)).assertExists()
+        // 8.0 W now, against the session's own 12.0 W average and 25.0 W peak.
+        compose.onNodeWithText("8.0 W").assertExists()
+    }
+
+    @Test
+    fun `a limit hold says the battery is not charging rather than nothing was reported`() {
+        render(open, charging.copy(status = BatteryManager.BATTERY_STATUS_NOT_CHARGING))
+        compose.onNodeWithText(string(R.string.stats_detail_power_now)).assertExists()
+        compose.onNodeWithText(string(R.string.battery_value_not_charging)).assertExists()
+    }
+
+    @Test
+    fun `a finished session has no present to report`() {
+        render(closed, charging)
+        compose.onNodeWithText(string(R.string.stats_detail_power_now)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `an open session the caller did not vouch for shows no live value`() {
+        // Null readout is how the caller says "this is not the session that is charging right now".
+        render(open, null)
+        compose.onNodeWithText(string(R.string.stats_detail_power_now)).assertDoesNotExist()
+    }
+}


### PR DESCRIPTION
## What changed

- The dashboard charging card now says how fast the charge is going: "Charging slowly", "Charging", "Charging fast", or "Charging very fast", based on the same measured wattage it already displays.
- The Battery & charging screen gained two rows: the live charge power, and the maximum wattage the connected charger advertises ("Charger max"). When the battery is positively not taking charge (unplugged, held at a limit, full) the power row says "Not charging" instead of the misleading "Not reported".
- The charge session screen shows a live "Power now" value alongside the existing peak and average, but only while viewing the session that is actually charging right now.

## Technical Context

- The speed buckets are AOSP SettingsLib's own thresholds (slow < 5 W, fast > 7.5 W) applied to the *measured* draw rather than the charger-advertised maximum the lock screen classifies. The label therefore always matches the wattage figure shown beside it and tapers honestly near full. The > 15 W "very fast" bucket is Amply-specific (2x the AOSP fast bar). Titles re-classify on each 3 s battery poll; boundary flicker is accepted rather than debounced.
- `BatteryManager.EXTRA_MAX_CHARGING_CURRENT/VOLTAGE` are `@hide`, so `BatteryReader` reads the extras by their literal stable AOSP keys. Values at or below zero normalize to null ("no charger" rather than "a 0 W charger"), and a missing advertised voltage falls back to AOSP's assumed 5 V.
- "Power now" is gated on the viewed session's id matching the boot-scoped live session, not just on the session being open: the detail query is unrestricted by-id, so a dangling open row from an earlier boot must not be attributed the current charge's wattage.
- `BatteryEffect` moved (`git mv`) from the dashboard package to `battery/ui`: the hub and stats screens reuse its "Not charging" vs "Not reported" semantics, and `stats/ui` must not depend on dashboard presentation files. The power arithmetic lives as readout overloads on `StatsPowerCalculator`, which already owned the calculation.
