### PR TITLE
Charging: Add GrapheneOS charge-limit support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,7 +8,7 @@ Amply is an **experimental Android controller for OEM battery charge-protection 
 temporarily allows a full charge, then restores the user's protective policy at 100%, on unplug, or at a safety
 timeout.
 
-Several control adapters exist — four OEM adapters plus a custom-ROM (LineageOS) adapter. **Pixel charging optimization** is capability-gated to Pixel 6a and newer phones on
+Several control adapters exist — four OEM adapters plus two custom-ROM adapters (LineageOS, GrapheneOS). **Pixel charging optimization** is capability-gated to Pixel 6a and newer phones on
 Android 15+ when Google's charging-optimization controller is present. **Samsung battery protection** (global
 `protect_battery` keys) is gated to verified One UI generations — One UI 8 multi-mode, and the legacy One UI 4/5
 toggle — on the system user. **Xiaomi charging protection** (secure `security_pc_secure_protect_mode_key`,
@@ -19,10 +19,15 @@ binary Adaptive/Unrestricted) is gated to the HyperOS 2.x ROM (`ro.mi.os.version
 `lineagesettings` provider, keys `charging_control_enabled`/`_mode`/`_charging_limit`) is manufacturer-agnostic —
 gated to a **physically-qualified device-codename allowlist** (HAL enforcement is per-device) plus the provider and
 system user; **reads are unprivileged (ContentResolver), writes require Shizuku** (the shell UID holds
-`lineageos.permission.WRITE_SETTINGS`, which `WRITE_SECURE_SETTINGS` does not cover). Other Pixels, Samsung on
-unverified One UI versions (6/7, 9+), non-HyperOS-2 Xiaomi devices, non-ColorOS-15 Oplus devices, and unqualified
-LineageOS builds remain diagnostics-only. See the qualification ledger (`.claude/skills/device-qualification/`) for
-the verified devices and mappings.
+`lineageos.permission.WRITE_SETTINGS`, which `WRITE_SECURE_SETTINGS` does not cover). **GrapheneOS charge limit**
+(world-readable `global battery_charge_limit`, binary FixedLimit(80)/Unrestricted, WSS-writable — no Shizuku) is
+gated to GrapheneOS identity (its `app.grapheneos.*` core packages; no property/feature/fingerprint marker exists)
+plus key presence and the system user; the ROM **latches the key at plug-session start** (`policyLatchesAtPlug`),
+so external writes take effect at the next unplug→replug — handled by a pending-until-replug verification state
+and a 30s session grace window; the reconnect gesture is unsupported there. Other Pixels, Samsung on
+unverified One UI versions (6/7, 9+), non-HyperOS-2 Xiaomi devices, non-ColorOS-15 Oplus devices, unqualified
+LineageOS builds, and GrapheneOS builds without the key remain diagnostics-only. See the qualification ledger
+(`.claude/skills/device-qualification/`) for the verified devices and mappings.
 
 Package: `eu.darken.amply`. License: GPL-3.0-or-later. Status: pre-launch (current version in `VERSION`).
 

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -30,6 +30,13 @@ single shared store, every write reaches every collector, so the deduplication h
   (Shizuku) readback, or a hardware reading for a *different* policy, does **not** clear it — the old policy
   legitimately still reads during the ~11–12s Pixel HAL transition. A WorkManager `SettleScheduler` fires one refresh
   at the window's end so the static widget/tile clear across process death.
+- **Plug-latched pending** (adapters with `policyLatchesAtPlug`, GrapheneOS): the ROM samples the configured policy
+  only at plug-session start, so a write made while plugged carries `PendingRequest(awaitingReplug = true)` — a
+  *condition*, not a countdown, with **no expiry**. It resolves only on evidence (`computeRefreshPending`'s latched
+  arm): written-unplugged, an observed unplug (live, or the persisted `unpluggedSeenAt` watermark), hardware state 4
+  for the exact target, or — for full-charge targets — the battery observably charging *above* the adapter's cap.
+  Surfaces show a "replug to apply" hint instead of a spinner; the hint may linger while nothing observes a replug
+  (accepted staleness), but the reverse error — claiming applied when not — cannot occur.
 - **Widget persistent-policy writes are atomic**: the ∞80% / ∞100% buttons route through a serialized
   `ACTION_SET_PERSISTENT_POLICY` command that cancels any running session **without restoring** and force-writes the
   chosen policy, so an explicit always-on choice never races the session's own writes.
@@ -47,8 +54,8 @@ indistinguishable).
 
 ## OEM Adapters
 
-Per-adapter detail (Samsung, Xiaomi, OnePlus/ColorOS, LineageOS, Pixel — keys, value domains, write ordering,
-session overrides) lives in the **`oem-adapters` skill** — read it before changing anything under
+Per-adapter detail (Samsung, Xiaomi, OnePlus/ColorOS, LineageOS, GrapheneOS, Pixel — keys, value domains, write
+ordering, session overrides) lives in the **`oem-adapters` skill** — read it before changing anything under
 `charging/core/adapter`.
 
 ## Temporary Session & Recovery
@@ -56,6 +63,11 @@ session overrides) lives in the **`oem-adapters` skill** — read it before chan
 - Before removing the limit, Amply persists the exact verified/requested protective policy (or the stored baseline).
 - A `specialUse` foreground service monitors the sticky battery broadcast (~30 s) and restores on: full charge,
   disconnect-after-connection, a 15-minute arming timeout, or a 24-hour safety timeout.
+- **Replug grace window** (plug-latched adapters only): a disconnect does not restore immediately — the engine emits
+  `MARK_DISCONNECTED` and opens a persisted 30s window (`REPLUG_GRACE_MILLIS`, wall clock, survives process death);
+  a replug inside it emits `MARK_REPLUGGED` and continues the session (the plug transition is what latches the
+  override), expiry or a backwards clock restores as before. `full` and the 24h safety timeout keep priority. On
+  every other adapter `replugGraceMillis` is 0 and the decision table is unchanged.
 - While active, the service watches the adapter's settings URIs; an unexpected native/system change **cancels without
   restoring**, so Amply never overwrites a newer external choice.
 - Boot recovery runs the restore *inside the service* with a bounded convergence check (re-write until the HAL

--- a/.claude/rules/privileged-access.md
+++ b/.claude/rules/privileged-access.md
@@ -38,9 +38,9 @@ for get / put / WSS grant / diagnostic snapshots. Hard rules:
   the allowlist without an explicit, reviewed reason.
 - Every writable key carries an explicit **per-key value domain** (`SettingWritePolicy`) — the boundary itself
   rejects out-of-domain values. The Samsung keys (`global protect_battery`, `global battery_protection_threshold`),
-  the Xiaomi key (`secure security_pc_secure_protect_mode_key`), and the Oplus keys (`system
-  regular_charge_protection_switch_state`, `system smart_charge_protection_switch_state`) are all **live** on gated
-  devices (see Capability Gates).
+  the Xiaomi key (`secure security_pc_secure_protect_mode_key`), the Oplus keys (`system
+  regular_charge_protection_switch_state`, `system smart_charge_protection_switch_state`), and the GrapheneOS key
+  (`global battery_charge_limit`) are all **live** on gated devices (see Capability Gates).
 
 ## Capability Gates
 
@@ -86,6 +86,32 @@ model-scoped), and the system user. Use `ro.mi.os.version.code`, NOT the frozen 
 assumptions: the feature is treated as present on any HyperOS 2 device (a device lacking it reads the key
 absent → a harmless false claim of control), and daemon-level enforcement of external writes is pending
 long-term observation (see Known gaps below).
+
+### GrapheneOS
+
+GrapheneOS control requires **all** of: GrapheneOS identity (`DeviceInfo.isGrapheneOs` — resolved from the OS's
+core `app.grapheneos.*` packages via PackageManager `<queries>` entries; **no** graphene property, system feature,
+or fingerprint marker exists, verified on a real device), a present world-readable `global battery_charge_limit`
+key (the capability signal — GrapheneOS ships the toggle exactly where its implementation works), and the system
+user. Identity is deliberately **not** OR-ed with key presence: the adapter is registered ahead of the Pixel
+adapter, and a future stock Pixel shipping a same-named key must not be swallowed as GrapheneOS.
+
+The key is binary (`1` = fixed 80% cap with bypass charging, `0` = off) and WSS-writable — **no Shizuku needed**.
+The defining quirk is **`policyLatchesAtPlug`**: the ROM samples the key only at plug-session start, so an external
+write reads back correctly but has no hardware effect until the next unplug→replug (the native Settings toggle
+applies live because Settings pokes the charging service directly). Three mechanisms handle this — the
+pending-until-replug verification state (condition-based, no settling clock), the session engine's 30s replug grace
+window (a disconnect during a session opens a window instead of restoring, so the user's replug latches the
+override rather than a premature restore), and `reapply == apply` (no observer to re-trigger). While enforcing, the
+device reports the stock-Pixel hardware signal (`EXTRA_CHARGING_STATUS` = 4), which the adapter decodes for real
+enforcement evidence. The reconnect gesture is unsupported — its override write lands strictly after the replug
+broadcast, which the ROM has already sampled past.
+
+Qualification is **remote** (issue #49, Pixel 9 Pro XL `komodo`, GrapheneOS 2026080501 / Android 17): the tester
+physically observed enforcement (held at 80% with the shield and state 4) and the latch behavior. Package
+visibility of `app.grapheneos.*` from app context and the factory-absent key state are still unverified on-device;
+both fail closed (Pixel-adapter diagnostics, or diagnostics + contribution wizard). Record any new evidence in the
+qualification ledger (`device-qualification` skill).
 
 ### LineageOS
 

--- a/.claude/skills/device-qualification/SKILL.md
+++ b/.claude/skills/device-qualification/SKILL.md
@@ -50,6 +50,7 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
 | Samsung | Galaxy Tab A9+ SM-X210 One UI 8.0; Galaxy S20 FE SM-G781B One UI 4.1 | Full — sync readback + HAL enforcement | Modern multi-mode + legacy toggle, session E2E, native-change cancel, reboot recovery, R8 beta | 2026-07-21 |
 | Xiaomi | Xiaomi 13T `2306EPN60G` HyperOS 2.0 (`ro.mi.os.version.code=2`) | **Partial** — mapping/readback/session verified; the adaptive 80% hold could not be triggered, so daemon-level hardware enforcement is **not yet demonstrated** | Read matrix, both-direction writes, session at 100%, unknown-value refusal, R8 beta | 2026-07-21 |
 | OnePlus (Oplus) | OnePlus Nord CE4 Lite `CPH2621` ColorOS 15 (`ro.build.version.oplusrom=V15.0.0`) | Full — enforcement directly observable (device holds at 80%); external writes stick | Two mutually-exclusive `system` keys (Charging limit / Smart charging), WSS-only write rejected + Shizuku write succeeds for all three policies, WSS-only UX (controls disabled + Shizuku-required banner) | 2026-07-21 |
+| GrapheneOS | Pixel 9 Pro XL `komodo`, GrapheneOS 2026080501 / Android 17 — **REMOTE qualification via issue #49** (tester-run protocol, not maintainer hardware) | **Enforcement observed**: held at 80% with shield, `dumpsys battery` status=4/Charging state=4/policy=2 (limit on) vs 2/1/1 (off); shell-UID writes move the Settings UI live, **latch at plug-session start** — mid-session writes have no hardware effect until unplug→replug, replug reliably applies the current value | Key isolation (`settings list` diff → single `global battery_charge_limit` 0/1), write→UI both directions, mid-session no-op both directions, replug latch both directions, hardware signal both states. **NOT run**: app-context access tiers (WSS write from Amply, `app.grapheneos.*` package visibility), sessions/boot recovery, wireless, factory-absent key state, secondary user | 2026-08-12 |
 
 ## Known gaps
 
@@ -114,6 +115,23 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
     (`google/oriole/oriole:16/…/release-keys`), so fingerprint sniffing is not a fallback. Otherwise clean on this
     ROM: install/launch/onboarding/dashboard/settings with no crashes, honest "Unsupported device" reporting, live
     battery monitoring across simulated plug/level transitions, and the charge alarm firing at threshold.
+- **GrapheneOS** — landed **live** on remote qualification (issue #49; the only OEM row not tested on maintainer
+  hardware). Open items, all failing closed:
+  - **`app.grapheneos.*` package visibility from app context is unverified** — `<queries>` package entries are
+    specified platform behavior (not SELinux-fragile like `ro.lineage.*`), but GrapheneOS hardens aggressively. If
+    the packages are hidden, `isGrapheneOs` is false and the device falls to the Pixel adapter as
+    matched/diagnostics-only — no unsafe write path, but support silently vanishes; the first tester report of
+    "still unsupported" on the test build should check `is_grapheneos=` in the device report.
+  - **App-context WSS write unverified** — the tester's writes ran as shell UID; an Amply-originated
+    `Settings.Global.putString` under granted WSS is expected to behave identically (same namespace rules) but has
+    not been observed. The read-back-equality check catches a silently-failing write.
+  - **Factory-absent key state unknown** — the tester's device had the key present while off; whether a
+    never-toggled install exposes it is unverified. Absent → gate fails closed → diagnostics + contribution wizard
+    (`adapter_detail_grapheneos_no_key`), and `read()` refuses (`unrecognizedValue`) so a session never clobbers it.
+  - **State 4 below the limit unverified** — evidence was sampled at the 80% hold; if the ROM reports 4 only while
+    holding, a FixedLimit pending clears late (at the hold) instead of instantly. Cosmetic.
+  - **Wireless charging and secondary users**: NOT RUN (gated to system user).
+  - Sessions/boot-recovery/R8 smoke on real GrapheneOS hardware: pending the test build posted to issue #49.
 - **Xiaomi** — adaptive hardware enforcement of external writes unconfirmed; treat the adapter as provisional until
   the 80% hold is physically observed.
   - **HyperOS 3 candidate mapping (contribution report, 2026-08-07 — unqualified, stays diagnostics-only).** A

--- a/.claude/skills/device-qualification/SKILL.md
+++ b/.claude/skills/device-qualification/SKILL.md
@@ -130,6 +130,12 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
     (`adapter_detail_grapheneos_no_key`), and `read()` refuses (`unrecognizedValue`) so a session never clobbers it.
   - **State 4 below the limit unverified** — evidence was sampled at the 80% hold; if the ROM reports 4 only while
     holding, a FixedLimit pending clears late (at the hold) instead of instantly. Cosmetic.
+  - **A plugged restore configures but cannot enforce** — restore-at-100%, the 24h safety timeout,
+    manual restore, and a plugged boot recovery all write the protective value while a plug session
+    is running; the ROM won't enforce it until the next replug, and no code path can change that
+    (mid-session writes are ignored by design). Amply's state is correct — config protective,
+    session/recovery closed, pending-until-replug hint shown — and the exposure is one charge cycle,
+    bounded by the plug session the user is already in. Deliberately NOT treated as a defect.
   - **Wireless charging and secondary users**: NOT RUN (gated to system user).
   - Sessions/boot-recovery/R8 smoke on real GrapheneOS hardware: pending the test build posted to issue #49.
 - **Xiaomi** — adaptive hardware enforcement of external writes unconfirmed; treat the adapter as provisional until

--- a/.claude/skills/oem-adapters/SKILL.md
+++ b/.claude/skills/oem-adapters/SKILL.md
@@ -90,6 +90,34 @@ states v1 can restore exactly (a supported fixed limit, or Unrestricted); AUTO/C
 an absent/malformed `enabled` decode to `Unknown(unrecognizedValue=true)` so a temporary session refuses rather than
 clobbering the user's native choice. Verified devices + coverage: see the qualification ledger (`device-qualification` skill).
 
+## GrapheneOS Adapter
+
+One live adapter (`grapheneos-chargelimit-v1`) for GrapheneOS's own "Limit to 80%" (Settings → Battery → Charging
+optimization). **ROM-identity adapter, ordered after the Lineage pair and BEFORE `pixel`** in `AdapterRegistry` —
+GrapheneOS ships only on Pixels, and the Pixel probe (any Google/Pixel*) would otherwise swallow the device as a
+matched-but-diagnostics-only stock Pixel. Gate: `DeviceInfo.isGrapheneOs` (core `app.grapheneos.*` packages via
+PackageManager `<queries>` — NO property/feature/fingerprint marker exists; verified empty on a real device) +
+`hasBatteryChargeLimit` (world-readable key presence — the capability signal, deliberately NOT part of identity) +
+system user. No lab adapter: a GrapheneOS build without the key stays on this adapter as diagnostics-only with
+`contributionWanted`.
+
+Single key `global battery_charge_limit`: `1` = fixed 80% cap (bypass charging; hard-wired, no threshold key) →
+`FixedLimit(80)`, `0` = off → `Unrestricted`; absent/other → `Unknown(unrecognizedValue=true)` (factory-absent
+semantics unverified — refuse, don't guess). WSS-writable, **no Shizuku**. SYNC_READBACK with read-back equality;
+session override = Unrestricted; protective default = FixedLimit(80); `reapply == apply` (no observer-poke — see
+below); reconnect gesture **unsupported** (structurally: the gesture's override write lands strictly after the
+replug broadcast, which the ROM has already sampled past).
+
+**The defining quirk: `policyLatchesAtPlug = true`.** GrapheneOS samples the key only at plug-session start; an
+external write updates the Settings UI live but has no hardware effect until the next unplug→replug (the native
+toggle applies live because Settings pokes the charging service directly — so the session watcher's
+cancel-without-restore on an observed external change stays correct). This drives the pending-until-replug
+verification state and the session engine's 30s replug grace window (see `rules/architecture.md`). While enforcing,
+the device reports stock-Pixel hardware state 4 (`EXTRA_CHARGING_STATUS`), which the adapter's own `decodeHardware`
+maps to `Verified(FixedLimit(80), BATTERY_HARDWARE)` — deliberately not shared with the Pixel decode, which also
+maps state 5 to an Adaptive profile this adapter cannot restore. Remote qualification (issue #49): see the
+`device-qualification` skill.
+
 ## Pixel Adapter
 
 Writes **only** two secure settings:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,10 @@
     <queries>
         <package android:name="moe.shizuku.privileged.api" />
         <package android:name="com.google.android.settings.intelligence" />
+        <!-- GrapheneOS identity: no property/feature/fingerprint marker exists, so detection resolves
+             these core OS packages (DeviceInfo.GRAPHENEOS_PACKAGES). -->
+        <package android:name="app.grapheneos.setupwizard" />
+        <package android:name="app.grapheneos.info" />
         <!-- LineageOS private settings provider — needed so resolveContentProvider/query aren't
              hidden by package visibility on API 30+ (the Lineage charge-control adapter reads it). -->
         <provider android:authorities="lineagesettings" />

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargeStatus.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargeStatus.kt
@@ -14,6 +14,8 @@ const val SETTLING_WINDOW_MILLIS = 15_000L
  */
 fun ChargingState.isSettling(now: Long): Boolean {
     val p = pending ?: return false
+    // A latched request has no clock to run down — surfaces show the replug hint, not a spinner.
+    if (p.awaitingReplug) return false
     val age = now - p.requestedAt
     if (age !in 0 until SETTLING_WINDOW_MILLIS) return false // expired, or clock moved backwards
     val obs = observation
@@ -24,3 +26,9 @@ fun ChargingState.isSettling(now: Long): Boolean {
 
 /** The policy a settling request is converging on, or null when nothing is pending. Surfaces choose their own copy. */
 fun ChargingState.settlingTarget(): ChargePolicy? = pending?.target
+
+/**
+ * True while a written policy is waiting for the user to unplug and replug before the charging
+ * hardware can pick it up (plug-latched adapters). Mutually exclusive with [isSettling].
+ */
+fun ChargingState.isAwaitingReplug(): Boolean = pending?.awaitingReplug == true

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingPreferences.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingPreferences.kt
@@ -35,6 +35,17 @@ internal data class PolicyState(
     @SerialName("lastRequestedAt") val lastRequestedAt: Long = 0L,
     @SerialName("protective") val protective: String? = null,
     @SerialName("lastPersistent") val lastPersistent: String? = null,
+    /**
+     * External-power state at the moment of the last request, recorded only by plug-latched adapters
+     * (null elsewhere). True means the write could not take effect yet and stays pending-until-replug.
+     */
+    @SerialName("lastRequestedPlugged") val lastRequestedPlugged: Boolean? = null,
+    /**
+     * Wall clock of the last observed unpowered moment while a plug-latched request was unresolved.
+     * A value after [lastRequestedAt] proves a plug transition happened since the write — the next
+     * plug session latches the configured value, so the request is resolved. 0 = never observed.
+     */
+    @SerialName("unpluggedSeenAt") val unpluggedSeenAt: Long = 0L,
 )
 
 /**
@@ -49,6 +60,8 @@ internal fun decodePolicyState(raw: String?, json: Json): PolicyState {
         lastRequestedAt = obj.longOrDefault("lastRequestedAt"),
         protective = obj.stringOrNull("protective"),
         lastPersistent = obj.stringOrNull("lastPersistent"),
+        lastRequestedPlugged = obj.booleanOrNull("lastRequestedPlugged"),
+        unpluggedSeenAt = obj.longOrDefault("unpluggedSeenAt"),
     )
 }
 
@@ -59,6 +72,9 @@ private fun JsonObject.stringOrNull(name: String): String? = primitiveOrNull(nam
 
 private fun JsonObject.longOrDefault(name: String, default: Long = 0L): Long =
     primitiveOrNull(name)?.takeUnless { it.isString }?.content?.toLongOrNull() ?: default
+
+private fun JsonObject.booleanOrNull(name: String): Boolean? =
+    primitiveOrNull(name)?.takeUnless { it.isString }?.content?.toBooleanStrictOrNull()
 
 @Singleton
 class ChargingPreferences @Inject constructor(
@@ -100,6 +116,7 @@ class ChargingPreferences @Inject constructor(
         policy: ChargePolicy,
         persistent: Boolean,
         nowMillis: Long = System.currentTimeMillis(),
+        plugged: Boolean? = null,
     ) {
         policyState.update { current ->
             current.copy(
@@ -111,13 +128,33 @@ class ChargingPreferences @Inject constructor(
                 } else {
                     current.protective
                 },
+                lastRequestedPlugged = plugged,
+                // Each request starts unresolved; a watermark from a previous request must not
+                // resolve this one (it can only postdate it if the wall clock moved backwards).
+                unpluggedSeenAt = 0L,
             )
+        }
+    }
+
+    /**
+     * Record that the device was observed without external power while a plug-latched request was
+     * unresolved. Monotonic and one-shot per request: once a watermark after the request exists,
+     * further observations change nothing (and cause no store write).
+     */
+    suspend fun recordUnpluggedSeen(nowMillis: Long = System.currentTimeMillis()) {
+        policyState.update { current ->
+            if (current.unpluggedSeenAt >= nowMillis) current else current.copy(unpluggedSeenAt = nowMillis)
         }
     }
 
     suspend fun lastRequestedNow(): ChargePolicy? = ChargePolicy.fromStableId(policyState.value().lastRequested)
 
     suspend fun lastRequestedAtNow(): Long = policyState.value().lastRequestedAt
+
+    /** Plug state at the last request (plug-latched adapters only); null = not recorded. */
+    suspend fun lastRequestedPluggedNow(): Boolean? = policyState.value().lastRequestedPlugged
+
+    suspend fun unpluggedSeenAtNow(): Long = policyState.value().unpluggedSeenAt
 
     suspend fun protectivePolicyNow(): ChargePolicy = policyState.value().protectivePolicy()
 

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -2,7 +2,10 @@ package eu.darken.amply.charging.core
 
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
+import android.os.BatteryManager
 import eu.darken.amply.R
+import eu.darken.amply.battery.core.BatteryReader
+import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.charging.core.access.AccessBackend
 import eu.darken.amply.charging.core.access.AccessResolver
 import eu.darken.amply.charging.core.access.AccessSnapshot
@@ -135,6 +138,7 @@ class ChargingRepository @Inject constructor(
     private val preferences: ChargingPreferences,
     private val shizukuController: ShizukuController,
     private val settleScheduler: SettleScheduler,
+    private val batteryReader: BatteryReader,
 ) {
     private val operationMutex = Mutex()
     // Separate from operationMutex: the ~25s grant deliberately never holds operationMutex (see below),
@@ -295,6 +299,16 @@ class ChargingRepository @Inject constructor(
             return ApplyResult(false, observation, "Setup required")
         }
 
+        // Plug-latched adapters: capture plug state BEFORE the write — it decides whether this write
+        // can take effect now (unplugged: the very next plug session samples it) or must wait for a
+        // replug. Null = plug state unreadable; treated as plugged, never claiming an effect that may
+        // not exist.
+        val pluggedAtWrite: Boolean? = if (adapter.policyLatchesAtPlug) {
+            batteryReader.read().plugged?.let { it != 0 }
+        } else {
+            null
+        }
+
         mutableState.value = state.value.copy(
             busy = true,
             message = caString { it.getString(R.string.charging_message_applying, policy.label.get(it)) },
@@ -323,7 +337,7 @@ class ChargingRepository @Inject constructor(
         // The physical write committed. Record it durably even under cancellation (the setting already
         // changed), and never strand busy=true nor lose the fact that the write landed.
         val now = System.currentTimeMillis()
-        withContext(NonCancellable) { preferences.recordRequested(policy, persistent, now) }
+        withContext(NonCancellable) { preferences.recordRequested(policy, persistent, now, plugged = pluggedAtWrite) }
         return try {
             val access = accessResolver.snapshot()
             val observation = when (adapter.verification) {
@@ -334,21 +348,30 @@ class ChargingRepository @Inject constructor(
             } as? ChargeObservation.Verified ?: ChargeObservation.LastRequested(policy)
             // Suppress the settling cue when there is no transition to wait for: sync-readback adapters
             // apply immediately, and async hardware may already report the target on a no-op re-apply.
-            val settled = when (adapter.verification) {
-                VerificationStrategy.SYNC_READBACK ->
-                    (observation as? ChargeObservation.Verified)?.policy == policy
-                VerificationStrategy.ASYNC_HARDWARE ->
-                    (adapter.readHardware(context) as? ChargeObservation.Verified)?.let {
-                        it.backend == BackendKind.BATTERY_HARDWARE && it.policy == policy
-                    } ?: false
+            // Plug-latched adapters are the exception: their readback only proves *configuration* —
+            // settled iff written unplugged (the next plug session samples it) or the hardware already
+            // reports the exact target (no-op re-apply while enforcing).
+            val settled = when {
+                adapter.policyLatchesAtPlug ->
+                    pluggedAtWrite == false || hardwareConfirms(adapter.readHardware(context), policy)
+                else -> when (adapter.verification) {
+                    VerificationStrategy.SYNC_READBACK ->
+                        (observation as? ChargeObservation.Verified)?.policy == policy
+                    VerificationStrategy.ASYNC_HARDWARE ->
+                        hardwareConfirms(adapter.readHardware(context), policy)
+                }
             }
-            val pending = if (settled) null else PendingRequest(policy, now)
+            val pending = if (settled) {
+                null
+            } else {
+                PendingRequest(policy, now, awaitingReplug = adapter.policyLatchesAtPlug)
+            }
             // Timing copy lives solely in the dashboard's settling line; these must stay accurate
             // when nothing is pending (sync-readback adapters, no-op re-applies).
-            val messageRes = if (observation is ChargeObservation.Verified) {
-                R.string.charging_message_verified
-            } else {
-                R.string.charging_message_requested
+            val messageRes = when {
+                pending?.awaitingReplug == true -> R.string.charging_message_applied_replug
+                observation is ChargeObservation.Verified -> R.string.charging_message_verified
+                else -> R.string.charging_message_requested
             }
             val message = caString { it.getString(messageRes, policy.label.get(it)) }
             mutableState.value = state.value.copy(
@@ -378,7 +401,7 @@ class ChargingRepository @Inject constructor(
             mutableState.value = state.value.copy(
                 busy = false,
                 observation = ChargeObservation.LastRequested(policy),
-                pending = PendingRequest(policy, now),
+                pending = PendingRequest(policy, now, awaitingReplug = fallbackAwaitsReplug(adapter, pluggedAtWrite)),
             )
             settleScheduler.schedule(now)
             throw e
@@ -391,7 +414,7 @@ class ChargingRepository @Inject constructor(
             mutableState.value = state.value.copy(
                 busy = false,
                 observation = observation,
-                pending = PendingRequest(policy, now),
+                pending = PendingRequest(policy, now, awaitingReplug = fallbackAwaitsReplug(adapter, pluggedAtWrite)),
                 message = message,
             )
             settleScheduler.schedule(now)
@@ -430,6 +453,17 @@ class ChargingRepository @Inject constructor(
         // Confirmation must come from the hardware, not the settings-level `observation` above: with Shizuku
         // or WSS the settings readback is `Verified` while the HAL is still converging, so pending would
         // otherwise never clear until the window expired.
+        val latches = adapter?.policyLatchesAtPlug == true
+        val battery = if (latches) batteryReader.read() else null
+        // Plug-latched adapters: an observed unpowered moment durably resolves an unresolved latched
+        // request — the plug session that sampled the old value is over, so the next one samples the
+        // new value. Persisted as a watermark so a later *plugged* refresh still knows it happened.
+        if (latches && battery?.plugged == 0 &&
+            preferences.lastRequestedPluggedNow() == true &&
+            preferences.unpluggedSeenAtNow() <= preferences.lastRequestedAtNow()
+        ) {
+            preferences.recordUnpluggedSeen(System.currentTimeMillis())
+        }
         val pending = computeRefreshPending(
             reqPolicy = preferences.lastRequestedNow(),
             reqAt = preferences.lastRequestedAtNow(),
@@ -437,6 +471,11 @@ class ChargingRepository @Inject constructor(
             observation = observation,
             hardware = adapter?.readHardware(context),
             verification = adapter?.verification ?: VerificationStrategy.ASYNC_HARDWARE,
+            policyLatchesAtPlug = latches,
+            reqPlugged = if (latches) preferences.lastRequestedPluggedNow() else null,
+            unpluggedSeenAt = if (latches) preferences.unpluggedSeenAtNow() else 0L,
+            battery = battery,
+            limitPercent = adapter?.latchedLimitPercent() ?: NO_LATCHED_LIMIT,
         )
         val built = ChargingState(
             device = DeviceInfo.current(context),
@@ -547,6 +586,18 @@ internal fun chooseSyncObservation(
  * successful read resolves the transition: a Verified value (matching OR different — a different value is a
  * native/competing change that has already taken effect) or a readable-but-unrecognized OEM value. Only a
  * genuinely unreadable/generic-unknown sync state keeps the request pending until the window expires.
+ *
+ * Plug-latched adapters ([policyLatchesAtPlug]) are a third case: their readback proves *configuration*, not
+ * effect, and there is no clock to run down — the ROM samples the key at the next plug-session start, whenever
+ * that is. Such a request resolves only on evidence (any one suffices):
+ *  1. it was written while confidently unplugged ([reqPlugged] == false) — the very next plug samples it;
+ *  2. an unpowered moment was observed and persisted since the write ([unpluggedSeenAt] > [reqAt]);
+ *  3. the [battery] evidence reports unpowered right now — same resolution, observed live;
+ *  4. the hardware reports the exact target (the configured limit is demonstrably enforcing);
+ *  5. limit-disproof, the only positive signal for a full-charge target: actively charging (or full)
+ *     ABOVE the adapter's cap ([limitPercent]) proves no limit session is enforcing. Below the cap the
+ *     evidence is genuinely ambiguous — a latched limit also reads "charging" while still climbing.
+ * Otherwise it stays pending with [PendingRequest.awaitingReplug] set, without expiry.
  */
 internal fun computeRefreshPending(
     reqPolicy: ChargePolicy?,
@@ -555,19 +606,57 @@ internal fun computeRefreshPending(
     observation: ChargeObservation,
     hardware: ChargeObservation?,
     verification: VerificationStrategy,
+    policyLatchesAtPlug: Boolean = false,
+    reqPlugged: Boolean? = null,
+    unpluggedSeenAt: Long = 0L,
+    battery: BatteryReadout? = null,
+    limitPercent: Int = NO_LATCHED_LIMIT,
 ): PendingRequest? {
     if (reqPolicy == null || reqAt <= 0L) return null
-    if (now - reqAt !in 0 until SETTLING_WINDOW_MILLIS) return null
     if (observation is ChargeObservation.Unsupported || observation is ChargeObservation.NeedsSetup) return null
+    if (policyLatchesAtPlug) {
+        // No clock guard: a backwards wall-clock jump only disables the watermark comparison (rule 2)
+        // until a fresh unplug is observed — clearing here would claim "applied" without evidence,
+        // which is the one error this state exists to prevent. Live evidence (rules 3–5) is unaffected.
+        val resolved = reqPlugged == false ||
+            unpluggedSeenAt > reqAt ||
+            battery?.plugged == 0 ||
+            hardwareConfirms(hardware, reqPolicy) ||
+            (reqPolicy.allowsFullCharge &&
+                battery != null && battery.onCharger &&
+                (battery.levelPercent ?: 0) > limitPercent &&
+                (battery.status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                    battery.status == BatteryManager.BATTERY_STATUS_FULL))
+        return if (resolved) null else PendingRequest(reqPolicy, reqAt, awaitingReplug = true)
+    }
+    if (now - reqAt !in 0 until SETTLING_WINDOW_MILLIS) return null
     val confirmed = when (verification) {
         VerificationStrategy.SYNC_READBACK ->
             observation is ChargeObservation.Verified ||
                 (observation is ChargeObservation.Unknown && observation.unrecognizedValue)
-        VerificationStrategy.ASYNC_HARDWARE ->
-            hardware is ChargeObservation.Verified &&
-                hardware.backend == BackendKind.BATTERY_HARDWARE &&
-                hardware.policy == reqPolicy
+        VerificationStrategy.ASYNC_HARDWARE -> hardwareConfirms(hardware, reqPolicy)
     }
     if (confirmed) return null
     return PendingRequest(reqPolicy, reqAt)
 }
+
+/** Sentinel for "no latched fixed-limit cap": no observable percent can exceed it, disabling limit-disproof. */
+internal const val NO_LATCHED_LIMIT = 100
+
+/** The cap a plug-latched adapter's limit-disproof rule compares against, from its protective default. */
+internal fun ChargingAdapter.latchedLimitPercent(): Int =
+    (defaultProtectivePolicy as? ChargePolicy.FixedLimit)?.percent ?: NO_LATCHED_LIMIT
+
+/** A BATTERY_HARDWARE-verified observation for exactly [target]. */
+internal fun hardwareConfirms(hardware: ChargeObservation?, target: ChargePolicy): Boolean =
+    hardware is ChargeObservation.Verified &&
+        hardware.backend == BackendKind.BATTERY_HARDWARE &&
+        hardware.policy == target
+
+/**
+ * Whether a degraded post-write fallback [PendingRequest] must carry the replug condition: only on a
+ * plug-latched adapter, and not when the write demonstrably happened unplugged (then the next plug
+ * samples it and the windowed cue is the honest one).
+ */
+private fun fallbackAwaitsReplug(adapter: ChargingAdapter, pluggedAtWrite: Boolean?): Boolean =
+    adapter.policyLatchesAtPlug && pluggedAtWrite != false

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -304,8 +304,10 @@ class ChargingRepository @Inject constructor(
         // Plug-latched adapters: capture plug state BEFORE the write — it decides whether this write
         // can take effect now (unplugged: the very next plug session samples it) or must wait for a
         // replug. Null = plug state unreadable; treated as plugged, never claiming an effect that may
-        // not exist.
-        val pluggedAtWrite: Boolean? = if (adapter.policyLatchesAtPlug) {
+        // not exist. Re-sampled AFTER the write below: a plug landing between this sample and the
+        // write's effect latches the OLD value, so "written unplugged" is only claimed when both
+        // samples agree.
+        val pluggedBeforeWrite: Boolean? = if (adapter.policyLatchesAtPlug) {
             batteryReader.read().plugged?.let { it != 0 }
         } else {
             null
@@ -337,7 +339,14 @@ class ChargingRepository @Inject constructor(
         }
 
         // The physical write committed. Record it durably even under cancellation (the setting already
-        // changed), and never strand busy=true nor lose the fact that the write landed.
+        // changed), and never strand busy=true nor lose the fact that the write landed. Unplugged is
+        // only trusted when the samples on BOTH sides of the write agree (see pluggedBeforeWrite).
+        val pluggedAtWrite: Boolean? = if (adapter.policyLatchesAtPlug) {
+            val after = runCatching { batteryReader.read().plugged?.let { it != 0 } }.getOrNull()
+            if (pluggedBeforeWrite == false && after == false) false else true
+        } else {
+            null
+        }
         val now = System.currentTimeMillis()
         withContext(NonCancellable) { preferences.recordRequested(policy, persistent, now, plugged = pluggedAtWrite) }
         return try {
@@ -617,6 +626,13 @@ internal fun computeRefreshPending(
     if (reqPolicy == null || reqAt <= 0L) return null
     if (observation is ChargeObservation.Unsupported || observation is ChargeObservation.NeedsSetup) return null
     if (policyLatchesAtPlug) {
+        // A configured readback that no longer matches the request is a native/competing change that
+        // has already taken effect (the native toggle applies live on these ROMs) — the request is
+        // obsolete and must not keep demanding a replug. Same for a readable-but-unrecognized value,
+        // which a session start refuses on. A MATCHING readback proves only configuration and never
+        // resolves — that is the whole point of this arm.
+        if (observation is ChargeObservation.Verified && observation.policy != reqPolicy) return null
+        if (observation is ChargeObservation.Unknown && observation.unrecognizedValue) return null
         // No clock guard: a backwards wall-clock jump only disables the watermark comparison (rule 2)
         // until a fresh unplug is observed — clearing here would claim "applied" without evidence,
         // which is the one error this state exists to prevent. Live evidence (rules 3–5) is unaffected.

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -120,6 +120,8 @@ data class ChargingState(
     val hasSupportLead: Boolean
         get() = adapterMatched ||
             device.hasProtectBattery ||
+            device.hasBatteryChargeLimit ||
+            device.isGrapheneOs ||
             device.hasLineageSettingsProvider ||
             device.hasChargingOptimization ||
             device.oneUiVersion != null ||

--- a/app/src/main/java/eu/darken/amply/charging/core/DeviceInfo.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/DeviceInfo.kt
@@ -2,6 +2,7 @@ package eu.darken.amply.charging.core
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.UserManager
@@ -70,12 +71,16 @@ data class DeviceInfo(
                 runCatching { it.packageManager.hasSystemFeature(FEATURE_LINEAGE_OS) }
                     .getOrDefault(false)
             } ?: false,
-            // GrapheneOS identity via its core system packages (see isGrapheneOs). getPackageInfo
+            // GrapheneOS identity via its core system packages (see isGrapheneOs). getApplicationInfo
             // needs the <queries> package entries but no permission; any one package suffices, so a
-            // renamed or slimmed component doesn't break detection. Fail closed.
+            // renamed or slimmed component doesn't break detection. The FLAG_SYSTEM check keeps a
+            // user-installed APK squatting on the name from spoofing ROM identity. Fail closed.
             hasGrapheneOsPackages = context?.let { ctx ->
                 GRAPHENEOS_PACKAGES.any { pkg ->
-                    runCatching { ctx.packageManager.getPackageInfo(pkg, 0) }.isSuccess
+                    runCatching {
+                        val flags = ctx.packageManager.getApplicationInfo(pkg, 0).flags
+                        flags and (ApplicationInfo.FLAG_SYSTEM or ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0
+                    }.getOrDefault(false)
                 }
             } ?: false,
             hasProtectBattery = context?.let {

--- a/app/src/main/java/eu/darken/amply/charging/core/DeviceInfo.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/DeviceInfo.kt
@@ -20,7 +20,9 @@ data class DeviceInfo(
     val oplusRomVersion: Int? = null,
     val lineageOsVersion: String? = null,
     val hasLineageFeature: Boolean = false,
+    val hasGrapheneOsPackages: Boolean = false,
     val hasProtectBattery: Boolean = false,
+    val hasBatteryChargeLimit: Boolean = false,
     val hasLineageSettingsProvider: Boolean = false,
     val isSystemUser: Boolean = true,
 ) {
@@ -33,6 +35,17 @@ data class DeviceInfo(
      * the feature still match, and so unit tests can construct either shape.
      */
     val isLineageOs: Boolean get() = hasLineageFeature || lineageOsVersion != null
+
+    /**
+     * Whether this is a GrapheneOS build. There is no system property, feature, or fingerprint
+     * marker at all — `getprop` on a real device contains no "graphene" and the fingerprint is
+     * stock-Google-shaped (verified on Pixel 9 Pro XL, build 2026080501) — so identity comes from
+     * the OS's own core `app.grapheneos.*` system packages, resolved via PackageManager with
+     * matching `<queries>` entries. Deliberately NOT OR-ed with [hasBatteryChargeLimit]: this
+     * adapter is registered ahead of the live Pixel adapter, and a future stock Pixel shipping a
+     * same-named key must not be swallowed as "GrapheneOS".
+     */
+    val isGrapheneOs: Boolean get() = hasGrapheneOsPackages
 
     companion object {
         fun current(context: Context? = null) = DeviceInfo(
@@ -57,9 +70,24 @@ data class DeviceInfo(
                 runCatching { it.packageManager.hasSystemFeature(FEATURE_LINEAGE_OS) }
                     .getOrDefault(false)
             } ?: false,
+            // GrapheneOS identity via its core system packages (see isGrapheneOs). getPackageInfo
+            // needs the <queries> package entries but no permission; any one package suffices, so a
+            // renamed or slimmed component doesn't break detection. Fail closed.
+            hasGrapheneOsPackages = context?.let { ctx ->
+                GRAPHENEOS_PACKAGES.any { pkg ->
+                    runCatching { ctx.packageManager.getPackageInfo(pkg, 0) }.isSuccess
+                }
+            } ?: false,
             hasProtectBattery = context?.let {
                 runCatching {
                     Settings.Global.getString(it.contentResolver, KEY_PROTECT_BATTERY) != null
+                }.getOrDefault(false)
+            } ?: false,
+            // GrapheneOS's charge-limit key, world-readable in `global`. Presence is the capability
+            // gate (the OS only ships the toggle where its implementation works); fail closed.
+            hasBatteryChargeLimit = context?.let {
+                runCatching {
+                    Settings.Global.getString(it.contentResolver, KEY_BATTERY_CHARGE_LIMIT) != null
                 }.getOrDefault(false)
             } ?: false,
             // Whether LineageOS's private settings provider is installed (the charge-control settings
@@ -84,6 +112,19 @@ data class DeviceInfo(
 
         // Shared with the Samsung adapters; duplicated here to keep DeviceInfo dependency-free.
         const val KEY_PROTECT_BATTERY = "protect_battery"
+
+        // Shared with the GrapheneOS adapter; duplicated here to keep DeviceInfo dependency-free.
+        const val KEY_BATTERY_CHARGE_LIMIT = "battery_charge_limit"
+
+        /**
+         * Core GrapheneOS system packages used as the identity signal — chosen for being integral
+         * to the OS (setup wizard, the built-in "Info" app) rather than user-removable extras.
+         * Each needs a `<queries>` package entry in the manifest.
+         */
+        val GRAPHENEOS_PACKAGES = listOf(
+            "app.grapheneos.setupwizard",
+            "app.grapheneos.info",
+        )
 
         /** Authority of LineageOS's private settings provider (`content://lineagesettings/...`). */
         const val LINEAGE_SETTINGS_AUTHORITY = "lineagesettings"

--- a/app/src/main/java/eu/darken/amply/charging/core/PendingRequest.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/PendingRequest.kt
@@ -9,4 +9,11 @@ package eu.darken.amply.charging.core
 data class PendingRequest(
     val target: ChargePolicy,
     val requestedAt: Long,
+    /**
+     * True when the write can only latch at the next plug transition (a
+     * [eu.darken.amply.charging.core.adapter.ChargingAdapter.policyLatchesAtPlug] adapter wrote while
+     * external power was present). Resolution is a *condition* — an observed unplug, or hardware
+     * evidence for the target — never the settling-window clock, so such a request carries no expiry.
+     */
+    val awaitingReplug: Boolean = false,
 )

--- a/app/src/main/java/eu/darken/amply/charging/core/access/shizuku/ChargingControlUserService.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/access/shizuku/ChargingControlUserService.kt
@@ -203,6 +203,8 @@ internal object SettingWritePolicy {
             "security_pc_secure_protect_mode_key" to setOf("0", "1"),
         ),
         "global" to mapOf(
+            // GrapheneOS charge limit (1 = fixed 80% cap; the ROM latches it at plug-session start)
+            "battery_charge_limit" to setOf("0", "1"),
             // Samsung battery protection
             "protect_battery" to setOf("0", "1", "3"),
             "battery_protection_threshold" to setOf("80", "85", "90", "95"),

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/AdapterRegistry.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/AdapterRegistry.kt
@@ -17,6 +17,7 @@ class AdapterRegistry @Inject constructor(
     @ApplicationContext private val context: Context,
     lineage: LineageChargingAdapter,
     lineageLab: LineageLabAdapter,
+    grapheneOs: GrapheneOsChargingAdapter,
     pixel: PixelChargingAdapter,
     samsungModern: SamsungModernChargingAdapter,
     samsungLegacy: SamsungLegacyChargingAdapter,
@@ -26,14 +27,17 @@ class AdapterRegistry @Inject constructor(
     onePlus: OnePlusChargingAdapter,
     onePlusLab: OnePlusLabAdapter,
 ) {
-    // LineageOS adapters come FIRST: a custom ROM changes charging control regardless of the OEM
+    // Custom-ROM adapters come FIRST: a custom ROM changes charging control regardless of the OEM
     // hardware underneath, so a LineageOS build on Samsung/Xiaomi/OnePlus/Pixel must be handled by the
     // Lineage live/lab pair — never swallowed by a manufacturer-based OEM adapter. lineageLab (any
     // LineageOS build) sits right after the live adapter (qualified codenames) and before all OEM
-    // adapters. Stock devices are not isLineageOs, so both skip and OEM matching proceeds.
+    // adapters. GrapheneOS is the same class and must precede `pixel` specifically: it ships only on
+    // Pixels, and the Pixel probe matches any Google/Pixel* device, which would swallow it as a
+    // matched-but-diagnostics-only stock Pixel. Stock devices match neither ROM identity, so all
+    // three skip and OEM matching proceeds.
     // Live adapters otherwise match only their verified scopes; same-OEM misses fall to the lab adapters.
     private val adapters = listOf(
-        lineage, lineageLab,
+        lineage, lineageLab, grapheneOs,
         pixel, samsungModern, samsungLegacy, samsungLab, xiaomi, xiaomiLab, onePlus, onePlusLab,
     )
 

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
@@ -66,6 +66,16 @@ interface ChargingAdapter {
      */
     val preferShizukuForWrites: Boolean get() = false
 
+    /**
+     * The ROM's charging service samples the configured policy only at the START of a plug session:
+     * a write made while external power is present has no hardware effect until the next
+     * unplug→replug (GrapheneOS). Reads stay synchronous ([VerificationStrategy.SYNC_READBACK] —
+     * the readback truthfully reports the *configured* value); this flag changes what a settled
+     * write means (pending-until-replug instead of the settling window) and arms the session
+     * engine's disconnect grace window.
+     */
+    val policyLatchesAtPlug: Boolean get() = false
+
     fun probe(device: DeviceInfo): AdapterSupport
     fun readHardware(context: Context): ChargeObservation? = null
     fun decodeHardware(chargingState: Int, plugged: Boolean): ChargeObservation? = null

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapter.kt
@@ -1,0 +1,168 @@
+package eu.darken.amply.charging.core.adapter
+
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import android.provider.Settings
+import eu.darken.amply.R
+import eu.darken.amply.charging.core.BackendKind
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.access.AccessBackend
+import eu.darken.amply.charging.core.access.SettingMutation
+import eu.darken.amply.charging.core.access.SettingNamespace
+import eu.darken.amply.common.ca.toCaString
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * GrapheneOS charging control via its own single key (remote qualification on a Pixel 9 Pro XL
+ * `komodo`, GrapheneOS 2026080501 / Android 17, issue #49; see the qualification ledger in
+ * .claude/skills/device-qualification/):
+ *
+ * - `global battery_charge_limit` — "Limit to 80%": `1` = hard 80% cap (with bypass charging),
+ *   `0` = off. Hard-wired to 80, no threshold key. World-readable; writes need only WSS.
+ *
+ * The defining quirk is [policyLatchesAtPlug]: GrapheneOS samples the key only at the START of a
+ * plug session. An external write updates the Settings UI live but has no hardware effect until
+ * the next unplug→replug (the native toggle applies live because Settings pokes the charging
+ * service directly — which also means an observed external change is a real, live user choice and
+ * the session watcher's cancel-without-restore stays correct). Consequences wired through the
+ * capability flag: pending-until-replug verification, the session replug grace window, and
+ * `reapply == apply` (there is no observer to re-trigger; the plug event is the trigger).
+ *
+ * While the limit is enforcing, the device reports the same hardware signal as stock Pixel
+ * (`EXTRA_CHARGING_STATUS` = 4, battery status NOT_CHARGING at the cap), so [decodeHardware]
+ * provides real enforcement evidence — the only proof that beats a merely-configured readback on
+ * this ROM. The reconnect gesture stays unsupported: its override write lands strictly after the
+ * replug broadcast, which this ROM has already sampled past.
+ *
+ * Identity is package-based ([DeviceInfo.isGrapheneOs]); capability is the key's presence — the OS
+ * ships the toggle exactly where its implementation works, and GrapheneOS is a single vendor on a
+ * narrow Pixel-only device set, so no codename allowlist is needed. Registered BEFORE the Pixel
+ * adapter, whose Google+Pixel probe would otherwise swallow every GrapheneOS device.
+ */
+@Singleton
+class GrapheneOsChargingAdapter @Inject constructor() : ChargingAdapter {
+    override val id = "grapheneos-chargelimit-v1"
+    override val displayName = R.string.adapter_name_grapheneos.toCaString()
+
+    override val supportedPolicies = listOf(
+        ChargePolicy.FixedLimit(LIMIT_PERCENT),
+        ChargePolicy.Unrestricted,
+    )
+
+    override val verification = VerificationStrategy.SYNC_READBACK
+    override val policyLatchesAtPlug = true
+
+    override val observedSettingUris
+        get() = listOf(Settings.Global.getUriFor(KEY_CHARGE_LIMIT))
+
+    override fun probe(device: DeviceInfo): AdapterSupport {
+        val matched = device.isGrapheneOs
+        return AdapterSupport(
+            matched = matched,
+            controlEnabled = matched && device.hasBatteryChargeLimit && device.isSystemUser,
+            detail = when {
+                !matched -> R.string.adapter_detail_requires_grapheneos
+                !device.hasBatteryChargeLimit -> R.string.adapter_detail_grapheneos_no_key
+                !device.isSystemUser -> R.string.adapter_detail_secondary_user
+                else -> R.string.adapter_detail_grapheneos_ready
+            },
+            // A GrapheneOS build without the key is exactly what the contribution wizard can map
+            // (e.g. a future release that moves or renames it).
+            contributionWanted = matched && !device.hasBatteryChargeLimit,
+        )
+    }
+
+    override suspend fun read(backend: AccessBackend): ChargeObservation {
+        val limit = backend.read(SettingNamespace.GLOBAL, KEY_CHARGE_LIMIT)
+        if (!limit.readable) {
+            return ChargeObservation.Unknown(
+                limit.error ?: R.string.charging_reason_settings_unreadable.toCaString(),
+            )
+        }
+        return when (limit.value) {
+            VALUE_OFF -> ChargeObservation.Verified(ChargePolicy.Unrestricted, backend.kind)
+            VALUE_LIMITED -> ChargeObservation.Verified(ChargePolicy.FixedLimit(LIMIT_PERCENT), backend.kind)
+            // Includes absence: the gate required the key, so a missing value mid-run is an anomaly,
+            // and the factory-absent state is unverified — refuse rather than guess (a session start
+            // refuses on this instead of overwriting a state it cannot restore).
+            else -> ChargeObservation.Unknown(
+                R.string.charging_reason_value_unrecognized.toCaString(
+                    KEY_CHARGE_LIMIT, limit.value.toString(),
+                ),
+                unrecognizedValue = true,
+            )
+        }
+    }
+
+    override suspend fun apply(policy: ChargePolicy, backend: AccessBackend): Boolean {
+        val value = when (policy) {
+            ChargePolicy.FixedLimit(LIMIT_PERCENT) -> VALUE_LIMITED
+            ChargePolicy.Unrestricted -> VALUE_OFF
+            else -> return false
+        }
+        if (!backend.write(SettingMutation(SettingNamespace.GLOBAL, KEY_CHARGE_LIMIT, value))) return false
+        // Command success does not guarantee the final configuration; require read-back equality.
+        // This verifies the CONFIGURED value only — enforcement follows at the next plug session
+        // (policyLatchesAtPlug), which the pending-until-replug state tracks.
+        val observed = read(backend)
+        return observed is ChargeObservation.Verified && observed.policy == policy
+    }
+
+    override fun readHardware(context: Context): ChargeObservation? {
+        val battery = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        val plugged = (battery?.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0) ?: 0) != 0
+        val chargingState = battery?.getIntExtra(BatteryManager.EXTRA_CHARGING_STATUS, STATE_INVALID)
+            ?: STATE_INVALID
+        return decodeHardware(chargingState, plugged)
+    }
+
+    /**
+     * Not shared with the Pixel decode on purpose: Pixel maps state 5 to a verified Adaptive
+     * profile, which this adapter neither supports nor could restore. Everything GrapheneOS was
+     * observed to report (4 while holding, 1 otherwise) decodes the same way as on stock Pixel.
+     */
+    override fun decodeHardware(chargingState: Int, plugged: Boolean): ChargeObservation? {
+        // Unplugged, the sticky broadcast retains its last powered value — never evidence.
+        if (!plugged) return null
+        return when (chargingState) {
+            STATE_LONG_LIFE -> ChargeObservation.Verified(
+                ChargePolicy.FixedLimit(LIMIT_PERCENT),
+                BackendKind.BATTERY_HARDWARE,
+            )
+            STATE_NORMAL -> ChargeObservation.Unknown(R.string.charging_reason_hw_normal.toCaString())
+            STATE_TOO_COLD -> ChargeObservation.Unknown(R.string.charging_reason_hw_too_cold.toCaString())
+            STATE_TOO_HOT -> ChargeObservation.Unknown(R.string.charging_reason_hw_too_hot.toCaString())
+            else -> ChargeObservation.Unknown(R.string.charging_reason_hw_unrecognized.toCaString())
+        }
+    }
+
+    override fun nativeSettingsIntent(context: Context): Intent {
+        // AOSP Settings → Battery hosts GrapheneOS's "Charging optimization"; never the Google
+        // Settings-Intelligence action, which does not exist on this ROM.
+        val specific = Intent(Intent.ACTION_POWER_USAGE_SUMMARY).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        return if (specific.resolveActivity(context.packageManager) != null) {
+            specific
+        } else {
+            Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+    }
+
+    companion object {
+        const val KEY_CHARGE_LIMIT = DeviceInfo.KEY_BATTERY_CHARGE_LIMIT
+        const val VALUE_LIMITED = "1"
+        const val VALUE_OFF = "0"
+        const val LIMIT_PERCENT = 80
+
+        // BatteryManager.EXTRA_CHARGING_STATUS values (hidden extra; same encoding as stock Pixel).
+        private const val STATE_INVALID = 0
+        private const val STATE_NORMAL = 1
+        private const val STATE_TOO_COLD = 2
+        private const val STATE_TOO_HOT = 3
+        private const val STATE_LONG_LIFE = 4
+    }
+}

--- a/app/src/main/java/eu/darken/amply/diagnostics/core/ContributionAllowlist.kt
+++ b/app/src/main/java/eu/darken/amply/diagnostics/core/ContributionAllowlist.kt
@@ -21,6 +21,8 @@ object ContributionAllowlist {
         SettingId(SettingNamespace.SECURE, "adaptive_charging_enabled") to setOf("0", "1"),
         // Xiaomi HyperOS charging protection
         SettingId(SettingNamespace.SECURE, "security_pc_secure_protect_mode_key") to setOf("0", "1"),
+        // GrapheneOS charging optimization
+        SettingId(SettingNamespace.GLOBAL, "battery_charge_limit") to setOf("0", "1"),
         // Samsung battery protection
         SettingId(SettingNamespace.GLOBAL, "protect_battery") to setOf("0", "1", "3"),
         SettingId(SettingNamespace.GLOBAL, "battery_protection_threshold") to setOf("80", "85", "90", "95"),

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionManager.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionManager.kt
@@ -100,6 +100,12 @@ class ChargeSessionManager @Inject constructor(
         )
         val result = repository.applyTemporary(overridePolicy)
         if (result.success) {
+            // Reconcile the persist-first conservative flag with the repository's authoritative
+            // post-write computation (it re-samples plug state around the write), so the session
+            // notification and the dashboard's pending hint can never disagree. Best-effort: a
+            // failure here leaves the conservative flag, which errs toward showing the hint.
+            val awaiting = repository.state.value.pending?.awaitingReplug == true
+            runCatching { sessionStore.setOverrideAwaitingReplug(awaiting) }
             result
         } else {
             // A two-key OEM transition can partially succeed. Keep recovery state unless the

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionManager.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionManager.kt
@@ -22,7 +22,10 @@ class ChargeSessionManager @Inject constructor(
 ) {
     private val mutex = Mutex()
 
-    suspend fun begin(nowMillis: Long = System.currentTimeMillis()): ApplyResult = mutex.withLock {
+    suspend fun begin(
+        nowMillis: Long = System.currentTimeMillis(),
+        pluggedAtStart: Boolean? = null,
+    ): ApplyResult = mutex.withLock {
         sessionStore.currentSession()?.let {
             return@withLock ApplyResult(
                 success = true,
@@ -90,6 +93,10 @@ class ChargeSessionManager @Inject constructor(
                 bootCount = bootCountProvider.current(),
                 createdAtMillis = nowMillis,
             ),
+            // Plug-latched adapter + started while plugged (or plug state unknown): the override
+            // write below cannot take effect until an unplug→replug, so the session must surface
+            // that instruction until the replug is observed.
+            overrideAwaitingReplug = adapter?.policyLatchesAtPlug == true && pluggedAtStart != false,
         )
         val result = repository.applyTemporary(overridePolicy)
         if (result.success) {
@@ -125,6 +132,10 @@ class ChargeSessionManager @Inject constructor(
     }
 
     suspend fun markConnected() = sessionStore.markConnected()
+
+    suspend fun markDisconnected(nowMillis: Long) = sessionStore.markDisconnected(nowMillis)
+
+    suspend fun markReplugged() = sessionStore.markReplugged()
 }
 
 fun ChargeObservation.policyOrNull(): ChargePolicy? = when (this) {

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -358,10 +358,12 @@ class ChargeSessionService : Service() {
                 }
                 SessionDecision.MARK_DISCONNECTED -> {
                     if (assessment != null) interruptionAssessor.onSessionDecision(assessment, decision)
-                    manager.markDisconnected(System.currentTimeMillis())
-                    // The plug session that ran the old policy just ended: the session override is
-                    // latched by whichever plug comes next, so its pending-until-replug resolves now.
+                    // Watermark FIRST: the plug session that ran the old policy just ended, so the
+                    // override's pending-until-replug resolves now. If the process dies between
+                    // these two writes, a re-delivered MARK_DISCONNECTED re-runs both; the reverse
+                    // order could lose the unplug evidence to a replug-side clear.
                     preferences.recordUnpluggedSeen()
+                    manager.markDisconnected(System.currentTimeMillis())
                     startAsForeground(
                         SessionNotifications.session(this, connected = true, graceWindow = true),
                     )
@@ -386,6 +388,9 @@ class ChargeSessionService : Service() {
                 }
                 SessionDecision.CONTINUE -> {
                     if (assessment != null) interruptionAssessor.onSessionDecision(assessment, decision)
+                    // A restarted process resuming mid-grace has no expiry nudge yet; without one an
+                    // expired window would wait for the next 30s poll before restoring.
+                    if (session.disconnectedAtMillis != null && !plugged) scheduleGraceExpiry()
                     startAsForeground(
                         SessionNotifications.session(
                             this,

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -68,6 +68,7 @@ class ChargeSessionService : Service() {
     private val quickGesture = QuickFullChargeGesture()
     private var monitorJob: Job? = null
     private var gestureExpiryJob: Job? = null
+    private var graceExpiryJob: Job? = null
     // Written under the dispatch lock, but read by the battery receiver/monitor loop outside it.
     @Volatile private var recoveryJob: Job? = null
     private var settingObserverRegistered = false
@@ -156,7 +157,7 @@ class ChargeSessionService : Service() {
             log(TAG) { "Starting a one-time full-charge session" }
             // A brand-new session in this process is not an interruption; drop any stale assessment.
             pendingSessionAssessment = null
-            val result = manager.begin()
+            val result = manager.begin(pluggedAtStart = currentPlugged())
             if (!result.success) {
                 log(TAG, Logging.Priority.WARN) { "Unable to start full-charge session: ${result.message}" }
                 if (fullChargeStore.currentSession() != null) SessionNotifications.showRecovery(this)
@@ -275,6 +276,30 @@ class ChargeSessionService : Service() {
         }
     }
 
+    /**
+     * Grace expiry isn't broadcast-driven: while unplugged nothing evaluates between the 30s polls,
+     * so without a nudge an expired window could keep the device unprotected for most of a poll
+     * period. Mirrors the gesture-expiry nudge: scheduled once when the window opens, generation-
+     * bound so a stale nudge can't leak into a later monitoring run.
+     */
+    private fun scheduleGraceExpiry() {
+        if (graceExpiryJob?.isActive == true) return
+        val generation = coordinator.currentGeneration
+        graceExpiryJob = scope.launch {
+            delay(SessionDecisionEngine.REPLUG_GRACE_MILLIS + 500)
+            coordinator.submitEvaluationForGeneration(
+                Evaluation(null, SystemClock.elapsedRealtime()),
+                generation,
+            )
+        }
+    }
+
+    /** Plug state from the sticky battery broadcast; null when it cannot be read right now. */
+    private fun currentPlugged(): Boolean? = runCatching {
+        registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+            ?.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
+    }.getOrNull()?.let { if (it < 0) null else it != 0 }
+
     // Callers must hold the dispatch lock — either via the evaluation consumer or a command handler.
     // observedAtElapsed is when the underlying battery state was seen, not when we process it.
     private suspend fun evaluateBattery(
@@ -306,6 +331,11 @@ class ChargeSessionService : Service() {
                 nowMillis = System.currentTimeMillis(),
                 plugged = plugged,
                 full = full,
+                replugGraceMillis = if (policyLatchesAtPlug) {
+                    SessionDecisionEngine.REPLUG_GRACE_MILLIS
+                } else {
+                    0L
+                },
             )
             when (decision) {
                 SessionDecision.MARK_CONNECTED -> {
@@ -316,6 +346,31 @@ class ChargeSessionService : Service() {
                     } else {
                         manager.markConnected()
                     }
+                    startAsForeground(
+                        SessionNotifications.session(
+                            this,
+                            connected = true,
+                            // Started while already plugged on a plug-latched adapter: this plug
+                            // session still runs the old policy — instruct the replug.
+                            awaitingReplug = session.overrideAwaitingReplug,
+                        ),
+                    )
+                }
+                SessionDecision.MARK_DISCONNECTED -> {
+                    if (assessment != null) interruptionAssessor.onSessionDecision(assessment, decision)
+                    manager.markDisconnected(System.currentTimeMillis())
+                    // The plug session that ran the old policy just ended: the session override is
+                    // latched by whichever plug comes next, so its pending-until-replug resolves now.
+                    preferences.recordUnpluggedSeen()
+                    startAsForeground(
+                        SessionNotifications.session(this, connected = true, graceWindow = true),
+                    )
+                    scheduleGraceExpiry()
+                }
+                SessionDecision.MARK_REPLUGGED -> {
+                    if (assessment != null) interruptionAssessor.onSessionDecision(assessment, decision)
+                    manager.markReplugged()
+                    graceExpiryJob?.cancel()
                     startAsForeground(SessionNotifications.session(this, connected = true))
                 }
                 // Restore is safety-critical and holds the dispatch lock: run it BEFORE any optional
@@ -332,7 +387,12 @@ class ChargeSessionService : Service() {
                 SessionDecision.CONTINUE -> {
                     if (assessment != null) interruptionAssessor.onSessionDecision(assessment, decision)
                     startAsForeground(
-                        SessionNotifications.session(this, connected = plugged || session.connectedSeen),
+                        SessionNotifications.session(
+                            this,
+                            connected = plugged || session.connectedSeen,
+                            awaitingReplug = session.overrideAwaitingReplug && plugged,
+                            graceWindow = session.disconnectedAtMillis != null && !plugged,
+                        ),
                     )
                 }
             }
@@ -526,6 +586,7 @@ class ChargeSessionService : Service() {
         coordinator.close()
         monitorJob?.cancel()
         gestureExpiryJob?.cancel()
+        graceExpiryJob?.cancel()
         unregisterSettingObserver()
         startAsForeground(SessionNotifications.recovering(this))
         recoveryJob = scope.launch {
@@ -603,6 +664,7 @@ class ChargeSessionService : Service() {
         log(TAG) { "Restoring the saved charging policy" }
         restoring = true
         coordinator.close()
+        graceExpiryJob?.cancel()
         unregisterSettingObserver()
         // Read the stable work id before the restore clears the session record, so a later upgrade of
         // a still-pending interruption event can be matched to it (the owner token is not stable).
@@ -701,6 +763,13 @@ class ChargeSessionService : Service() {
     private fun reconnectGestureAvailable() =
         adapterRegistry.select().adapter?.reconnectGestureSupported == true
 
+    // Resolved once per service lifetime: adapter selection is immutable device information, and
+    // per-tick selection is deliberately avoided in the session branch (see the note in
+    // evaluateBattery about DeviceInfo.current()'s cost under the dispatch lock).
+    private val policyLatchesAtPlug by lazy {
+        adapterRegistry.select().adapter?.policyLatchesAtPlug == true
+    }
+
     private fun stopMonitoring() {
         // Drop any un-consumed pickup assessment so it can never leak into a later session/monitor run.
         pendingSessionAssessment = null
@@ -710,6 +779,7 @@ class ChargeSessionService : Service() {
         coordinator.closeAndInvalidate()
         monitorJob?.cancel()
         gestureExpiryJob?.cancel()
+        graceExpiryJob?.cancel()
         quickGesture.reset()
         unregisterSettingObserver()
         stopForeground(STOP_FOREGROUND_REMOVE)

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/FullChargeStore.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/FullChargeStore.kt
@@ -143,6 +143,11 @@ class FullChargeStore @Inject constructor(
         sessionValue.update { it?.copy(disconnectedAtMillis = null, overrideAwaitingReplug = false) }
     }
 
+    /** Post-write reconciliation of the awaiting-replug hint (see ChargeSessionManager.begin). */
+    suspend fun setOverrideAwaitingReplug(awaiting: Boolean) {
+        sessionValue.update { it?.copy(overrideAwaitingReplug = awaiting) }
+    }
+
     /** Adopt the current process as the session's owner and flag CONNECTED in a single atomic edit. */
     suspend fun markConnectedAndAdopt(provenance: WorkProvenance) {
         sessionValue.update { it?.copy(connectedSeen = true, provenance = provenance) }

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/FullChargeStore.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/FullChargeStore.kt
@@ -46,6 +46,18 @@ data class ChargeSessionRecord(
      * interruption event ties back to this so a later restore can resolve it.
      */
     @SerialName("workId") val workId: String? = null,
+    /**
+     * Wall clock of the first disconnect observed inside a plug-latched adapter's replug grace
+     * window; null = not in grace. Persisted so the window survives process death (the expiry
+     * decision compares wall clocks, not elapsedRealtime).
+     */
+    @SerialName("disconnectedAtMillis") val disconnectedAtMillis: Long? = null,
+    /**
+     * Plug-latched adapters: the session override was written while external power was present, so
+     * the charging hardware has not picked it up and won't until an unplug→replug. Cleared by the
+     * replug ([FullChargeStore.markReplugged]); drives the "unplug and replug" session hint.
+     */
+    @SerialName("overrideAwaitingReplug") val overrideAwaitingReplug: Boolean = false,
 )
 
 /**
@@ -100,6 +112,7 @@ class FullChargeStore @Inject constructor(
         startedAtMillis: Long,
         workId: String? = null,
         provenance: WorkProvenance? = null,
+        overrideAwaitingReplug: Boolean = false,
     ) {
         sessionValue.update {
             ChargeSessionRecord(
@@ -108,12 +121,26 @@ class FullChargeStore @Inject constructor(
                 connectedSeen = false,
                 provenance = provenance,
                 workId = workId,
+                overrideAwaitingReplug = overrideAwaitingReplug,
             )
         }
     }
 
     suspend fun markConnected() {
         sessionValue.update { it?.copy(connectedSeen = true) }
+    }
+
+    /** Open the replug grace window: record the first disconnect a plug-latched session observed. */
+    suspend fun markDisconnected(nowMillis: Long) {
+        sessionValue.update { it?.copy(disconnectedAtMillis = nowMillis) }
+    }
+
+    /**
+     * A replug inside the grace window: the plug transition latched the session override, so both
+     * the window and the awaiting-replug hint end in one atomic edit.
+     */
+    suspend fun markReplugged() {
+        sessionValue.update { it?.copy(disconnectedAtMillis = null, overrideAwaitingReplug = false) }
     }
 
     /** Adopt the current process as the session's owner and flag CONNECTED in a single atomic edit. */

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/GestureBasis.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/GestureBasis.kt
@@ -28,8 +28,10 @@ import eu.darken.amply.charging.core.ChargePolicy
  * unrestricted decodes as [ChargeObservation.Unknown] on Pixel's powered NORMAL state, so a journal
  * fallback would keep claiming a limit that no longer exists. Only a [ChargeObservation.Verified]
  * fixed limit may be named. In practice nothing loses a percentage it legitimately had: only the
- * Pixel adapter implements `decodeHardware` and only Pixel supports the reconnect gesture, so an
- * unverified state simply falls back to the generic "while your charge limit is holding" copy.
+ * Pixel and GrapheneOS adapters implement `decodeHardware`, and only Pixel supports the reconnect
+ * gesture (GrapheneOS latches the setting at plug-session start, so the gesture's write-after-replug
+ * can never take effect there) — an unverified state simply falls back to the generic "while your
+ * charge limit is holding" copy.
  *
  * Accepted residual (arming only, distinct from the above): with any-level ON, inconclusive hardware
  * evidence plus a stale protective journal still arms even if charging was since set unrestricted

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/InterruptionDecision.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/InterruptionDecision.kt
@@ -31,8 +31,8 @@ object InterruptionDecisionEngine {
 
     /**
      * A session pickup that crossed a same-boot death warrants an event only when a restore was
-     * actually due (a `RESTORE_*` decision). `CONTINUE` / `MARK_CONNECTED` mean the session resumed
-     * unharmed — no event.
+     * actually due (a `RESTORE_*` decision). `CONTINUE` / `MARK_*` mean the session resumed
+     * unharmed — the replug-grace marks included, they just move the session along — no event.
      */
     fun shouldRecordForSession(survived: Boolean, sameBoot: Boolean, decision: SessionDecision): Boolean {
         if (!survived || !sameBoot) return false
@@ -42,7 +42,9 @@ object InterruptionDecisionEngine {
             SessionDecision.RESTORE_ARM_TIMEOUT,
             SessionDecision.RESTORE_SAFETY_TIMEOUT -> true
             SessionDecision.CONTINUE,
-            SessionDecision.MARK_CONNECTED -> false
+            SessionDecision.MARK_CONNECTED,
+            SessionDecision.MARK_DISCONNECTED,
+            SessionDecision.MARK_REPLUGGED -> false
         }
     }
 

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/SessionDecision.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/SessionDecision.kt
@@ -104,8 +104,16 @@ object SessionDecisionEngine {
                     SessionDecision.RESTORE_DISCONNECTED
                 else -> SessionDecision.CONTINUE
             }
+            // A replug only continues the session INSIDE the persisted window. A later replug (e.g.
+            // the process was dead through expiry) has already latched whatever the key held — no
+            // decision can affect the running plug session — so honoring the expired bound by
+            // restoring is the conservative end state: config protective, session closed.
             session.connectedSeen && plugged && session.disconnectedAtMillis != null ->
-                SessionDecision.MARK_REPLUGGED
+                if (nowMillis - session.disconnectedAtMillis in 0 until replugGraceMillis) {
+                    SessionDecision.MARK_REPLUGGED
+                } else {
+                    SessionDecision.RESTORE_DISCONNECTED
+                }
             !session.connectedSeen && plugged -> SessionDecision.MARK_CONNECTED
             !session.connectedSeen && !plugged && age >= armTimeoutMillis ->
                 SessionDecision.RESTORE_ARM_TIMEOUT

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/SessionDecision.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/SessionDecision.kt
@@ -53,6 +53,10 @@ object SessionStartDecider {
 enum class SessionDecision {
     CONTINUE,
     MARK_CONNECTED,
+    /** Plug-latched grace: first disconnect observed — open the replug window instead of restoring. */
+    MARK_DISCONNECTED,
+    /** Plug-latched grace: replug inside the window — the plug transition latched the override. */
+    MARK_REPLUGGED,
     RESTORE_FULL,
     RESTORE_DISCONNECTED,
     RESTORE_ARM_TIMEOUT,
@@ -63,6 +67,21 @@ object SessionDecisionEngine {
     const val ARM_TIMEOUT_MILLIS = 15 * 60 * 1000L
     const val SAFETY_TIMEOUT_MILLIS = 24 * 60 * 60 * 1000L
 
+    /**
+     * Replug grace for plug-latched adapters: how long after a disconnect the session keeps waiting
+     * for the replug that latches its override, instead of restoring immediately. Wall clock — the
+     * timestamp is persisted in the session record and must survive process death. Long enough to
+     * read a notification and re-seat a cable; bounded because during grace the device sits unplugged
+     * with the override *configured* — expiry restores, and a post-expiry replug then latches the
+     * already-restored protective value (fail safe).
+     */
+    const val REPLUG_GRACE_MILLIS = 30_000L
+
+    /**
+     * [replugGraceMillis] > 0 only for plug-latched adapters
+     * ([eu.darken.amply.charging.core.adapter.ChargingAdapter.policyLatchesAtPlug]); 0 disables the
+     * grace path entirely, keeping every other adapter's decisions unchanged.
+     */
     fun decide(
         session: ChargeSessionRecord,
         nowMillis: Long,
@@ -70,12 +89,23 @@ object SessionDecisionEngine {
         full: Boolean,
         armTimeoutMillis: Long = ARM_TIMEOUT_MILLIS,
         safetyTimeoutMillis: Long = SAFETY_TIMEOUT_MILLIS,
+        replugGraceMillis: Long = 0L,
     ): SessionDecision {
         val age = (nowMillis - session.startedAtMillis).coerceAtLeast(0)
         return when {
             full -> SessionDecision.RESTORE_FULL
             age >= safetyTimeoutMillis -> SessionDecision.RESTORE_SAFETY_TIMEOUT
-            session.connectedSeen && !plugged -> SessionDecision.RESTORE_DISCONNECTED
+            session.connectedSeen && !plugged -> when {
+                replugGraceMillis <= 0L -> SessionDecision.RESTORE_DISCONNECTED
+                session.disconnectedAtMillis == null -> SessionDecision.MARK_DISCONNECTED
+                // Expiry — or a backwards wall clock, which voids the window's evidence: fail safe
+                // and restore rather than waiting on a timestamp that proves nothing anymore.
+                nowMillis - session.disconnectedAtMillis !in 0 until replugGraceMillis ->
+                    SessionDecision.RESTORE_DISCONNECTED
+                else -> SessionDecision.CONTINUE
+            }
+            session.connectedSeen && plugged && session.disconnectedAtMillis != null ->
+                SessionDecision.MARK_REPLUGGED
             !session.connectedSeen && plugged -> SessionDecision.MARK_CONNECTED
             !session.connectedSeen && !plugged && age >= armTimeoutMillis ->
                 SessionDecision.RESTORE_ARM_TIMEOUT

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/SessionNotifications.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/SessionNotifications.kt
@@ -109,7 +109,18 @@ object SessionNotifications {
             .build()
     }
 
-    fun session(context: Context, connected: Boolean): Notification {
+    /**
+     * [awaitingReplug]: plug-latched adapter, override written while plugged — the cable must be
+     * re-seated before charging past the limit can start. [graceWindow]: that unplug happened and
+     * the session is waiting out the replug grace window. Mutually exclusive by construction
+     * (awaiting shows plugged, grace shows unplugged); grace wins if both are ever passed.
+     */
+    fun session(
+        context: Context,
+        connected: Boolean,
+        awaitingReplug: Boolean = false,
+        graceWindow: Boolean = false,
+    ): Notification {
         ensureChannels(context)
         val restoreIntent = Intent(context, ChargeSessionService::class.java).apply {
             action = ChargeSessionService.ACTION_RESTORE
@@ -130,10 +141,15 @@ object SessionNotifications {
             .setSmallIcon(R.drawable.ic_launcher_monochrome)
             .setContentTitle(context.getString(R.string.session_notification_title))
             .setContentText(
-                context.getString(
-                    if (connected) R.string.session_notification_active
-                    else R.string.session_notification_armed,
-                ),
+                when {
+                    graceWindow -> context.getString(
+                        R.string.session_notification_grace,
+                        SessionDecisionEngine.REPLUG_GRACE_MILLIS / 1000,
+                    )
+                    connected && awaitingReplug -> context.getString(R.string.session_notification_replug)
+                    connected -> context.getString(R.string.session_notification_active)
+                    else -> context.getString(R.string.session_notification_armed)
+                },
             )
             .setContentIntent(openPendingIntent)
             .setOngoing(true)

--- a/app/src/main/java/eu/darken/amply/main/core/DeviceSupportReporter.kt
+++ b/app/src/main/java/eu/darken/amply/main/core/DeviceSupportReporter.kt
@@ -39,12 +39,14 @@ data class DeviceSupportReport(
     val oplusRomVersion: Int?,
     val lineageOsVersion: String?,
     val isLineageOs: Boolean,
+    val isGrapheneOs: Boolean,
     /**
      * LineageOS charge-control probe: the bound provider plus the configured mode, which together bound what can
      * be said about HAL limit support. Null when unknown (not LineageOS, or no Shizuku) — never read as a negative.
      */
     val lineageHealth: LineageHealthSummary?,
     val hasProtectBattery: Boolean,
+    val hasBatteryChargeLimit: Boolean,
     val hasLineageSettingsProvider: Boolean,
     val adapterId: String?,
     val adapterMatched: Boolean,
@@ -89,8 +91,10 @@ class DeviceSupportReporter @Inject constructor(
             oplusRomVersion = device.oplusRomVersion,
             lineageOsVersion = device.lineageOsVersion,
             isLineageOs = device.isLineageOs,
+            isGrapheneOs = device.isGrapheneOs,
             lineageHealth = lineageHealth,
             hasProtectBattery = device.hasProtectBattery,
+            hasBatteryChargeLimit = device.hasBatteryChargeLimit,
             hasLineageSettingsProvider = device.hasLineageSettingsProvider,
             adapterId = selection.adapter?.id,
             adapterMatched = selection.support.matched,
@@ -123,7 +127,7 @@ internal fun sanitizeReportValue(value: String?, max: Int = 120): String {
 /** Deterministic, single stable schema. Keep field order fixed so reports are diff-friendly. */
 internal fun formatReport(report: DeviceSupportReport): String = buildString {
     appendLine("Amply device-support request")
-    appendLine("report_schema=8")
+    appendLine("report_schema=9")
     appendLine("app_version=${report.appVersionName} (${report.appVersionCode})")
     appendLine("distribution=${report.flavor}/${report.buildType}")
     appendLine("manufacturer=${report.manufacturer}")
@@ -143,6 +147,9 @@ internal fun formatReport(report: DeviceSupportReport): String = buildString {
     // and reads "none" even on LineageOS (see LineageOsDetector).
     appendLine("is_lineageos=${report.isLineageOs}")
     appendLine("lineageos_version=${report.lineageOsVersion ?: "none"}")
+    // Identity via core app.grapheneos.* packages — GrapheneOS exposes no property/feature marker
+    // and keeps a stock-shaped fingerprint (see DeviceInfo.isGrapheneOs).
+    appendLine("is_grapheneos=${report.isGrapheneOs}")
     // Observation, NOT a verdict. Provider selection branches on the configured mode before capability, so a
     // device in a time-based mode reports Deadline having never consulted either limit-capable provider. And
     // there is no negative case: Toggle also accepts MODE_LIMIT and enforces the cap itself. NOT_OBSERVED is
@@ -151,6 +158,7 @@ internal fun formatReport(report: DeviceSupportReport): String = buildString {
     appendLine("lineage_cc_mode=${report.lineageHealth?.mode ?: "unknown"}")
     appendLine("lineage_cc_limit_mechanism=${report.lineageHealth?.limitMechanism?.name ?: "UNKNOWN"}")
     appendLine("has_protect_battery=${report.hasProtectBattery}")
+    appendLine("has_battery_charge_limit=${report.hasBatteryChargeLimit}")
     appendLine("has_lineage_settings_provider=${report.hasLineageSettingsProvider}")
     appendLine("adapter=${report.adapterId ?: "none"}")
     appendLine("adapter_matched=${report.adapterMatched}")

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -64,6 +64,7 @@ import eu.darken.amply.charging.core.PendingRequest
 import eu.darken.amply.charging.core.SETTLING_WINDOW_MILLIS
 import eu.darken.amply.charging.core.access.AccessSnapshot
 import eu.darken.amply.charging.core.access.BackendStatus
+import eu.darken.amply.charging.core.isAwaitingReplug
 import eu.darken.amply.charging.core.isSettling
 import eu.darken.amply.charging.core.settlingTarget
 import eu.darken.amply.common.ca.CaString
@@ -391,7 +392,8 @@ private fun StatusCard(
     // away from the dashboard (opening the battery hub); this clock is presentation-only.
     var now by remember { mutableLongStateOf(System.currentTimeMillis()) }
     LaunchedEffect(pending) {
-        if (pending != null) {
+        // Awaiting-replug requests have no countdown to animate; the clock only serves isSettling.
+        if (pending != null && !pending.awaitingReplug) {
             val end = pending.requestedAt + SETTLING_WINDOW_MILLIS
             while (System.currentTimeMillis() < end) {
                 now = System.currentTimeMillis()
@@ -495,6 +497,16 @@ private fun StatusCard(
             Spacer(Modifier.height(4.dp))
             Text(
                 stringResource(R.string.dashboard_waiting_target, target),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.tertiary,
+            )
+        } else if (state.charging.isAwaitingReplug()) {
+            // Plug-latched adapters: the configured value is real (the title/readback above is
+            // honest) but the charging hardware only samples it at the next plug session. No
+            // spinner — there is no clock running down, only a condition the user completes.
+            Spacer(Modifier.height(4.dp))
+            Text(
+                stringResource(R.string.dashboard_waiting_replug),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.tertiary,
             )
@@ -1061,6 +1073,84 @@ private fun DashboardScreenApplyingPreview() = PreviewWrapper {
                 ),
                 observation = ChargeObservation.LastRequested(ChargePolicy.FixedLimit(80)),
                 pending = PendingRequest(ChargePolicy.FixedLimit(80), requestedAt),
+            ),
+        ),
+        adbCommand = "adb shell pm grant eu.darken.amply android.permission.WRITE_SECURE_SETTINGS",
+        onRefresh = {},
+        onSettings = {},
+        onStartFull = {},
+        onRestore = {},
+        onApply = {},
+        onQuickFullChargeChange = {},
+        onAlarmEnabledChange = {},
+        onAlarmTargetChange = {},
+        onFixNotifications = {},
+        onOpenBatteryHub = {},
+        onRetryCapture = {},
+        onPinWidget = {},
+        onAddTile = {},
+        onDismissQuickAccess = {},
+        onDismissInterruption = {},
+        onNativeSettings = {},
+        onOpenShizuku = {},
+        onAllowShizuku = {},
+        onGrantWss = {},
+        onCopyAdb = {},
+        onCopyWebUsbLink = {},
+        onPrepareSupportReport = {},
+        onCopySupportReport = {},
+        onOpenContribution = {},
+        onOpenSupportIssue = {},
+        onEmailSupport = {},
+        onHelp = {},
+    )
+}
+
+// GrapheneOS plug-latched pending: Unrestricted is configured (verified readback, green check) but
+// the hardware still holds the old 80% limit — the replug hint replaces the settling countdown.
+@AmplyPreview
+@Composable
+private fun DashboardScreenAwaitingReplugPreview() = PreviewWrapper {
+    DashboardScreen(
+        state = DashboardUiState(
+            onboardingComplete = true,
+            batteryReadout = BatteryReadout(
+                levelPercent = 80,
+                status = android.os.BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+                plugged = android.os.BatteryManager.BATTERY_PLUGGED_USB,
+                temperatureTenthsC = 276,
+            ),
+            charging = ChargingState(
+                device = DeviceInfo("Google", "Pixel 9 Pro XL", 37, "preview"),
+                adapterName = "GrapheneOS charge limit".toCaString(),
+                adapterId = "grapheneos-chargelimit-v1",
+                supportedPolicies = listOf(
+                    ChargePolicy.FixedLimit(80),
+                    ChargePolicy.Unrestricted,
+                ),
+                syncVerification = true,
+                controlEnabled = true,
+                access = AccessSnapshot(
+                    direct = BackendStatus(
+                        available = true,
+                        granted = true,
+                        detail = "Charge-control access granted".toCaString(),
+                    ),
+                    shizuku = BackendStatus(
+                        available = false,
+                        granted = false,
+                        detail = "Shizuku not installed".toCaString(),
+                    ),
+                ),
+                observation = ChargeObservation.Verified(
+                    ChargePolicy.Unrestricted,
+                    BackendKind.DIRECT_WSS,
+                ),
+                pending = PendingRequest(
+                    ChargePolicy.Unrestricted,
+                    requestedAt = 1L,
+                    awaitingReplug = true,
+                ),
             ),
         ),
         adbCommand = "adb shell pm grant eu.darken.amply android.permission.WRITE_SECURE_SETTINGS",

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
@@ -225,7 +225,10 @@ class DashboardViewModel @Inject constructor(
             .map { it.pending }
             .distinctUntilChanged()
             .flatMapLatest { pending ->
-                if (pending == null) {
+                if (pending == null || pending.awaitingReplug) {
+                    // Awaiting-replug requests have no deadline: resolution comes from evidence at
+                    // the next refresh (MainActivity's battery receiver fires one on every plug
+                    // transition while the UI is visible; the SettleRefreshWorker covers the rest).
                     emptyFlow()
                 } else {
                     flow {

--- a/app/src/main/java/eu/darken/amply/main/ui/tile/ChargeTileService.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/tile/ChargeTileService.kt
@@ -12,6 +12,7 @@ import androidx.core.content.ContextCompat
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.amply.R
 import eu.darken.amply.charging.core.ChargingRepository
+import eu.darken.amply.charging.core.isAwaitingReplug
 import eu.darken.amply.common.debug.logging.Logging
 import eu.darken.amply.common.debug.logging.log
 import eu.darken.amply.common.debug.logging.logTag
@@ -55,7 +56,13 @@ class ChargeTileService : TileService() {
                     render(
                         active = sessionActive,
                         available = state.canApply,
-                        detail = (state.access?.label ?: state.adapterName).get(this@ChargeTileService),
+                        // Plug-latched pending beats the static access/adapter label: opening QS is
+                        // the tile's refresh cadence, so this is exactly when the hint is fresh.
+                        detail = if (state.isAwaitingReplug()) {
+                            getString(R.string.tile_replug_hint)
+                        } else {
+                            (state.access?.label ?: state.adapterName).get(this@ChargeTileService)
+                        },
                     )
                 }
             }

--- a/app/src/main/java/eu/darken/amply/main/ui/widget/AmplyWidget.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/widget/AmplyWidget.kt
@@ -217,10 +217,12 @@ private fun statusLine(
     requestedTarget: ChargePolicy?,
 ): String {
     if (sessionActive) {
-        return if (settling) {
-            context.getString(R.string.widget_status_charging_waiting)
-        } else {
-            context.getString(R.string.widget_status_charging_once)
+        return when {
+            settling -> context.getString(R.string.widget_status_charging_waiting)
+            // Plug-latched adapters: the session exists but its override hasn't latched — claiming
+            // "charging to 100% once" would be false until the user re-seats the cable.
+            awaitingReplug -> context.getString(R.string.widget_status_charging_replug)
+            else -> context.getString(R.string.widget_status_charging_once)
         }
     }
     if (settling) {

--- a/app/src/main/java/eu/darken/amply/main/ui/widget/AmplyWidget.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/widget/AmplyWidget.kt
@@ -51,6 +51,7 @@ import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.ChargingPreferences
 import eu.darken.amply.charging.core.ChargingRepository
 import eu.darken.amply.charging.core.ChargingState
+import eu.darken.amply.charging.core.isAwaitingReplug
 import eu.darken.amply.charging.core.isSettling
 import eu.darken.amply.charging.core.settlingTarget
 import eu.darken.amply.fullcharge.core.FullChargeStore
@@ -105,7 +106,14 @@ class AmplyWidget : GlanceAppWidget() {
             val requestedTarget by preferences.lastRequested.collectAsState(initial = initialRequested)
 
             val display = widgetDisplay(state, sessionActive = session != null, now = System.currentTimeMillis())
-            val status = statusLine(context, display.sessionActive, display.settling, state, requestedTarget)
+            val status = statusLine(
+                context,
+                display.sessionActive,
+                display.settling,
+                display.awaitingReplug,
+                state,
+                requestedTarget,
+            )
             val showBrand = display.steady && LocalSize.current.width >= BRAND_MIN_WIDTH
             val titleStyle = TextStyle(color = TITLE_COLOR, fontWeight = FontWeight.Bold)
             Column(
@@ -172,21 +180,25 @@ class AmplyWidget : GlanceAppWidget() {
 
 /**
  * Structural (context-free) widget display derivation, kept pure so the branches are JVM-unit-testable.
- * `sessionActive` wins over everything; `settling` is the pending-request window; `steady` (a plain resting
- * policy, nothing in flight) is the only state that shows the brand mark.
+ * `sessionActive` wins over everything; `settling` is the pending-request window; `awaitingReplug` is a
+ * plug-latched adapter's condition-based pending (mutually exclusive with settling by construction);
+ * `steady` (a plain resting policy, nothing in flight) is the only state that shows the brand mark.
  */
 internal data class WidgetDisplay(
     val sessionActive: Boolean,
     val settling: Boolean,
+    val awaitingReplug: Boolean,
     val steady: Boolean,
 )
 
 internal fun widgetDisplay(state: ChargingState, sessionActive: Boolean, now: Long): WidgetDisplay {
     val settling = state.isSettling(now)
+    val awaitingReplug = state.isAwaitingReplug()
     return WidgetDisplay(
         sessionActive = sessionActive,
         settling = settling,
-        steady = !sessionActive && !settling,
+        awaitingReplug = awaitingReplug,
+        steady = !sessionActive && !settling && !awaitingReplug,
     )
 }
 
@@ -200,6 +212,7 @@ private fun statusLine(
     context: Context,
     sessionActive: Boolean,
     settling: Boolean,
+    awaitingReplug: Boolean,
     state: ChargingState,
     requestedTarget: ChargePolicy?,
 ): String {
@@ -213,6 +226,14 @@ private fun statusLine(
     if (settling) {
         return context.getString(
             R.string.widget_status_waiting_suffix,
+            widgetLabel(context, state.settlingTarget() ?: requestedTarget),
+        )
+    }
+    // Plug-latched adapters: the value is configured (label it) but only takes effect at the next
+    // plug session. May linger while nothing observes a replug; never claims the reverse error.
+    if (awaitingReplug) {
+        return context.getString(
+            R.string.widget_status_replug_suffix,
             widgetLabel(context, state.settlingTarget() ?: requestedTarget),
         )
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,8 @@
     <string name="session_notification_title" formatted="false">Charging to 100% once</string>
     <string name="session_notification_armed">Waiting for a charger</string>
     <string name="session_notification_active">Charge protection returns at 100% or when unplugged.</string>
+    <string name="session_notification_replug">Unplug and replug the charger to start charging fully</string>
+    <string name="session_notification_grace">Plug back in within %1$d seconds to charge fully</string>
     <string name="session_notification_restore">Restore now</string>
     <string name="gesture_channel_name">Reconnect gesture</string>
     <string name="gesture_channel_description" formatted="false">Shows while the reconnect-for-100% gesture is watching for a replug</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,6 +81,7 @@
     <string name="charging_message_applying">Applying %1$s…</string>
     <string name="charging_message_write_failed">Write failed</string>
     <string name="charging_message_verified">%1$s setting verified</string>
+    <string name="charging_message_applied_replug">%1$s set — takes effect after you unplug and replug</string>
     <string name="charging_message_requested">%1$s requested</string>
     <string name="charging_message_shizuku_granted">Shizuku permission granted</string>
     <string name="charging_message_shizuku_denied">Shizuku permission was not granted</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -531,6 +531,7 @@
     <string name="widget_button_full_once" formatted="false">1×100%</string>
     <string name="widget_status_charging_waiting" formatted="false">Charging to 100% · waiting…</string>
     <string name="widget_status_charging_once" formatted="false">Charging to 100% once</string>
+    <string name="widget_status_charging_replug" formatted="false">1×100% · replug to start</string>
     <string name="widget_status_waiting_suffix">%1$s · waiting for system…</string>
     <string name="widget_status_replug_suffix">%1$s · replug to apply</string>
     <string name="widget_label_limited">Limited to %1$d%%</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="tile_label" formatted="false">100% once</string>
     <string name="tile_active">Restore limit</string>
     <string name="tile_override_active">Temporary override active</string>
+    <string name="tile_replug_hint">Replug to apply</string>
     <string name="widget_description">Amply charge controls</string>
     <string name="session_channel_name">Full charge and restore</string>
     <string name="session_channel_description" formatted="false">Shows while Amply is allowing a full charge, and while it restores your limit afterwards</string>
@@ -373,6 +374,7 @@
     <string name="dashboard_applying">Applying…</string>
     <string name="dashboard_device_line">%1$s · Android API %2$d</string>
     <string name="dashboard_waiting_target">Waiting for the system to switch to %1$s — this can take about 15 seconds…</string>
+    <string name="dashboard_waiting_replug">Takes effect the next time you unplug and replug the charger</string>
     <string name="dashboard_settling_fallback_target">the new policy</string>
     <string name="dashboard_session_once_title" formatted="false">Charging to 100% once</string>
     <string name="dashboard_session_returns">%1$s will return automatically at 100%% or when you unplug.</string>
@@ -530,6 +532,7 @@
     <string name="widget_status_charging_waiting" formatted="false">Charging to 100% · waiting…</string>
     <string name="widget_status_charging_once" formatted="false">Charging to 100% once</string>
     <string name="widget_status_waiting_suffix">%1$s · waiting for system…</string>
+    <string name="widget_status_replug_suffix">%1$s · replug to apply</string>
     <string name="widget_label_limited">Limited to %1$d%%</string>
     <string name="widget_label_unlimited" formatted="false">Unlimited (100%)</string>
     <string name="widget_label_adaptive">Adaptive charging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="adapter_name_oneplus">OnePlus/Oppo/Realme (diagnostics)</string>
     <string name="adapter_name_oplus_protection">ColorOS charging protection</string>
     <string name="adapter_name_lineageos">LineageOS charging control</string>
+    <string name="adapter_name_grapheneos">GrapheneOS charge limit</string>
 
     <!-- Adapter support detail (why a device is or isn\'t controllable) -->
     <string name="adapter_detail_requires_pixel">Requires a supported Google Pixel phone</string>
@@ -134,6 +135,9 @@
     <string name="adapter_detail_xiaomi_ready">Xiaomi charging protection detected; changes apply immediately</string>
     <string name="adapter_detail_requires_oplus">Requires a OnePlus, Oppo, or Realme device on ColorOS 15</string>
     <string name="adapter_detail_oplus_ready">ColorOS charging protection detected; control requires Shizuku</string>
+    <string name="adapter_detail_requires_grapheneos">Requires GrapheneOS</string>
+    <string name="adapter_detail_grapheneos_no_key">GrapheneOS detected, but its charge-limit setting is not present on this build</string>
+    <string name="adapter_detail_grapheneos_ready">GrapheneOS charge limit detected — changes take effect when the charger is reconnected</string>
     <string name="adapter_detail_requires_lineageos">Requires a qualified LineageOS device</string>
     <string name="adapter_detail_lineageos_no_provider">LineageOS charging control is not available on this build</string>
     <string name="adapter_detail_lineageos_ready">LineageOS charging control detected; control requires Shizuku</string>

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargeStatusTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargeStatusTest.kt
@@ -55,4 +55,24 @@ class ChargeStatusTest {
         state().settlingTarget() shouldBe target
         state(pending = null).settlingTarget() shouldBe null
     }
+
+    // --- awaitingReplug: a latched request is a condition, not a countdown ---
+
+    @Test
+    fun `an awaiting-replug request is never settling`() {
+        val s = state(pending = PendingRequest(target, t0, awaitingReplug = true))
+        s.isSettling(t0 + 5_000) shouldBe false
+    }
+
+    @Test
+    fun `isAwaitingReplug mirrors the pending flag`() {
+        state(pending = PendingRequest(target, t0, awaitingReplug = true)).isAwaitingReplug() shouldBe true
+        state().isAwaitingReplug() shouldBe false
+        state(pending = null).isAwaitingReplug() shouldBe false
+    }
+
+    @Test
+    fun `settlingTarget still reports an awaiting-replug target`() {
+        state(pending = PendingRequest(target, t0, awaitingReplug = true)).settlingTarget() shouldBe target
+    }
 }

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingPreferencesTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingPreferencesTest.kt
@@ -249,6 +249,62 @@ class ChargingPreferencesTest {
         collectors.forEach { it.cancel() }
     }
 
+    // --- Plug-latched request bookkeeping ---------------------------------------------------------
+
+    @Test
+    fun `plug state at request is recorded and null when not provided`() = runTest {
+        preferences.recordRequested(ChargePolicy.Unrestricted, persistent = false, nowMillis = 1L, plugged = true)
+        preferences.lastRequestedPluggedNow() shouldBe true
+
+        preferences.recordRequested(ChargePolicy.Unrestricted, persistent = false, nowMillis = 2L)
+        preferences.lastRequestedPluggedNow() shouldBe null
+    }
+
+    @Test
+    fun `a new request resets the unplugged watermark`() = runTest {
+        preferences.recordRequested(ChargePolicy.Unrestricted, persistent = false, nowMillis = 1L, plugged = true)
+        preferences.recordUnpluggedSeen(nowMillis = 5L)
+        preferences.unpluggedSeenAtNow() shouldBe 5L
+
+        // The old watermark must not resolve the next request.
+        preferences.recordRequested(ChargePolicy.FixedLimit(80), persistent = false, nowMillis = 10L, plugged = true)
+        preferences.unpluggedSeenAtNow() shouldBe 0L
+    }
+
+    @Test
+    fun `the unplugged watermark is monotonic`() = runTest {
+        preferences.recordUnpluggedSeen(nowMillis = 10L)
+        preferences.recordUnpluggedSeen(nowMillis = 5L)
+        preferences.unpluggedSeenAtNow() shouldBe 10L
+    }
+
+    @Test
+    fun `a legacy record without the latched fields reads their defaults`() = runTest {
+        writeRawRecord(
+            """{"lastRequested":"adaptive","lastRequestedAt":5,""" +
+                """"protective":"fixed:90","lastPersistent":"adaptive"}""",
+        )
+
+        preferences.lastRequestedPluggedNow() shouldBe null
+        preferences.unpluggedSeenAtNow() shouldBe 0L
+        // …and the pre-existing fields still decode.
+        preferences.lastRequestedNow() shouldBe ChargePolicy.Adaptive
+        preferences.protectivePolicyNow() shouldBe ChargePolicy.FixedLimit(90)
+    }
+
+    @Test
+    fun `wrong-typed latched fields fall back alone`() = runTest {
+        writeRawRecord(
+            """{"lastRequested":"adaptive","lastRequestedAt":5,""" +
+                """"lastRequestedPlugged":"yes","unpluggedSeenAt":"soon"}""",
+        )
+
+        preferences.lastRequestedPluggedNow() shouldBe null
+        preferences.unpluggedSeenAtNow() shouldBe 0L
+        preferences.lastRequestedNow() shouldBe ChargePolicy.Adaptive
+        preferences.lastRequestedAtNow() shouldBe 5L
+    }
+
     /** Writes the stored JSON directly, standing in for a corrupt or foreign-written record. */
     private suspend fun writeRawRecord(json: String) {
         appDataStore.store.edit { it[stringPreferencesKey("policy.v2")] = json }

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryPersistenceTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryPersistenceTest.kt
@@ -18,6 +18,7 @@ import eu.darken.amply.charging.core.access.ShizukuSettingsBackend
 import eu.darken.amply.charging.core.access.shizuku.ShizukuController
 import eu.darken.amply.charging.core.access.shizuku.ShizukuInstallationDetector
 import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.adapter.GrapheneOsChargingAdapter
 import eu.darken.amply.charging.core.adapter.LineageChargingAdapter
 import eu.darken.amply.charging.core.adapter.LineageLabAdapter
 import eu.darken.amply.charging.core.adapter.OnePlusChargingAdapter
@@ -103,6 +104,7 @@ class ChargingRepositoryPersistenceTest {
                 context = context,
                 lineage = LineageChargingAdapter(LineageSettingsClient(context)),
                 lineageLab = LineageLabAdapter(),
+                grapheneOs = GrapheneOsChargingAdapter(),
                 pixel = PixelChargingAdapter(),
                 samsungModern = SamsungModernChargingAdapter(),
                 samsungLegacy = SamsungLegacyChargingAdapter(),

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryPersistenceTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryPersistenceTest.kt
@@ -10,6 +10,7 @@ import android.content.pm.ResolveInfo
 import android.os.Build
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.battery.core.BatteryReader
 import eu.darken.amply.charging.core.access.AccessResolver
 import eu.darken.amply.charging.core.access.DirectSettingsBackend
 import eu.darken.amply.charging.core.access.LineageSettingsClient
@@ -121,6 +122,7 @@ class ChargingRepositoryPersistenceTest {
             settleScheduler = object : SettleScheduler {
                 override fun schedule(requestedAtMillis: Long) = Unit
             },
+            batteryReader = BatteryReader(context),
         )
     }
 

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingStateSupportLeadTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingStateSupportLeadTest.kt
@@ -70,4 +70,18 @@ class ChargingStateSupportLeadTest {
         ChargingState(device = device(hasProtectBattery = true), adapterId = null).hasSupportLead shouldBe true
         ChargingState(device = device(hasChargingOptimization = true), adapterId = null).hasSupportLead shouldBe true
     }
+
+    @Test
+    fun `grapheneos identity or its charge-limit key is a lead even when no adapter matched`() {
+        // A future ROM shipping the same key under a non-Google brand reaches the catch-all but
+        // still carries an actionable lead; same for GrapheneOS identity without the key.
+        ChargingState(
+            device = device().copy(hasBatteryChargeLimit = true),
+            adapterId = null,
+        ).hasSupportLead shouldBe true
+        ChargingState(
+            device = device().copy(hasGrapheneOsPackages = true),
+            adapterId = null,
+        ).hasSupportLead shouldBe true
+    }
 }

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingSyncReadTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingSyncReadTest.kt
@@ -2,6 +2,7 @@ package eu.darken.amply.charging.core
 
 import android.content.Context
 import android.content.Intent
+import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.charging.core.access.AccessBackend
 import eu.darken.amply.charging.core.access.BackendStatus
 import eu.darken.amply.charging.core.access.SettingMutation
@@ -22,6 +23,13 @@ class ChargingSyncReadTest {
     private val target = ChargePolicy.FixedLimit(80)
     private val other = ChargePolicy.Unrestricted
     private val t0 = 1_000_000L
+
+    private companion object {
+        // android.os.BatteryManager.BATTERY_STATUS_* — inlined so this stays a plain JVM test.
+        const val STATUS_CHARGING = 2
+        const val STATUS_NOT_CHARGING = 4
+        const val STATUS_FULL = 5
+    }
 
     private fun verified(policy: ChargePolicy, backend: BackendKind) = ChargeObservation.Verified(policy, backend)
     private fun unrecognized() = ChargeObservation.Unknown("weird".toCaString(), unrecognizedValue = true)
@@ -190,6 +198,115 @@ class ChargingSyncReadTest {
     @Test
     fun `async ignores settings-only verification without a hardware signal`() {
         async(verified(target, BackendKind.SHIZUKU), null) shouldBe PendingRequest(target, t0)
+    }
+
+    // --- computeRefreshPending: plug-latched condition (no clock, resolves only on evidence) ---
+
+    private fun latched(
+        reqPolicy: ChargePolicy = other, // Unrestricted: the direction with no hardware confirmation
+        reqPlugged: Boolean? = true,
+        unpluggedSeenAt: Long = 0L,
+        battery: BatteryReadout? = null,
+        hardware: ChargeObservation? = null,
+        now: Long = t0 + 5_000,
+        limitPercent: Int = 80,
+    ) = computeRefreshPending(
+        reqPolicy = reqPolicy,
+        reqAt = t0,
+        now = now,
+        observation = verified(reqPolicy, BackendKind.DIRECT_WSS), // readback always confirms the config
+        hardware = hardware,
+        verification = VerificationStrategy.SYNC_READBACK,
+        policyLatchesAtPlug = true,
+        reqPlugged = reqPlugged,
+        unpluggedSeenAt = unpluggedSeenAt,
+        battery = battery,
+        limitPercent = limitPercent,
+    )
+
+    private fun pluggedBattery(percent: Int? = null, status: Int? = null) =
+        BatteryReadout(levelPercent = percent, status = status, plugged = 2 /* USB */)
+
+    @Test
+    fun `latched written while plugged stays pending despite a verified readback`() {
+        latched() shouldBe PendingRequest(other, t0, awaitingReplug = true)
+    }
+
+    @Test
+    fun `latched pending has no expiry`() {
+        latched(now = t0 + SETTLING_WINDOW_MILLIS * 100) shouldBe PendingRequest(other, t0, awaitingReplug = true)
+    }
+
+    @Test
+    fun `latched written unplugged is settled immediately`() {
+        latched(reqPlugged = false) shouldBe null
+    }
+
+    @Test
+    fun `latched unknown plug state at write is treated as plugged`() {
+        latched(reqPlugged = null) shouldBe PendingRequest(other, t0, awaitingReplug = true)
+    }
+
+    @Test
+    fun `latched resolves once an unplug was observed after the write`() {
+        latched(unpluggedSeenAt = t0 + 1) shouldBe null
+    }
+
+    @Test
+    fun `latched watermark at exactly the request time does not resolve`() {
+        latched(unpluggedSeenAt = t0) shouldBe PendingRequest(other, t0, awaitingReplug = true)
+    }
+
+    @Test
+    fun `latched resolves on live unpowered evidence`() {
+        latched(battery = BatteryReadout(plugged = 0)) shouldBe null
+    }
+
+    @Test
+    fun `latched unreported plug state is not unpowered evidence`() {
+        latched(battery = BatteryReadout(plugged = null)) shouldBe PendingRequest(other, t0, awaitingReplug = true)
+    }
+
+    @Test
+    fun `latched limit target resolves on matching hardware evidence`() {
+        latched(reqPolicy = target, hardware = verified(target, BackendKind.BATTERY_HARDWARE)) shouldBe null
+    }
+
+    @Test
+    fun `latched settings-level verification is not hardware evidence`() {
+        latched(reqPolicy = target, hardware = verified(target, BackendKind.SHIZUKU)) shouldBe
+            PendingRequest(target, t0, awaitingReplug = true)
+    }
+
+    @Test
+    fun `latched unrestricted resolves once charging above the cap`() {
+        latched(battery = pluggedBattery(percent = 81, status = STATUS_CHARGING)) shouldBe null
+        latched(battery = pluggedBattery(percent = 100, status = STATUS_FULL)) shouldBe null
+    }
+
+    @Test
+    fun `latched unrestricted charging at or below the cap is ambiguous and stays pending`() {
+        // A latched limit also reads "charging" while still climbing toward the cap.
+        latched(battery = pluggedBattery(percent = 80, status = STATUS_CHARGING)) shouldBe
+            PendingRequest(other, t0, awaitingReplug = true)
+    }
+
+    @Test
+    fun `latched unrestricted held above the cap without charging stays pending`() {
+        // NOT_CHARGING above the cap proves nothing about THIS request; only active charging does.
+        latched(battery = pluggedBattery(percent = 85, status = STATUS_NOT_CHARGING)) shouldBe
+            PendingRequest(other, t0, awaitingReplug = true)
+    }
+
+    @Test
+    fun `latched limit-disproof never applies to a limit target`() {
+        latched(reqPolicy = target, battery = pluggedBattery(percent = 90, status = STATUS_CHARGING)) shouldBe
+            PendingRequest(target, t0, awaitingReplug = true)
+    }
+
+    @Test
+    fun `latched backwards clock keeps pending rather than claiming applied`() {
+        latched(now = t0 - 1) shouldBe PendingRequest(other, t0, awaitingReplug = true)
     }
 
     private class FakeBackend(override val kind: BackendKind) : AccessBackend {

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingSyncReadTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingSyncReadTest.kt
@@ -210,11 +210,12 @@ class ChargingSyncReadTest {
         hardware: ChargeObservation? = null,
         now: Long = t0 + 5_000,
         limitPercent: Int = 80,
+        observation: ChargeObservation = verified(reqPolicy, BackendKind.DIRECT_WSS), // matching config
     ) = computeRefreshPending(
         reqPolicy = reqPolicy,
         reqAt = t0,
         now = now,
-        observation = verified(reqPolicy, BackendKind.DIRECT_WSS), // readback always confirms the config
+        observation = observation,
         hardware = hardware,
         verification = VerificationStrategy.SYNC_READBACK,
         policyLatchesAtPlug = true,
@@ -307,6 +308,25 @@ class ChargingSyncReadTest {
     @Test
     fun `latched backwards clock keeps pending rather than claiming applied`() {
         latched(now = t0 - 1) shouldBe PendingRequest(other, t0, awaitingReplug = true)
+    }
+
+    @Test
+    fun `latched pending clears when a competing native change is configured`() {
+        // The native toggle applies live on these ROMs: a readback verifying a DIFFERENT policy
+        // means the request is obsolete and must not keep demanding a replug.
+        latched(observation = verified(target, BackendKind.DIRECT_WSS)) shouldBe null
+    }
+
+    @Test
+    fun `latched pending clears on an unrecognized configured value`() {
+        latched(observation = unrecognized()) shouldBe null
+    }
+
+    @Test
+    fun `latched matching readback never resolves on its own`() {
+        // Configuration is exactly what a matching readback proves — and exactly not enough.
+        latched(observation = verified(other, BackendKind.SHIZUKU)) shouldBe
+            PendingRequest(other, t0, awaitingReplug = true)
     }
 
     private class FakeBackend(override val kind: BackendKind) : AccessBackend {

--- a/app/src/test/java/eu/darken/amply/charging/core/DeviceInfoLineageDetectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/DeviceInfoLineageDetectionTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.charging.core.access.LineageChargeReadout
 import eu.darken.amply.charging.core.access.LineageChargeReader
 import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.adapter.GrapheneOsChargingAdapter
 import eu.darken.amply.charging.core.adapter.LineageChargingAdapter
 import eu.darken.amply.charging.core.adapter.LineageLabAdapter
 import eu.darken.amply.charging.core.adapter.OnePlusChargingAdapter
@@ -45,6 +46,7 @@ class DeviceInfoLineageDetectionTest {
             context = context,
             lineage = LineageChargingAdapter(stubReader, setOf("some-qualified-codename")),
             lineageLab = LineageLabAdapter(),
+            grapheneOs = GrapheneOsChargingAdapter(),
             pixel = PixelChargingAdapter(),
             samsungModern = SamsungModernChargingAdapter(),
             samsungLegacy = SamsungLegacyChargingAdapter(),

--- a/app/src/test/java/eu/darken/amply/charging/core/DeviceInfoTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/DeviceInfoTest.kt
@@ -37,4 +37,24 @@ class DeviceInfoTest {
     fun `neither signal means stock android`() {
         device(version = null, feature = false).isLineageOs shouldBe false
     }
+
+    @Test
+    fun `grapheneos identity comes from its packages alone`() {
+        device().copy(hasGrapheneOsPackages = true).isGrapheneOs shouldBe true
+        device().isGrapheneOs shouldBe false
+    }
+
+    @Test
+    fun `the charge-limit key alone is never grapheneos identity`() {
+        // The adapter is registered ahead of the live Pixel adapter; a future stock Pixel shipping
+        // a same-named key must not be swallowed as GrapheneOS.
+        device().copy(hasBatteryChargeLimit = true).isGrapheneOs shouldBe false
+    }
+
+    @Test
+    fun `detection probes fail closed without a context`() {
+        val info = DeviceInfo.current(context = null)
+        info.hasGrapheneOsPackages shouldBe false
+        info.hasBatteryChargeLimit shouldBe false
+    }
 }

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterMutationDomainTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterMutationDomainTest.kt
@@ -20,6 +20,7 @@ class AdapterMutationDomainTest {
 
     private val adapters = listOf(
         PixelChargingAdapter(),
+        GrapheneOsChargingAdapter(),
         SamsungModernChargingAdapter(),
         SamsungLegacyChargingAdapter(),
         XiaomiChargingAdapter(),

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
@@ -29,6 +29,7 @@ class AdapterRegistrySelectionTest {
         context = ApplicationProvider.getApplicationContext(),
         lineage = LineageChargingAdapter(stubReader, setOf("oriole")),
         lineageLab = LineageLabAdapter(),
+        grapheneOs = GrapheneOsChargingAdapter(),
         pixel = PixelChargingAdapter(),
         samsungModern = SamsungModernChargingAdapter(),
         samsungLegacy = SamsungLegacyChargingAdapter(),
@@ -77,6 +78,56 @@ class AdapterRegistrySelectionTest {
             DeviceInfo("Google", "Pixel 8", 36, "test", hasChargingOptimization = true),
         )
         selection.adapter?.id shouldBe "google-pixel-lab-v1"
+    }
+
+    private fun graphene(
+        packages: Boolean = true,
+        key: Boolean = true,
+        systemUser: Boolean = true,
+    ) = DeviceInfo(
+        manufacturer = "Google",
+        model = "Pixel 9 Pro XL",
+        sdk = 37,
+        fingerprint = "test",
+        codename = "komodo",
+        hasChargingOptimization = false,
+        hasGrapheneOsPackages = packages,
+        hasBatteryChargeLimit = key,
+        isSystemUser = systemUser,
+    )
+
+    @Test
+    fun `grapheneos selects its live adapter ahead of the pixel adapter`() {
+        // Without the ordering, the Pixel probe (any Google/Pixel*) would swallow the device as a
+        // matched-but-diagnostics-only stock Pixel.
+        val selection = registry.select(graphene())
+        selection.adapter?.id shouldBe "grapheneos-chargelimit-v1"
+        selection.support.controlEnabled shouldBe true
+    }
+
+    @Test
+    fun `grapheneos without the key stays on its adapter as diagnostics-only`() {
+        val selection = registry.select(graphene(key = false))
+        selection.adapter?.id shouldBe "grapheneos-chargelimit-v1"
+        selection.support.controlEnabled shouldBe false
+        selection.support.contributionWanted shouldBe true
+    }
+
+    @Test
+    fun `a stock pixel with the key present is not treated as grapheneos`() {
+        // Identity is packages-only: the key alone must fall through to the Pixel adapter.
+        val selection = registry.select(
+            graphene(packages = false).copy(hasChargingOptimization = true),
+        )
+        selection.adapter?.id shouldBe "google-pixel-lab-v1"
+    }
+
+    @Test
+    fun `lineageos wins over the graphene adapter for lineage builds on pixel hardware`() {
+        // Both are ROM-identity adapters; a LineageOS Pixel carries the Lineage feature and no
+        // graphene packages, so ordering only matters for hypothetical both-signal devices — the
+        // Lineage pair stays first.
+        registry.select(lineageWithDeniedProperty("komodo", "Google")).adapter?.id shouldBe "lineageos-lab"
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/ContributionEligibilityTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/ContributionEligibilityTest.kt
@@ -22,6 +22,7 @@ class ContributionEligibilityTest {
         context = context,
         lineage = LineageChargingAdapter(stubReader),
         lineageLab = LineageLabAdapter(),
+        grapheneOs = GrapheneOsChargingAdapter(),
         pixel = PixelChargingAdapter(),
         samsungModern = SamsungModernChargingAdapter(),
         samsungLegacy = SamsungLegacyChargingAdapter(),
@@ -69,6 +70,16 @@ class ContributionEligibilityTest {
         val support = registry.select(device("Google", model = "Pixel 8")).support
         support.matched shouldBe true
         support.contributionWanted shouldBe false
+    }
+
+    @Test
+    fun `grapheneos with the key does not solicit, without it it does`() {
+        val ready = device("Google", model = "Pixel 9 Pro XL", sdk = 37)
+            .copy(hasChargingOptimization = false, hasGrapheneOsPackages = true, hasBatteryChargeLimit = true)
+        registry.select(ready).support.contributionWanted shouldBe false
+
+        // A future GrapheneOS build that drops or moves the key is exactly what the wizard can map.
+        registry.select(ready.copy(hasBatteryChargeLimit = false)).support.contributionWanted shouldBe true
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapterHardwareTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapterHardwareTest.kt
@@ -1,0 +1,54 @@
+package eu.darken.amply.charging.core.adapter
+
+import android.content.Context
+import android.content.Intent
+import android.os.BatteryManager
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.charging.core.BackendKind
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GrapheneOsChargingAdapterHardwareTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val adapter = GrapheneOsChargingAdapter()
+
+    private fun seedBattery(plugged: Int, chargingStatus: Int) {
+        context.sendStickyBroadcast(
+            Intent(Intent.ACTION_BATTERY_CHANGED)
+                .putExtra(BatteryManager.EXTRA_PLUGGED, plugged)
+                .putExtra(BatteryManager.EXTRA_CHARGING_STATUS, chargingStatus),
+        )
+    }
+
+    @Test
+    fun `plugged long life broadcast verifies the fixed 80 limit`() {
+        // The tester-observed enforcing state: shield up, "Charging state: 4" (issue #49).
+        seedBattery(plugged = BatteryManager.BATTERY_PLUGGED_USB, chargingStatus = 4)
+
+        adapter.readHardware(context) shouldBe ChargeObservation.Verified(
+            ChargePolicy.FixedLimit(80),
+            BackendKind.BATTERY_HARDWARE,
+        )
+    }
+
+    @Test
+    fun `unplugged long life broadcast is not verified`() {
+        seedBattery(plugged = 0, chargingStatus = 4)
+
+        adapter.readHardware(context) shouldBe null
+    }
+
+    @Test
+    fun `plugged normal broadcast stays unknown`() {
+        // The tester-observed limit-off state: "Charging state: 1".
+        seedBattery(plugged = BatteryManager.BATTERY_PLUGGED_USB, chargingStatus = 1)
+
+        adapter.readHardware(context).shouldBeInstanceOf<ChargeObservation.Unknown>()
+    }
+}

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapterTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapterTest.kt
@@ -1,0 +1,206 @@
+package eu.darken.amply.charging.core.adapter
+
+import eu.darken.amply.R
+import eu.darken.amply.charging.core.BackendKind
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.access.AccessBackend
+import eu.darken.amply.charging.core.access.BackendStatus
+import eu.darken.amply.charging.core.access.SettingMutation
+import eu.darken.amply.charging.core.access.SettingNamespace
+import eu.darken.amply.charging.core.access.SettingRead
+import eu.darken.amply.common.ca.toCaString
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class GrapheneOsChargingAdapterTest {
+    private val adapter = GrapheneOsChargingAdapter()
+
+    private fun graphene(
+        packages: Boolean = true,
+        key: Boolean = true,
+        systemUser: Boolean = true,
+    ) = DeviceInfo(
+        manufacturer = "Google",
+        model = "Pixel 9 Pro XL",
+        sdk = 37,
+        fingerprint = "google/komodo/komodo:17/CP2A.260805.005/2026080501:user/release-keys",
+        codename = "komodo",
+        // The real GrapheneOS shape: no Settings-Intelligence controller.
+        hasChargingOptimization = false,
+        hasGrapheneOsPackages = packages,
+        hasBatteryChargeLimit = key,
+        isSystemUser = systemUser,
+    )
+
+    @Test
+    fun `grapheneos identity with the key and system user enables control`() {
+        val support = adapter.probe(graphene())
+
+        support.matched shouldBe true
+        support.controlEnabled shouldBe true
+        support.detail shouldBe R.string.adapter_detail_grapheneos_ready
+        support.contributionWanted shouldBe false
+    }
+
+    @Test
+    fun `a stock pixel does not match even with the key present`() {
+        // Identity is packages-only: this adapter precedes the live Pixel adapter, so a future
+        // stock Pixel shipping a same-named key must fall through to its own adapter.
+        val support = adapter.probe(graphene(packages = false))
+
+        support.matched shouldBe false
+        support.detail shouldBe R.string.adapter_detail_requires_grapheneos
+    }
+
+    @Test
+    fun `a missing key keeps control off and asks for a contribution`() {
+        val support = adapter.probe(graphene(key = false))
+
+        support.matched shouldBe true
+        support.controlEnabled shouldBe false
+        support.detail shouldBe R.string.adapter_detail_grapheneos_no_key
+        support.contributionWanted shouldBe true
+    }
+
+    @Test
+    fun `secondary user disables control`() {
+        val support = adapter.probe(graphene(systemUser = false))
+
+        support.matched shouldBe true
+        support.controlEnabled shouldBe false
+        support.detail shouldBe R.string.adapter_detail_secondary_user
+    }
+
+    @Test
+    fun `read maps both values`() = runTest {
+        adapter.read(backend("1")) shouldBe
+            ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.DIRECT_WSS)
+        adapter.read(backend("0")) shouldBe
+            ChargeObservation.Verified(ChargePolicy.Unrestricted, BackendKind.DIRECT_WSS)
+    }
+
+    @Test
+    fun `an absent key is unrecognized, not a policy`() = runTest {
+        // The gate required presence; factory-absent semantics are unverified. Refusing keeps a
+        // session start from overwriting a state this adapter cannot restore.
+        val observed = adapter.read(FakeBackend())
+
+        observed.shouldBeInstanceOf<ChargeObservation.Unknown>()
+        observed.unrecognizedValue shouldBe true
+    }
+
+    @Test
+    fun `unrecognized values are flagged as such`() = runTest {
+        val observed = adapter.read(backend("2"))
+
+        observed.shouldBeInstanceOf<ChargeObservation.Unknown>()
+        observed.unrecognizedValue shouldBe true
+    }
+
+    @Test
+    fun `unreadable state is unknown but not flagged unrecognized`() = runTest {
+        val observed = adapter.read(FakeBackend(readable = false))
+
+        observed.shouldBeInstanceOf<ChargeObservation.Unknown>()
+        observed.unrecognizedValue shouldBe false
+    }
+
+    @Test
+    fun `apply writes the single key`() = runTest {
+        val backend = FakeBackend()
+
+        adapter.apply(ChargePolicy.FixedLimit(80), backend) shouldBe true
+        adapter.apply(ChargePolicy.Unrestricted, backend) shouldBe true
+
+        backend.writes shouldContainExactly listOf(
+            SettingMutation(SettingNamespace.GLOBAL, GrapheneOsChargingAdapter.KEY_CHARGE_LIMIT, "1"),
+            SettingMutation(SettingNamespace.GLOBAL, GrapheneOsChargingAdapter.KEY_CHARGE_LIMIT, "0"),
+        )
+    }
+
+    @Test
+    fun `apply rejects unsupported policies without writing`() = runTest {
+        val backend = FakeBackend()
+
+        adapter.apply(ChargePolicy.Adaptive, backend) shouldBe false
+        adapter.apply(ChargePolicy.PauseAtFull, backend) shouldBe false
+        adapter.apply(ChargePolicy.FixedLimit(85), backend) shouldBe false
+
+        backend.writes shouldBe emptyList()
+    }
+
+    @Test
+    fun `apply fails on rejected or dropped writes`() = runTest {
+        adapter.apply(ChargePolicy.FixedLimit(80), FakeBackend(failWrites = true)) shouldBe false
+        // Write reports success but the value never lands: read-back equality must fail.
+        adapter.apply(ChargePolicy.FixedLimit(80), FakeBackend(dropWrites = true)) shouldBe false
+    }
+
+    @Test
+    fun `reapply is a plain apply`() = runTest {
+        // No observer-poke inversion: the ROM samples the key at plug-session start, so a forced
+        // re-write must not transiently flip the value the way the Pixel adapter does.
+        val backend = backend("1")
+
+        adapter.reapply(ChargePolicy.FixedLimit(80), backend) shouldBe true
+
+        backend.writes shouldContainExactly listOf(
+            SettingMutation(SettingNamespace.GLOBAL, GrapheneOsChargingAdapter.KEY_CHARGE_LIMIT, "1"),
+        )
+    }
+
+    @Test
+    fun `decode maps the pixel-style hardware states`() {
+        adapter.decodeHardware(chargingState = 4, plugged = true) shouldBe ChargeObservation.Verified(
+            ChargePolicy.FixedLimit(80),
+            BackendKind.BATTERY_HARDWARE,
+        )
+        // Unplugged the sticky broadcast retains its last powered value — never evidence.
+        adapter.decodeHardware(chargingState = 4, plugged = false) shouldBe null
+        adapter.decodeHardware(chargingState = 1, plugged = true)
+            .shouldBeInstanceOf<ChargeObservation.Unknown>()
+        // Adaptive (5) is not a policy this adapter supports; it must never verify.
+        adapter.decodeHardware(chargingState = 5, plugged = true)
+            .shouldBeInstanceOf<ChargeObservation.Unknown>()
+    }
+
+    @Test
+    fun `session capabilities`() {
+        adapter.id shouldBe "grapheneos-chargelimit-v1"
+        adapter.sessionOverridePolicy shouldBe ChargePolicy.Unrestricted
+        adapter.defaultProtectivePolicy shouldBe ChargePolicy.FixedLimit(80)
+        adapter.verification shouldBe VerificationStrategy.SYNC_READBACK
+        adapter.policyLatchesAtPlug shouldBe true
+        adapter.reconnectGestureSupported shouldBe false
+        adapter.preferShizukuForWrites shouldBe false
+    }
+
+    private fun backend(value: String) =
+        FakeBackend(values = mutableMapOf(GrapheneOsChargingAdapter.KEY_CHARGE_LIMIT to value))
+
+    private class FakeBackend(
+        private val readable: Boolean = true,
+        private val values: MutableMap<String, String> = mutableMapOf(),
+        private val failWrites: Boolean = false,
+        private val dropWrites: Boolean = false,
+    ) : AccessBackend {
+        override val kind = BackendKind.DIRECT_WSS
+        val writes = mutableListOf<SettingMutation>()
+
+        override suspend fun status() = BackendStatus(true, true, "test".toCaString())
+        override suspend fun read(namespace: SettingNamespace, key: String) =
+            SettingRead(readable, values[key], if (readable) null else "blocked".toCaString())
+
+        override suspend fun write(mutation: SettingMutation): Boolean {
+            if (failWrites) return false
+            writes += mutation
+            if (!dropWrites) values[mutation.key] = mutation.value
+            return true
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
+++ b/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
@@ -43,7 +43,32 @@ class StoredRecordFormatTest {
         json.encodeToString(ChargeSessionRecord.serializer(), record) shouldBe
             """{"restorePolicy":"fixed:80","startedAtMillis":1000,"connectedSeen":true,""" +
             """"provenance":{"token":"tok-a","pid":42,"bootCount":7,"createdAtMillis":1000},""" +
-            """"workId":"wid-1"}"""
+            """"workId":"wid-1","overrideAwaitingReplug":false}"""
+    }
+
+    @Test
+    fun `session record with replug-grace fields encodes to the pinned shape`() {
+        val record = ChargeSessionRecord(
+            restorePolicy = ChargePolicy.FixedLimit(80),
+            startedAtMillis = 1_000L,
+            connectedSeen = true,
+            disconnectedAtMillis = 2_000L,
+            overrideAwaitingReplug = true,
+        )
+
+        json.encodeToString(ChargeSessionRecord.serializer(), record) shouldBe
+            """{"restorePolicy":"fixed:80","startedAtMillis":1000,"connectedSeen":true,""" +
+            """"disconnectedAtMillis":2000,"overrideAwaitingReplug":true}"""
+    }
+
+    /** A record from a build before the replug grace window must decode with the grace fields off. */
+    @Test
+    fun `pre-grace session records decode with grace defaults`() {
+        val stored = """{"restorePolicy":"fixed:80","startedAtMillis":1000,"connectedSeen":true}"""
+
+        val decoded = json.decodeFromString(ChargeSessionRecord.serializer(), stored)
+        decoded.disconnectedAtMillis shouldBe null
+        decoded.overrideAwaitingReplug shouldBe false
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/diagnostics/core/DefaultContributionRepositoryTest.kt
+++ b/app/src/test/java/eu/darken/amply/diagnostics/core/DefaultContributionRepositoryTest.kt
@@ -9,6 +9,7 @@ import eu.darken.amply.charging.core.access.SettingNamespace
 import eu.darken.amply.charging.core.access.LineageHealthSummary
 import eu.darken.amply.charging.core.access.SettingsSnapshotSource
 import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.adapter.GrapheneOsChargingAdapter
 import eu.darken.amply.charging.core.adapter.LineageChargingAdapter
 import eu.darken.amply.charging.core.adapter.LineageLabAdapter
 import eu.darken.amply.charging.core.adapter.OnePlusChargingAdapter
@@ -53,6 +54,7 @@ class DefaultContributionRepositoryTest {
         context = ApplicationProvider.getApplicationContext(),
         lineage = LineageChargingAdapter(stubReader),
         lineageLab = LineageLabAdapter(),
+        grapheneOs = GrapheneOsChargingAdapter(),
         pixel = PixelChargingAdapter(),
         samsungModern = SamsungModernChargingAdapter(),
         samsungLegacy = SamsungLegacyChargingAdapter(),

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/SessionDecisionEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/SessionDecisionEngineTest.kt
@@ -153,11 +153,17 @@ class SessionDecisionEngineTest {
     }
 
     @Test
-    fun `replug after expiry is still marked when the session survived`() {
-        // The window is only enforced by unplugged evaluations; a late replug that reaches a live
-        // session means the override latched — continuing (to restore at 100%) is the safe outcome.
+    fun `replug after expiry restores instead of resuming a stale session`() {
+        // The latch already happened at the physical plug event either way; honoring the persisted
+        // bound closes the session with a protective config rather than resuming hours later.
         decideGrace(age = 10_000 + grace * 3, plugged = true, disconnectedAt = started + 10_000) shouldBe
-            SessionDecision.MARK_REPLUGGED
+            SessionDecision.RESTORE_DISCONNECTED
+    }
+
+    @Test
+    fun `replug with a backwards clock also restores`() {
+        decideGrace(age = 9_000, plugged = true, disconnectedAt = started + 10_000) shouldBe
+            SessionDecision.RESTORE_DISCONNECTED
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/SessionDecisionEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/SessionDecisionEngineTest.kt
@@ -93,6 +93,98 @@ class SessionDecisionEngineTest {
         decision shouldBe SessionDecision.CONTINUE
     }
 
+    // --- Replug grace window (plug-latched adapters; disabled via replugGraceMillis = 0 elsewhere) ---
+
+    private val grace = SessionDecisionEngine.REPLUG_GRACE_MILLIS
+
+    private fun decideGrace(
+        age: Long,
+        plugged: Boolean,
+        full: Boolean = false,
+        connectedSeen: Boolean = true,
+        disconnectedAt: Long? = null,
+        replugGraceMillis: Long = grace,
+    ) = SessionDecisionEngine.decide(
+        session = ChargeSessionRecord(
+            ChargePolicy.FixedLimit(80),
+            started,
+            connectedSeen,
+            disconnectedAtMillis = disconnectedAt,
+        ),
+        nowMillis = started + age,
+        plugged = plugged,
+        full = full,
+        replugGraceMillis = replugGraceMillis,
+    )
+
+    @Test
+    fun `grace disabled keeps the immediate disconnect restore`() {
+        decideGrace(age = 10_000, plugged = false, replugGraceMillis = 0L) shouldBe
+            SessionDecision.RESTORE_DISCONNECTED
+    }
+
+    @Test
+    fun `first disconnect opens the grace window instead of restoring`() {
+        decideGrace(age = 10_000, plugged = false) shouldBe SessionDecision.MARK_DISCONNECTED
+    }
+
+    @Test
+    fun `unplugged inside the window continues`() {
+        decideGrace(age = 10_000 + grace - 1, plugged = false, disconnectedAt = started + 10_000) shouldBe
+            SessionDecision.CONTINUE
+    }
+
+    @Test
+    fun `window expiry restores`() {
+        decideGrace(age = 10_000 + grace, plugged = false, disconnectedAt = started + 10_000) shouldBe
+            SessionDecision.RESTORE_DISCONNECTED
+    }
+
+    @Test
+    fun `a backwards clock voids the window and restores`() {
+        decideGrace(age = 9_000, plugged = false, disconnectedAt = started + 10_000) shouldBe
+            SessionDecision.RESTORE_DISCONNECTED
+    }
+
+    @Test
+    fun `replug inside the window is marked`() {
+        decideGrace(age = 15_000, plugged = true, disconnectedAt = started + 10_000) shouldBe
+            SessionDecision.MARK_REPLUGGED
+    }
+
+    @Test
+    fun `replug after expiry is still marked when the session survived`() {
+        // The window is only enforced by unplugged evaluations; a late replug that reaches a live
+        // session means the override latched — continuing (to restore at 100%) is the safe outcome.
+        decideGrace(age = 10_000 + grace * 3, plugged = true, disconnectedAt = started + 10_000) shouldBe
+            SessionDecision.MARK_REPLUGGED
+    }
+
+    @Test
+    fun `full battery wins over an open grace window`() {
+        decideGrace(age = 15_000, plugged = false, full = true, disconnectedAt = started + 10_000) shouldBe
+            SessionDecision.RESTORE_FULL
+    }
+
+    @Test
+    fun `safety timeout wins over an open grace window`() {
+        decideGrace(
+            age = SessionDecisionEngine.SAFETY_TIMEOUT_MILLIS,
+            plugged = false,
+            disconnectedAt = started + SessionDecisionEngine.SAFETY_TIMEOUT_MILLIS - 1_000,
+        ) shouldBe SessionDecision.RESTORE_SAFETY_TIMEOUT
+    }
+
+    @Test
+    fun `grace never engages before the first connection`() {
+        decideGrace(age = 1_000, plugged = false, connectedSeen = false) shouldBe SessionDecision.CONTINUE
+    }
+
+    @Test
+    fun `grace constant is the real duration`() {
+        SessionDecisionEngine.REPLUG_GRACE_MILLIS shouldBe 30_000L
+    }
+
     private fun decide(age: Long, connectedSeen: Boolean, plugged: Boolean, full: Boolean) =
         SessionDecisionEngine.decide(
             session = ChargeSessionRecord(ChargePolicy.FixedLimit(80), started, connectedSeen),

--- a/app/src/test/java/eu/darken/amply/main/core/DeviceSupportReporterTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/core/DeviceSupportReporterTest.kt
@@ -16,6 +16,8 @@ class DeviceSupportReporterTest {
         model: String = "SM-S911B",
         adapterId: String? = "samsung-lab",
         isLineageOs: Boolean = false,
+        isGrapheneOs: Boolean = false,
+        hasBatteryChargeLimit: Boolean = false,
         lineageHealth: LineageHealthSummary? = null,
     ) = DeviceSupportReport(
         manufacturer = manufacturer,
@@ -33,8 +35,10 @@ class DeviceSupportReporterTest {
         oplusRomVersion = null,
         lineageOsVersion = null,
         isLineageOs = isLineageOs,
+        isGrapheneOs = isGrapheneOs,
         lineageHealth = lineageHealth,
         hasProtectBattery = true,
+        hasBatteryChargeLimit = hasBatteryChargeLimit,
         hasLineageSettingsProvider = false,
         adapterId = adapterId,
         adapterMatched = adapterId != null,
@@ -52,7 +56,7 @@ class DeviceSupportReporterTest {
     fun `format is deterministic and schema-tagged`() {
         val text = formatReport(report())
         text shouldStartWith "Amply device-support request"
-        text shouldContain "report_schema=8"
+        text shouldContain "report_schema=9"
         text shouldContain "manufacturer=Samsung"
         text shouldContain "model=SM-S911B"
         text shouldContain "one_ui_version=61000"
@@ -60,6 +64,8 @@ class DeviceSupportReporterTest {
         text shouldContain "oplus_rom_version=none"
         text shouldContain "is_lineageos=false"
         text shouldContain "lineageos_version=none"
+        text shouldContain "is_grapheneos=false"
+        text shouldContain "has_battery_charge_limit=false"
         text shouldContain "has_protect_battery=true"
         text shouldContain "has_lineage_settings_provider=false"
         text shouldContain "adapter=samsung-lab"
@@ -111,6 +117,15 @@ class DeviceSupportReporterTest {
         val text = formatReport(report())
         text shouldContain "lineage_cc_provider=unknown"
         text shouldContain "lineage_cc_limit_mechanism=UNKNOWN"
+    }
+
+    @Test
+    fun `a grapheneos report carries identity and key presence`() {
+        // The triage-relevant pairing: identity without the key means the wizard should discover it;
+        // identity with the key means the live gate should have engaged.
+        val text = formatReport(report(isGrapheneOs = true, hasBatteryChargeLimit = true))
+        text shouldContain "is_grapheneos=true"
+        text shouldContain "has_battery_charge_limit=true"
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/main/ui/widget/WidgetDisplayTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/widget/WidgetDisplayTest.kt
@@ -43,4 +43,21 @@ class WidgetDisplayTest {
         display.settling shouldBe false
         display.steady shouldBe true
     }
+
+    @Test
+    fun `an awaiting-replug pending is its own state, never settling, and has no expiry`() {
+        val state = ChargingState(pending = PendingRequest(target, now, awaitingReplug = true))
+        val display = widgetDisplay(state, sessionActive = false, now = now + SETTLING_WINDOW_MILLIS * 100)
+        display.settling shouldBe false
+        display.awaitingReplug shouldBe true
+        display.steady shouldBe false
+    }
+
+    @Test
+    fun `an active session wins over an awaiting-replug pending`() {
+        val state = ChargingState(pending = PendingRequest(target, now, awaitingReplug = true))
+        val display = widgetDisplay(state, sessionActive = true, now = now + 1_000)
+        display.sessionActive shouldBe true
+        display.steady shouldBe false
+    }
 }


### PR DESCRIPTION
### What changed

Adds live charging control on GrapheneOS: the dashboard, widget, and tile can switch between the ROM's "Limit to 80%" and unrestricted charging, and the one-time full charge works — no Shizuku needed, a one-time WSS grant is enough. Because GrapheneOS only picks up an external change when the charger is reconnected, the app walks the user through that: an explicit "unplug and replug" cue on every surface instead of a spinner, and a session that survives the deliberate unplug→replug instead of cancelling itself. Devices where the setting is absent stay diagnostics-only with the contribution wizard offered.

Closes #49.

### Technical Context

- **Root constraint**: GrapheneOS samples `global battery_charge_limit` only at plug-session start (remote qualification in #49 — enforcement at 80% with hardware state 4 was physically observed by the reporter; the ledger row and known-gaps list in `device-qualification` record exactly what that run could and could not cover). Everything hangs off one new adapter capability, `policyLatchesAtPlug`; every behavioral branch keys on it, so existing adapters are bit-for-bit unchanged (pinned by the pre-existing test suites).
- **Why a condition-based pending state**: a 15s settling clock would silently claim success on a write with zero effect. The latched pending has no expiry and resolves only on evidence (written-unplugged with samples on both sides of the write agreeing, an observed unplug via a persisted watermark, hardware state 4, charging observably above the cap, or a competing native change). Deserves close review: `computeRefreshPending`'s latched arm and its tests.
- **Why the session grace window**: restore-on-disconnect fired on exactly the unplug the user performs to make the override latch, silently cancelling the full charge. The engine now opens a persisted 30s window (`MARK_DISCONNECTED`/`MARK_REPLUGGED`); expiry, backwards clocks, and late replugs all restore. Deserves close review: `SessionDecisionEngine` and the service's grace handlers.
- **Detection**: no graphene property/feature/fingerprint marker exists (verified on-device), so identity resolves core `app.grapheneos.*` system packages (with `FLAG_SYSTEM` required, so a name-squatting sideload can't spoof it) and is deliberately not OR-ed with key presence — the adapter precedes the Pixel adapter in the registry, and a future stock Pixel shipping a same-named key must not be swallowed.
- **Known limitations, all failing closed** (details in the `device-qualification` known-gaps entry): `app.grapheneos.*` package visibility from app context and app-context WSS writes are unverified until the reporter runs a test build; a plugged restore configures but cannot enforce until the next replug (inherent to the ROM — the pending hint says so); the replug hint can linger while nothing observes a replug (never the reverse error); factory-absent key state, wireless, and secondary users are unverified. On-device verification happens via a test build posted to #49, which CI cannot cover.
