### PR TITLE
Tile: Show an applying hint while a policy write settles

### DIFF
--- a/app/src/main/java/eu/darken/amply/main/ui/tile/ChargeTileService.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/tile/ChargeTileService.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.amply.R
 import eu.darken.amply.charging.core.ChargingRepository
 import eu.darken.amply.charging.core.isAwaitingReplug
+import eu.darken.amply.charging.core.isSettling
 import eu.darken.amply.common.debug.logging.Logging
 import eu.darken.amply.common.debug.logging.log
 import eu.darken.amply.common.debug.logging.logTag
@@ -56,12 +57,16 @@ class ChargeTileService : TileService() {
                     render(
                         active = sessionActive,
                         available = state.canApply,
-                        // Plug-latched pending beats the static access/adapter label: opening QS is
-                        // the tile's refresh cadence, so this is exactly when the hint is fresh.
-                        detail = if (state.isAwaitingReplug()) {
-                            getString(R.string.tile_replug_hint)
-                        } else {
-                            (state.access?.label ?: state.adapterName).get(this@ChargeTileService)
+                        // Pending states beat the static access/adapter label: opening QS is the
+                        // tile's refresh cadence, so this is exactly when they are fresh. The two
+                        // pending kinds are mutually exclusive by construction (a latched request is
+                        // never "settling"); the order documents intent, not a real priority.
+                        detail = when {
+                            state.isAwaitingReplug() -> getString(R.string.tile_replug_hint)
+                            state.isSettling(System.currentTimeMillis()) ->
+                                getString(R.string.tile_applying)
+                            else -> (state.access?.label ?: state.adapterName)
+                                .get(this@ChargeTileService)
                         },
                     )
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="tile_active">Restore limit</string>
     <string name="tile_override_active">Temporary override active</string>
     <string name="tile_replug_hint">Replug to apply</string>
+    <string name="tile_applying">Applying…</string>
     <string name="widget_description">Amply charge controls</string>
     <string name="session_channel_name">Full charge and restore</string>
     <string name="session_channel_description" formatted="false">Shows while Amply is allowing a full charge, and while it restores your limit afterwards</string>


### PR DESCRIPTION
### What changed

While a charging-policy change is still settling, the Quick Settings tile now shows "Applying…" as its subtitle instead of the static access/adapter label — matching the dashboard's cue, and the "Replug to apply" hint that plug-latched devices already had.

### Technical Context

- The two pending kinds (settling window, awaiting-replug) are mutually exclusive by construction — the when-chain order is documentation, not logic — so no new decision unit or test is warranted; both predicates are already pinned by their existing tests.
- The subtitle can go stale while QS stays open (~15s worst case); that matches the accepted staleness of the existing replug hint, since QS-open is the tile's only refresh cadence. Active sessions and API < 29 behave exactly as before.
