### PR TITLE
Charging: Warn when the hardware never confirms a fixed limit

### DIFF
--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -85,6 +85,14 @@ data class ChargingState(
     val access: AccessSnapshot? = null,
     val observation: ChargeObservation = ChargeObservation.Unknown(R.string.charging_reason_loading.toCaString()),
     val pending: PendingRequest? = null,
+    /**
+     * Standing contradiction: the charging hardware was EXPECTED to confirm the last requested
+     * policy (see [eu.darken.amply.charging.core.adapter.ChargingAdapter.confirmationExpected]) and
+     * still has not, well past the settling window. Catches both a stuck apply and "plugged in
+     * today, HAL never engaged" — the silent-failure class where the configured setting reads back
+     * fine while charging is not actually limited. Null whenever no expectation exists.
+     */
+    val unconfirmedTarget: ChargePolicy? = null,
     val busy: Boolean = false,
     // Set only while a Shizuku-driven WRITE_SECURE_SETTINGS grant is in flight, so the setup card can
     // show a progress cue on that specific action without conflating it with a policy apply (both busy).
@@ -150,6 +158,12 @@ class ChargingRepository @Inject constructor(
     private val batteryReader: BatteryReader,
 ) {
     private val operationMutex = Mutex()
+
+    // Debounce carry-over for the hardware-unconfirmed detector (see debounceUnconfirmed). Only
+    // touched inside refreshLocked, which always runs under operationMutex. Process death resets it —
+    // the warning then just needs one more stability interval, never the unsafe direction.
+    private var unconfirmedCandidate: ChargePolicy? = null
+    private var unconfirmedSince: Long = 0L
     // Separate from operationMutex: the ~25s grant deliberately never holds operationMutex (see below),
     // but manual and automatic callers must still be single-flighted against each other.
     private val grantMutex = Mutex()
@@ -283,11 +297,15 @@ class ChargingRepository @Inject constructor(
         if (adapter == null || !selection.support.controlEnabled) {
             val detail = selection.support.detail.toCaString()
             val observation = ChargeObservation.Unsupported(detail)
-            // Also drop the standing ready note: this branch means the gate just failed on a fresh
-            // selection (a capability can vanish between refresh and tap), and the field's contract
-            // is "null whenever control is unavailable" — keeping a stale "changes apply
-            // immediately" under the failure reason would contradict it.
-            mutableState.value = state.value.copy(observation = observation, message = detail, adapterDetail = null)
+            // Also drop the standing ready note and any hardware-unconfirmed warning: this branch
+            // means the gate just failed on a fresh selection (a capability can vanish between
+            // refresh and tap), and both fields' contracts exclude Unsupported states.
+            mutableState.value = state.value.copy(
+                observation = observation,
+                message = detail,
+                adapterDetail = null,
+                unconfirmedTarget = null,
+            )
             return ApplyResult(false, observation, context.getString(selection.support.detail))
         }
         if (policy !in adapter.supportedPolicies) {
@@ -308,6 +326,8 @@ class ChargingRepository @Inject constructor(
             mutableState.value = state.value.copy(
                 observation = observation,
                 message = R.string.charging_message_setup_required.toCaString(),
+                // NeedsSetup never warns (detector contract); drop a now-contradictory stale warning.
+                unconfirmedTarget = null,
             )
             return ApplyResult(false, observation, "Setup required")
         }
@@ -340,10 +360,14 @@ class ChargingRepository @Inject constructor(
             log(TAG, Logging.Priority.ERROR) { "Settings write failed for ${policy.stableId}" }
             val observation = ChargeObservation.Unknown(R.string.charging_reason_write_failed.toCaString())
             // Clear any stale pending so the failure is not masked by a prior request's "applying…" cue.
+            // The old unconfirmed warning goes too: a multi-key write can fail after partially changing
+            // configuration, so the previous target is no longer a safe standing claim — the next
+            // refresh recomputes from live evidence.
             mutableState.value = state.value.copy(
                 busy = false,
                 observation = observation,
                 pending = null,
+                unconfirmedTarget = null,
                 message = R.string.charging_message_write_failed.toCaString(),
             )
             return ApplyResult(false, observation, "Write failed")
@@ -401,6 +425,10 @@ class ChargingRepository @Inject constructor(
                 access = access,
                 observation = observation,
                 pending = pending,
+                // A fresh write voids any prior contradiction: the detector re-arms via refresh once
+                // the new request is past its own grace threshold. Stale warnings must never render
+                // over a new request's settling phase (all three publication copies clear this).
+                unconfirmedTarget = null,
                 message = message,
             )
             // Always schedule an eventual surface re-push, even for a settled write (pending == null).
@@ -424,6 +452,7 @@ class ChargingRepository @Inject constructor(
                 busy = false,
                 observation = ChargeObservation.LastRequested(policy),
                 pending = PendingRequest(policy, now, awaitingReplug = fallbackAwaitsReplug(adapter, pluggedAtWrite)),
+                unconfirmedTarget = null,
             )
             settleScheduler.schedule(now)
             throw e
@@ -437,6 +466,7 @@ class ChargingRepository @Inject constructor(
                 busy = false,
                 observation = observation,
                 pending = PendingRequest(policy, now, awaitingReplug = fallbackAwaitsReplug(adapter, pluggedAtWrite)),
+                unconfirmedTarget = null,
                 message = message,
             )
             settleScheduler.schedule(now)
@@ -448,6 +478,13 @@ class ChargingRepository @Inject constructor(
         val selection: AdapterSelection = registry.select()
         val access = accessResolver.snapshot()
         val adapter = selection.adapter
+        // ONE sticky observation for everything hardware-derived this refresh — plug state, the
+        // hardware decode, and the confirmation expectation must join on the same readout
+        // (BatteryReader's doc: never pair plug state across two sticky reads). Behavior-identical
+        // to the previous per-call adapter.readHardware(context): a missing extra decodes as
+        // INVALID(0) and an unreadable broadcast as unplugged, both yielding the same results.
+        val battery = batteryReader.read()
+        val hardware = adapter?.decodeHardware(battery.chargingStatus ?: 0, battery.onCharger)
         val observation = when {
             adapter == null -> ChargeObservation.Unsupported(selection.support.detail.toCaString())
             !selection.support.controlEnabled -> ChargeObservation.Unsupported(selection.support.detail.toCaString())
@@ -465,7 +502,7 @@ class ChargingRepository @Inject constructor(
                     // A readable-but-unrecognized OEM value must not be masked by a stale last
                     // request — the state is genuinely unknown, and a session start refuses on it.
                     read is ChargeObservation.Unknown && read.unrecognizedValue -> read
-                    else -> adapter.readHardware(context)
+                    else -> hardware
                         ?: preferences.lastRequestedNow()?.let(ChargeObservation::LastRequested)
                         ?: read
                         ?: ChargeObservation.Unknown(R.string.charging_reason_state_unavailable.toCaString())
@@ -476,22 +513,24 @@ class ChargingRepository @Inject constructor(
         // or WSS the settings readback is `Verified` while the HAL is still converging, so pending would
         // otherwise never clear until the window expired.
         val latches = adapter?.policyLatchesAtPlug == true
-        val battery = if (latches) batteryReader.read() else null
         // Plug-latched adapters: an observed unpowered moment durably resolves an unresolved latched
         // request — the plug session that sampled the old value is over, so the next one samples the
         // new value. Persisted as a watermark so a later *plugged* refresh still knows it happened.
-        if (latches && battery?.plugged == 0 &&
+        if (latches && battery.plugged == 0 &&
             preferences.lastRequestedPluggedNow() == true &&
             preferences.unpluggedSeenAtNow() <= preferences.lastRequestedAtNow()
         ) {
             preferences.recordUnpluggedSeen(System.currentTimeMillis())
         }
+        val reqPolicy = preferences.lastRequestedNow()
+        val reqAt = preferences.lastRequestedAtNow()
+        val now = System.currentTimeMillis()
         val pending = computeRefreshPending(
-            reqPolicy = preferences.lastRequestedNow(),
-            reqAt = preferences.lastRequestedAtNow(),
-            now = System.currentTimeMillis(),
+            reqPolicy = reqPolicy,
+            reqAt = reqAt,
+            now = now,
             observation = observation,
-            hardware = adapter?.readHardware(context),
+            hardware = hardware,
             verification = adapter?.verification ?: VerificationStrategy.ASYNC_HARDWARE,
             policyLatchesAtPlug = latches,
             reqPlugged = if (latches) preferences.lastRequestedPluggedNow() else null,
@@ -499,6 +538,19 @@ class ChargingRepository @Inject constructor(
             battery = battery,
             limitPercent = adapter?.latchedLimitPercent() ?: NO_LATCHED_LIMIT,
         )
+        val rawUnconfirmed = computeUnconfirmedTarget(
+            reqPolicy = reqPolicy,
+            reqAt = reqAt,
+            now = now,
+            observation = observation,
+            hardware = hardware,
+            confirmationExpected = reqPolicy != null &&
+                adapter?.confirmationExpected(reqPolicy, battery.chargingStatus, battery.onCharger) == true,
+        )
+        val debounce = debounceUnconfirmed(rawUnconfirmed, now, unconfirmedCandidate, unconfirmedSince)
+        unconfirmedCandidate = debounce.candidate
+        unconfirmedSince = debounce.sinceMillis
+        val unconfirmedTarget = debounce.surfaced
         val built = ChargingState(
             device = DeviceInfo.current(context),
             adapterName = adapter?.displayName ?: R.string.adapter_name_unsupported.toCaString(),
@@ -522,6 +574,7 @@ class ChargingRepository @Inject constructor(
             access = access,
             observation = observation,
             pending = pending,
+            unconfirmedTarget = unconfirmedTarget,
             busy = false,
             // grantingWss is intentionally left default here; mergeRefreshedState (below) carries an
             // in-flight grant's spinner over from the previous state so a concurrent refresh can't clear it.
@@ -675,6 +728,69 @@ internal fun computeRefreshPending(
     if (confirmed) return null
     return PendingRequest(reqPolicy, reqAt)
 }
+
+/**
+ * Standing contradiction detector behind [ChargingState.unconfirmedTarget]: the last requested policy
+ * was EXPECTED to be hardware-confirmed (see ChargingAdapter.confirmationExpected — live channel,
+ * reliably-reported policy class, nothing masking) and still is not, well past the settling window.
+ *
+ * No pending interplay is needed: the threshold exceeds the settling window, so a windowed pending has
+ * always expired by the time this can fire, and plug-latched pendings belong to adapters whose
+ * expectation is false by default. The threshold's slack (2× the window vs the measured ~11–12s Pixel
+ * HAL transition) keeps a merely-slow transition from flickering a warning; `now < reqAt` (backwards
+ * clock) falls under the same guard.
+ */
+internal fun computeUnconfirmedTarget(
+    reqPolicy: ChargePolicy?,
+    reqAt: Long,
+    now: Long,
+    observation: ChargeObservation,
+    hardware: ChargeObservation?,
+    confirmationExpected: Boolean,
+): ChargePolicy? {
+    if (reqPolicy == null || reqAt <= 0L) return null
+    if (observation is ChargeObservation.Unsupported || observation is ChargeObservation.NeedsSetup) return null
+    // An authoritative readback of a DIFFERENT configured policy means a competing/native change
+    // already replaced the request — warning that the obsolete request "may not be applying" would
+    // contradict the very policy the card above verifies. Same for a readable-but-unrecognized
+    // value (the state a session start refuses on). A readback verifying the REQUESTED policy while
+    // the hardware disagrees is exactly the contradiction this detector exists for.
+    if (observation is ChargeObservation.Verified && observation.policy != reqPolicy) return null
+    if (observation is ChargeObservation.Unknown && observation.unrecognizedValue) return null
+    if (now - reqAt < UNCONFIRMED_THRESHOLD_MILLIS) return null
+    if (!confirmationExpected) return null
+    if (hardwareConfirms(hardware, reqPolicy)) return null
+    return reqPolicy
+}
+
+/**
+ * Stability debounce over the raw detector output: the contradiction must hold across refreshes for
+ * [UNCONFIRMED_STABILITY_MILLIS] before it surfaces. Damps the plug-in transient — a device plugged
+ * in with an OLD fixed-limit request legitimately reads state 1 for the ~11–12s HAL transition, and
+ * the age threshold alone (measured from the write, not the plug) would warn instantly. Pure:
+ * callers thread the previous (candidate, sinceMillis) pair through.
+ */
+internal fun debounceUnconfirmed(
+    candidate: ChargePolicy?,
+    now: Long,
+    prevCandidate: ChargePolicy?,
+    prevSince: Long,
+): UnconfirmedDebounce {
+    if (candidate == null) return UnconfirmedDebounce(null, 0L, surfaced = null)
+    // A changed candidate — or a backwards clock, which voids the stability evidence — restarts.
+    val since = if (candidate == prevCandidate && now >= prevSince) prevSince else now
+    val surfaced = candidate.takeIf { now - since >= UNCONFIRMED_STABILITY_MILLIS }
+    return UnconfirmedDebounce(candidate, since, surfaced)
+}
+
+internal data class UnconfirmedDebounce(
+    val candidate: ChargePolicy?,
+    val sinceMillis: Long,
+    val surfaced: ChargePolicy?,
+)
+
+internal const val UNCONFIRMED_THRESHOLD_MILLIS = 2 * SETTLING_WINDOW_MILLIS
+internal const val UNCONFIRMED_STABILITY_MILLIS = SETTLING_WINDOW_MILLIS
 
 /** Sentinel for "no latched fixed-limit cap": no observable percent can exceed it, disabling limit-disproof. */
 internal const val NO_LATCHED_LIMIT = 100

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
@@ -76,6 +76,17 @@ interface ChargingAdapter {
      */
     val policyLatchesAtPlug: Boolean get() = false
 
+    /**
+     * Whether the charging hardware is currently EXPECTED to confirm [policy]: the policy class is
+     * one this hardware reliably reports, the evidence channel is live (plugged — unplugged sticky
+     * values are stale), and nothing is masking the signal (thermal throttling). Drives the
+     * "hardware never confirmed" warning: expected-and-missing is the contradiction worth showing.
+     * False by default — sync-readback adapters verify via settings and plug-latched adapters
+     * legitimately confirm only at the next plug session, so neither carries an expectation.
+     */
+    fun confirmationExpected(policy: ChargePolicy, chargingStatus: Int?, plugged: Boolean): Boolean =
+        false
+
     fun probe(device: DeviceInfo): AdapterSupport
     fun readHardware(context: Context): ChargeObservation? = null
     fun decodeHardware(chargingState: Int, plugged: Boolean): ChargeObservation? = null

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/PixelChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/PixelChargingAdapter.kt
@@ -126,6 +126,20 @@ class PixelChargingAdapter @Inject constructor() : ChargingAdapter {
         return apply(policy, backend)
     }
 
+    /**
+     * A fixed limit is the only policy the hardware reliably reports: state 4 stays set for the
+     * ENTIRE plugged fixed-limit session, even far below the cap (see [eu.darken.amply.stats.core.
+     * StatsLimitHitDetector]). Adaptive is deliberately excluded — an idle adaptive profile reads
+     * NORMAL(1), so its absence proves nothing — and Unrestricted maps to the same ambiguous 1.
+     * States 1/4/5 all count as a live, unmasked channel: 4 is "expected and delivered" (the
+     * confirms check clears it), 5 while a fixed limit was requested is a real contradiction worth
+     * warning about. Thermal (2/3) masks the policy and invalid/unrecognized values prove nothing.
+     */
+    override fun confirmationExpected(policy: ChargePolicy, chargingStatus: Int?, plugged: Boolean): Boolean =
+        plugged &&
+            policy == ChargePolicy.FixedLimit(80) &&
+            chargingStatus in setOf(CHARGING_STATE_NORMAL, CHARGING_STATE_LONG_LIFE, CHARGING_STATE_ADAPTIVE)
+
     override fun nativeSettingsIntent(context: Context): Intent {
         val specific = Intent().setComponent(
             ComponentName(

--- a/app/src/main/java/eu/darken/amply/main/core/WorkManagerSettleScheduler.kt
+++ b/app/src/main/java/eu/darken/amply/main/core/WorkManagerSettleScheduler.kt
@@ -7,6 +7,7 @@ import androidx.work.WorkManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.amply.charging.core.SETTLING_WINDOW_MILLIS
 import eu.darken.amply.charging.core.SettleScheduler
+import eu.darken.amply.charging.core.UNCONFIRMED_THRESHOLD_MILLIS
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -23,13 +24,27 @@ class WorkManagerSettleScheduler @Inject constructor(
 ) : SettleScheduler {
 
     override fun schedule(requestedAtMillis: Long) {
-        val fireAt = requestedAtMillis + SETTLING_WINDOW_MILLIS + CLEAR_BUFFER_MILLIS
-        val delay = (fireAt - System.currentTimeMillis()).coerceAtLeast(0L)
+        enqueue(
+            SettleRefreshWorker.UNIQUE_NAME,
+            requestedAtMillis + SETTLING_WINDOW_MILLIS + CLEAR_BUFFER_MILLIS,
+        )
+        // Second, separate push at the hardware-unconfirmed threshold: the silent-failure case this
+        // detector exists for (no HAL transition) may produce no charging-status broadcast, and the
+        // dashboard's own deadline observer disarms when pending clears at the window — without this
+        // the warning could wait indefinitely for an unrelated refresh trigger.
+        enqueue(
+            UNCONFIRMED_UNIQUE_NAME,
+            requestedAtMillis + UNCONFIRMED_THRESHOLD_MILLIS + CLEAR_BUFFER_MILLIS,
+        )
+    }
+
+    private fun enqueue(uniqueName: String, fireAtMillis: Long) {
+        val delay = (fireAtMillis - System.currentTimeMillis()).coerceAtLeast(0L)
         val request = OneTimeWorkRequestBuilder<SettleRefreshWorker>()
             .setInitialDelay(delay, TimeUnit.MILLISECONDS)
             .build()
         WorkManager.getInstance(context).enqueueUniqueWork(
-            SettleRefreshWorker.UNIQUE_NAME,
+            uniqueName,
             ExistingWorkPolicy.REPLACE,
             request,
         )
@@ -37,5 +52,6 @@ class WorkManagerSettleScheduler @Inject constructor(
 
     private companion object {
         const val CLEAR_BUFFER_MILLIS = 1_000L
+        const val UNCONFIRMED_UNIQUE_NAME = "${SettleRefreshWorker.UNIQUE_NAME}_unconfirmed"
     }
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Security
+import androidx.compose.material.icons.filled.WarningAmber
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -523,6 +524,30 @@ private fun StatusCard(
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.tertiary,
             )
+        } else if (state.charging.unconfirmedTarget != null) {
+            // The hardware was expected to confirm this policy and hasn't, well past the settling
+            // window — the configured setting may not actually be applying. Beats the apply
+            // message, which narrates exactly the request this contradicts.
+            Spacer(Modifier.height(8.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.WarningAmber,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.error,
+                )
+                Text(
+                    stringResource(
+                        R.string.dashboard_hw_unconfirmed,
+                        state.charging.unconfirmedTarget.shortLabel().asComposable(),
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
         } else {
             // The repository's apply message describes the request the settling line already
             // narrates, so only show it once settling has resolved.
@@ -1048,6 +1073,79 @@ private fun DashboardScreenLiveChargePreview() = PreviewWrapper {
 }
 
 // Mid-apply: spinner, "Applying…", and the waiting line with the duration hint.
+// The hardware-unconfirmed contradiction: an 80% limit was requested well past the settling window,
+// the device is plugged and charging, and the HAL never reported the long-life hold.
+@AmplyPreview
+@Composable
+private fun DashboardScreenHwUnconfirmedPreview() = PreviewWrapper {
+    DashboardScreen(
+        state = DashboardUiState(
+            onboardingComplete = true,
+            batteryReadout = BatteryReadout(
+                levelPercent = 84,
+                status = android.os.BatteryManager.BATTERY_STATUS_CHARGING,
+                plugged = android.os.BatteryManager.BATTERY_PLUGGED_AC,
+                temperatureTenthsC = 305,
+            ),
+            charging = ChargingState(
+                device = DeviceInfo("Google", "Pixel 8", 36, "preview"),
+                adapterName = "Pixel Charge Control".toCaString(),
+                adapterId = "pixel",
+                adapterDetail = "Charging changes take about 15 seconds to reach the hardware".toCaString(),
+                supportedPolicies = listOf(
+                    ChargePolicy.FixedLimit(80),
+                    ChargePolicy.Adaptive,
+                    ChargePolicy.Unrestricted,
+                ),
+                reconnectSupported = true,
+                controlEnabled = true,
+                access = AccessSnapshot(
+                    direct = BackendStatus(
+                        available = true,
+                        granted = true,
+                        detail = "Charge-control access granted".toCaString(),
+                    ),
+                    shizuku = BackendStatus(
+                        available = false,
+                        granted = false,
+                        detail = "Shizuku not installed".toCaString(),
+                    ),
+                ),
+                observation = ChargeObservation.LastRequested(ChargePolicy.FixedLimit(80)),
+                unconfirmedTarget = ChargePolicy.FixedLimit(80),
+            ),
+        ),
+        adbCommand = "adb shell pm grant eu.darken.amply android.permission.WRITE_SECURE_SETTINGS",
+        onRefresh = {},
+        onSettings = {},
+        onStartFull = {},
+        onRestore = {},
+        onApply = {},
+        onQuickFullChargeChange = {},
+        onAlarmEnabledChange = {},
+        onAlarmTargetChange = {},
+        onFixNotifications = {},
+        onOpenBatteryHub = {},
+        onRetryCapture = {},
+        onPinWidget = {},
+        onAddTile = {},
+        onDismissQuickAccess = {},
+        onDismissInterruption = {},
+        onNativeSettings = {},
+        onOpenShizuku = {},
+        onAllowShizuku = {},
+        onGrantWss = {},
+        onCopyAdb = {},
+        onCopyWebUsbLink = {},
+        onPrepareSupportReport = {},
+        onCopySupportReport = {},
+        onOpenContribution = {},
+        onOpenSupportIssue = {},
+        onEmailSupport = {},
+        onHelp = {},
+    )
+}
+
 @AmplyPreview
 @Composable
 private fun DashboardScreenApplyingPreview() = PreviewWrapper {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -375,6 +375,7 @@
     <string name="dashboard_device_line">%1$s · Android API %2$d</string>
     <string name="dashboard_waiting_target">Waiting for the system to switch to %1$s — this can take about 15 seconds…</string>
     <string name="dashboard_waiting_replug">Takes effect the next time you unplug and replug the charger</string>
+    <string name="dashboard_hw_unconfirmed">The charging hardware hasn\'t confirmed %1$s yet — it may not be applying</string>
     <string name="dashboard_settling_fallback_target">the new policy</string>
     <string name="dashboard_session_once_title" formatted="false">Charging to 100% once</string>
     <string name="dashboard_session_returns">%1$s will return automatically at 100%% or when you unplug.</string>

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingSyncReadTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingSyncReadTest.kt
@@ -329,6 +329,159 @@ class ChargingSyncReadTest {
             PendingRequest(other, t0, awaitingReplug = true)
     }
 
+    // --- computeUnconfirmedTarget: expected-but-missing hardware confirmation ---
+
+    private fun unconfirmed(
+        now: Long = t0 + UNCONFIRMED_THRESHOLD_MILLIS,
+        reqPolicy: ChargePolicy? = target,
+        reqAt: Long = t0,
+        observation: ChargeObservation = ChargeObservation.LastRequested(target),
+        hardware: ChargeObservation? = null,
+        expected: Boolean = true,
+    ) = computeUnconfirmedTarget(
+        reqPolicy = reqPolicy,
+        reqAt = reqAt,
+        now = now,
+        observation = observation,
+        hardware = hardware,
+        confirmationExpected = expected,
+    )
+
+    @Test
+    fun `an expected but missing confirmation surfaces the target after the threshold`() {
+        unconfirmed() shouldBe target
+    }
+
+    @Test
+    fun `inside the grace threshold nothing surfaces`() {
+        unconfirmed(now = t0 + UNCONFIRMED_THRESHOLD_MILLIS - 1) shouldBe null
+    }
+
+    @Test
+    fun `a backwards clock never surfaces a warning`() {
+        unconfirmed(now = t0 - 1) shouldBe null
+    }
+
+    @Test
+    fun `a matching hardware confirmation clears the warning`() {
+        unconfirmed(hardware = verified(target, BackendKind.BATTERY_HARDWARE)) shouldBe null
+    }
+
+    @Test
+    fun `hardware verifying a different policy still warns while the journal stands`() {
+        // WSS-only shape: the observation is only the last request, and state 5 while a fixed limit
+        // was requested means something else engaged adaptive — a real contradiction.
+        unconfirmed(hardware = verified(ChargePolicy.Adaptive, BackendKind.BATTERY_HARDWARE)) shouldBe target
+    }
+
+    @Test
+    fun `an authoritative readback of a different policy obsoletes the request`() {
+        // Shizuku shape: the settings verifiably hold another policy — a native/competing change
+        // replaced the request, and warning about the obsolete one would contradict the card title.
+        unconfirmed(
+            observation = verified(ChargePolicy.Adaptive, BackendKind.SHIZUKU),
+            hardware = verified(ChargePolicy.Adaptive, BackendKind.BATTERY_HARDWARE),
+        ) shouldBe null
+    }
+
+    @Test
+    fun `a readback verifying the requested policy with disagreeing hardware is the intended warning`() {
+        unconfirmed(observation = verified(target, BackendKind.SHIZUKU), hardware = null) shouldBe target
+    }
+
+    @Test
+    fun `an unrecognized configured value never warns`() {
+        unconfirmed(observation = unrecognized()) shouldBe null
+    }
+
+    @Test
+    fun `settings-level verification is not hardware confirmation`() {
+        unconfirmed(hardware = verified(target, BackendKind.SHIZUKU)) shouldBe target
+    }
+
+    @Test
+    fun `no expectation means no warning`() {
+        unconfirmed(expected = false) shouldBe null
+    }
+
+    @Test
+    fun `unsupported and setup states never warn`() {
+        unconfirmed(observation = ChargeObservation.Unsupported("n/a".toCaString())) shouldBe null
+        unconfirmed(observation = ChargeObservation.NeedsSetup("n/a".toCaString())) shouldBe null
+    }
+
+    @Test
+    fun `no recorded request never warns`() {
+        unconfirmed(reqPolicy = null) shouldBe null
+        unconfirmed(reqAt = 0L) shouldBe null
+    }
+
+    @Test
+    fun `the threshold exceeds the settling window`() {
+        // The doc contract that lets the detector ignore pending entirely.
+        (UNCONFIRMED_THRESHOLD_MILLIS > SETTLING_WINDOW_MILLIS) shouldBe true
+    }
+
+    // --- debounceUnconfirmed: the contradiction must hold stable before it surfaces ---
+
+    @Test
+    fun `a fresh candidate is held back until it proves stable`() {
+        val first = debounceUnconfirmed(target, now = t0, prevCandidate = null, prevSince = 0L)
+        first.surfaced shouldBe null
+        first.candidate shouldBe target
+
+        debounceUnconfirmed(
+            target,
+            now = t0 + UNCONFIRMED_STABILITY_MILLIS,
+            prevCandidate = first.candidate,
+            prevSince = first.sinceMillis,
+        ).surfaced shouldBe target
+    }
+
+    @Test
+    fun `a transient candidate that clears never surfaces`() {
+        // The plug-in transient: state 1 for the ~12s HAL transition, then state 4 clears it.
+        val first = debounceUnconfirmed(target, now = t0, prevCandidate = null, prevSince = 0L)
+        val cleared = debounceUnconfirmed(
+            null,
+            now = t0 + 12_000,
+            prevCandidate = first.candidate,
+            prevSince = first.sinceMillis,
+        )
+        cleared.surfaced shouldBe null
+        cleared.candidate shouldBe null
+
+        // A re-appearing candidate starts a fresh stability interval.
+        debounceUnconfirmed(
+            target,
+            now = t0 + 13_000,
+            prevCandidate = cleared.candidate,
+            prevSince = cleared.sinceMillis,
+        ).surfaced shouldBe null
+    }
+
+    @Test
+    fun `a changed candidate restarts the stability interval`() {
+        val first = debounceUnconfirmed(target, now = t0, prevCandidate = null, prevSince = 0L)
+        debounceUnconfirmed(
+            ChargePolicy.FixedLimit(90),
+            now = t0 + UNCONFIRMED_STABILITY_MILLIS,
+            prevCandidate = first.candidate,
+            prevSince = first.sinceMillis,
+        ).surfaced shouldBe null
+    }
+
+    @Test
+    fun `a backwards clock restarts rather than surfacing early`() {
+        val first = debounceUnconfirmed(target, now = t0, prevCandidate = null, prevSince = 0L)
+        debounceUnconfirmed(
+            target,
+            now = t0 - 1,
+            prevCandidate = first.candidate,
+            prevSince = first.sinceMillis,
+        ).surfaced shouldBe null
+    }
+
     private class FakeBackend(override val kind: BackendKind) : AccessBackend {
         override suspend fun status() = BackendStatus(true, true, "test".toCaString())
         override suspend fun read(namespace: SettingNamespace, key: String) = SettingRead(readable = false)

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/PixelChargingAdapterTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/PixelChargingAdapterTest.kt
@@ -178,6 +178,37 @@ class PixelChargingAdapterTest {
         adapter.read(backend).shouldBeInstanceOf<ChargeObservation.Unknown>()
     }
 
+    // --- confirmationExpected: only a plugged fixed limit on a live, unmasked channel ---
+
+    @Test
+    fun `confirmation is expected for a plugged fixed limit on live channel states`() {
+        // 1 (normal — the contradiction case), 4 (delivered), 5 (something else engaged adaptive).
+        listOf(1, 4, 5).forEach { status ->
+            adapter.confirmationExpected(ChargePolicy.FixedLimit(80), status, plugged = true) shouldBe true
+        }
+    }
+
+    @Test
+    fun `thermal masking and invalid states carry no expectation`() {
+        listOf(0, 2, 3, 99, null).forEach { status ->
+            adapter.confirmationExpected(ChargePolicy.FixedLimit(80), status, plugged = true) shouldBe false
+        }
+    }
+
+    @Test
+    fun `unplugged never carries an expectation`() {
+        adapter.confirmationExpected(ChargePolicy.FixedLimit(80), 4, plugged = false) shouldBe false
+    }
+
+    @Test
+    fun `only the fixed limit is reliably reported`() {
+        // Adaptive idles at state 1 and Unrestricted maps to the same ambiguous 1 — absence of a
+        // confirmation proves nothing for either, so neither may warn.
+        adapter.confirmationExpected(ChargePolicy.Adaptive, 1, plugged = true) shouldBe false
+        adapter.confirmationExpected(ChargePolicy.Unrestricted, 1, plugged = true) shouldBe false
+        adapter.confirmationExpected(ChargePolicy.FixedLimit(90), 1, plugged = true) shouldBe false
+    }
+
     private class FakeBackend(
         private val readable: Boolean = true,
         private val values: MutableMap<String, String> = mutableMapOf(),


### PR DESCRIPTION
### What changed

When a fixed charge limit is applied but the charging hardware never confirms it, the dashboard now shows an explicit warning ("the charging hardware hasn't confirmed the 80% limit yet — it may not be applying") instead of silently looking successful. Previously the "Applying…" spinner simply disappeared after 15 seconds whether or not the limit actually engaged — hiding exactly the failure class where the setting reads back fine while charging is never limited.

### Technical Context

- Adapters declare when a confirmation is *expected* (`confirmationExpected`): Pixel only for a plugged fixed limit on a live, unmasked channel — state 4 spans the entire plugged fixed-limit session, while Adaptive idles at the ambiguous state 1 and Unrestricted maps to the same 1, so their absence proves nothing and they never warn. Sync-readback and plug-latched (GrapheneOS) adapters carry no expectation structurally; GrapheneOS's post-replug case staying silent is deliberate scope.
- The signal lives on `ChargingState`, not `PendingRequest` — mutating pending at expiry would infinite-loop the dashboard's settling-deadline observer. Deserving close review: `computeUnconfirmedTarget` + `debounceUnconfirmed` and their test matrices, and the clears in every apply publication path.
- Three false-positive classes are designed out: an authoritative readback of a *different* configured policy (native/competing change) obsoletes the request instead of warning; a 15s stability debounce damps the plug-in transient (an old request legitimately reads state 1 for the ~12s HAL transition); a second scheduled refresh at the 30s threshold makes the warning appear even when the failing HAL emits no broadcast.
- Residual limitations: on WSS-only Pixels a native change is indistinguishable from a failed old request (hidden settings unreadable — the journal wins and the warning may be wrong until any re-apply); whether wireless charging reports state 4 as reliably as wired is a pre-existing qualification gap; and a broken/thermal-masked status channel suppresses the warning rather than risking a false claim.
- Also folds the per-refresh hardware reads into one sticky battery readout shared by the decode, the pending computation, and the expectation check (plug state must never be joined across two sticky reads).
