### PR TITLE
Charging: Gate GrapheneOS charge control on Shizuku

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,14 +20,15 @@ binary Adaptive/Unrestricted) is gated to the HyperOS 2.x ROM (`ro.mi.os.version
 gated to a **physically-qualified device-codename allowlist** (HAL enforcement is per-device) plus the provider and
 system user; **reads are unprivileged (ContentResolver), writes require Shizuku** (the shell UID holds
 `lineageos.permission.WRITE_SETTINGS`, which `WRITE_SECURE_SETTINGS` does not cover). **GrapheneOS charge limit**
-(world-readable `global battery_charge_limit`, binary FixedLimit(80)/Unrestricted, WSS-writable — no Shizuku) is
-gated to GrapheneOS identity (its `app.grapheneos.*` core packages; no property/feature/fingerprint marker exists)
-plus key presence and the system user; the ROM **latches the key at plug-session start** (`policyLatchesAtPlug`),
-so external writes take effect at the next unplug→replug — handled by a pending-until-replug verification state
-and a 30s session grace window; the reconnect gesture is unsupported there. Other Pixels, Samsung on
-unverified One UI versions (6/7, 9+), non-HyperOS-2 Xiaomi devices, non-ColorOS-15 Oplus devices, unqualified
-LineageOS builds, and GrapheneOS builds without the key remain diagnostics-only. See the qualification ledger
-(`.claude/skills/device-qualification/`) for the verified devices and mappings.
+(`global battery_charge_limit`, binary FixedLimit(80)/Unrestricted) is gated to GrapheneOS identity (its
+`app.grapheneos.*` core packages; no property/feature/fingerprint marker exists) plus the system user —
+**reads AND writes require Shizuku**: GrapheneOS marks the key `@Protected`, denying it to all third-party
+packages including WSS holders, with only the shell UID exempt. The ROM **latches the key at plug-session start**
+(`policyLatchesAtPlug`), so external writes take effect at the next unplug→replug — handled by a
+pending-until-replug verification state and a 30s session grace window; the reconnect gesture is unsupported
+there. Other Pixels, Samsung on unverified One UI versions (6/7, 9+), non-HyperOS-2 Xiaomi devices,
+non-ColorOS-15 Oplus devices, and unqualified LineageOS builds remain diagnostics-only. See the qualification
+ledger (`.claude/skills/device-qualification/`) for the verified devices and mappings.
 
 Package: `eu.darken.amply`. License: GPL-3.0-or-later. Status: pre-launch (current version in `VERSION`).
 

--- a/.claude/rules/privileged-access.md
+++ b/.claude/rules/privileged-access.md
@@ -90,13 +90,27 @@ long-term observation (see Known gaps below).
 ### GrapheneOS
 
 GrapheneOS control requires **all** of: GrapheneOS identity (`DeviceInfo.isGrapheneOs` — resolved from the OS's
-core `app.grapheneos.*` packages via PackageManager `<queries>` entries; **no** graphene property, system feature,
-or fingerprint marker exists, verified on a real device), a present world-readable `global battery_charge_limit`
-key (the capability signal — GrapheneOS ships the toggle exactly where its implementation works), and the system
-user. Identity is deliberately **not** OR-ed with key presence: the adapter is registered ahead of the Pixel
-adapter, and a future stock Pixel shipping a same-named key must not be swallowed as GrapheneOS.
+core `app.grapheneos.*` system packages (FLAG_SYSTEM required) via PackageManager `<queries>` entries; **no**
+graphene property, system feature, or fingerprint marker exists, verified on a real device) and the system user.
+**Key presence is deliberately NOT a gate condition and cannot be**: GrapheneOS declares the key
+`@Protected(read = SYSTEM_UI, readWrite = SETTINGS)` (frameworks_base `c30c6393`) and its SettingsProvider throws
+`SecurityException` on reads and writes from every other package — **including `WRITE_SECURE_SETTINGS` holders**;
+the check is package-based and runs after the permission check (`e87c93a2`). The unprivileged probe therefore
+reads absent whether the key exists or not (verified via the issue-#49 beta report: probe false while the same
+report showed the limit enforcing). The feature is treated as present on any GrapheneOS build (Xiaomi-precedent
+assumption; their platform ships it for every Google device, which is every device GrapheneOS supports). Accepted
+failure mode, same class as Xiaomi's: on a build without the feature a shell-UID write could still create the row
+and read back, yielding a harmless false claim of configured control — no battery hazard, and the hardware decode
+(state 4) stays honest.
 
-The key is binary (`1` = fixed 80% cap with bypass charging, `0` = off) and WSS-writable — **no Shizuku needed**.
+**Access is Shizuku-only.** The one usable exemption in their enforcement is the shell UID ("ADB is used for
+testing"), which is how the Shizuku user service executes `settings get/put`. The adapter sets
+`preferShizukuForWrites`; direct reads come back unreadable (SecurityException → `access_read_blocked`) and
+`readSyncDirectFirst` falls through to the Shizuku backend. The key is binary (`1` = fixed 80% cap with bypass
+charging, `0` = off); an **absent key decodes as the factory off state** — upstream reads it through
+`BoolSetting(GLOBAL, BATTERY_CHARGE_LIMIT, /* default */ false)`, so a never-toggled device has no row and
+charges unrestricted.
+
 The defining quirk is **`policyLatchesAtPlug`**: the ROM samples the key only at plug-session start, so an external
 write reads back correctly but has no hardware effect until the next unplug→replug (the native Settings toggle
 applies live because Settings pokes the charging service directly). Three mechanisms handle this — the
@@ -108,10 +122,10 @@ enforcement evidence. The reconnect gesture is unsupported — its override writ
 broadcast, which the ROM has already sampled past.
 
 Qualification is **remote** (issue #49, Pixel 9 Pro XL `komodo`, GrapheneOS 2026080501 / Android 17): the tester
-physically observed enforcement (held at 80% with the shield and state 4) and the latch behavior. Package
-visibility of `app.grapheneos.*` from app context and the factory-absent key state are still unverified on-device;
-both fail closed (Pixel-adapter diagnostics, or diagnostics + contribution wizard). Record any new evidence in the
-qualification ledger (`device-qualification` skill).
+physically observed enforcement (held at 80% with the shield and state 4), the latch behavior, and — via the
+0.3.2-beta0 report — that package detection works from app context while unprivileged key access is denied.
+Shizuku-path writes are the same shell-UID mechanism the tester's adb commands proved. Record any new evidence in
+the qualification ledger (`device-qualification` skill).
 
 ### LineageOS
 

--- a/.claude/skills/device-qualification/SKILL.md
+++ b/.claude/skills/device-qualification/SKILL.md
@@ -51,6 +51,7 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
 | Xiaomi | Xiaomi 13T `2306EPN60G` HyperOS 2.0 (`ro.mi.os.version.code=2`) | **Partial** — mapping/readback/session verified; the adaptive 80% hold could not be triggered, so daemon-level hardware enforcement is **not yet demonstrated** | Read matrix, both-direction writes, session at 100%, unknown-value refusal, R8 beta | 2026-07-21 |
 | OnePlus (Oplus) | OnePlus Nord CE4 Lite `CPH2621` ColorOS 15 (`ro.build.version.oplusrom=V15.0.0`) | Full — enforcement directly observable (device holds at 80%); external writes stick | Two mutually-exclusive `system` keys (Charging limit / Smart charging), WSS-only write rejected + Shizuku write succeeds for all three policies, WSS-only UX (controls disabled + Shizuku-required banner) | 2026-07-21 |
 | GrapheneOS | Pixel 9 Pro XL `komodo`, GrapheneOS 2026080501 / Android 17 — **REMOTE qualification via issue #49** (tester-run protocol, not maintainer hardware) | **Enforcement observed**: held at 80% with shield, `dumpsys battery` status=4/Charging state=4/policy=2 (limit on) vs 2/1/1 (off); shell-UID writes move the Settings UI live, **latch at plug-session start** — mid-session writes have no hardware effect until unplug→replug, replug reliably applies the current value | Key isolation (`settings list` diff → single `global battery_charge_limit` 0/1), write→UI both directions, mid-session no-op both directions, replug latch both directions, hardware signal both states. **NOT run**: app-context access tiers (WSS write from Amply, `app.grapheneos.*` package visibility), sessions/boot recovery, wireless, factory-absent key state, secondary user | 2026-08-12 |
+| GrapheneOS (follow-up) | Same device, **0.3.2-beta0 on-device report via issue #49** | **Package detection VERIFIED from app context** (`is_grapheneos=true` with the FLAG_SYSTEM check); **unprivileged key read DENIED** — `has_battery_charge_limit=false` while the very same report showed `battery_charging_status=4` (limit enforcing). Root cause in GrapheneOS source: the key is `@Protected(read = SYSTEM_UI, readWrite = SETTINGS)` (frameworks_base `c30c6393`); SettingsProvider throws SecurityException for all other packages **including WSS holders**, with the shell UID explicitly exempt ("ADB is used for testing", `e87c93a2`) — so the tester's earlier adb runs ARE the Shizuku-path evidence. Factory-absent semantics resolved from source: `BoolSetting(..., default false)` → absent = off | Detection + fail-closed probe verified live; adapter re-gated to Shizuku-only in response | 2026-08-13 |
 
 ## Known gaps
 
@@ -116,18 +117,14 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
     ROM: install/launch/onboarding/dashboard/settings with no crashes, honest "Unsupported device" reporting, live
     battery monitoring across simulated plug/level transitions, and the charge alarm firing at threshold.
 - **GrapheneOS** — landed **live** on remote qualification (issue #49; the only OEM row not tested on maintainer
-  hardware). Open items, all failing closed:
-  - **`app.grapheneos.*` package visibility from app context is unverified** — `<queries>` package entries are
-    specified platform behavior (not SELinux-fragile like `ro.lineage.*`), but GrapheneOS hardens aggressively. If
-    the packages are hidden, `isGrapheneOs` is false and the device falls to the Pixel adapter as
-    matched/diagnostics-only — no unsafe write path, but support silently vanishes; the first tester report of
-    "still unsupported" on the test build should check `is_grapheneos=` in the device report.
-  - **App-context WSS write unverified** — the tester's writes ran as shell UID; an Amply-originated
-    `Settings.Global.putString` under granted WSS is expected to behave identically (same namespace rules) but has
-    not been observed. The read-back-equality check catches a silently-failing write.
-  - **Factory-absent key state unknown** — the tester's device had the key present while off; whether a
-    never-toggled install exposes it is unverified. Absent → gate fails closed → diagnostics + contribution wizard
-    (`adapter_detail_grapheneos_no_key`), and `read()` refuses (`unrecognizedValue`) so a session never clobbers it.
+  hardware), then **re-gated to Shizuku-only** after the 0.3.2-beta0 on-device report (see the follow-up ledger
+  row). Resolved since the landing PR: package visibility ✔ verified from app context; app-context WSS access ✘
+  resolved as DENIED (`@Protected` — the reason for the re-gate, not a bug in Amply); factory-absent key state ✔
+  resolved from upstream source (`BoolSetting` default false → absent decodes as Unrestricted). Still open, all
+  failing closed or cosmetic:
+  - **Shizuku end-to-end on real hardware unverified** — the shell-UID `settings get/put` mechanism is proven (the
+    tester's adb runs), but Amply's own Shizuku service driving it, plus sessions/boot recovery/R8 smoke, await the
+    next beta report on issue #49.
   - **State 4 below the limit unverified** — evidence was sampled at the 80% hold; if the ROM reports 4 only while
     holding, a FixedLimit pending clears late (at the hold) instead of instantly. Cosmetic.
   - **A plugged restore configures but cannot enforce** — restore-at-100%, the 24h safety timeout,
@@ -137,7 +134,6 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
     session/recovery closed, pending-until-replug hint shown — and the exposure is one charge cycle,
     bounded by the plug session the user is already in. Deliberately NOT treated as a defect.
   - **Wireless charging and secondary users**: NOT RUN (gated to system user).
-  - Sessions/boot-recovery/R8 smoke on real GrapheneOS hardware: pending the test build posted to issue #49.
 - **Xiaomi** — adaptive hardware enforcement of external writes unconfirmed; treat the adapter as provisional until
   the 80% hold is physically observed.
   - **HyperOS 3 candidate mapping (contribution report, 2026-08-07 — unqualified, stays diagnostics-only).** A

--- a/.claude/skills/oem-adapters/SKILL.md
+++ b/.claude/skills/oem-adapters/SKILL.md
@@ -95,18 +95,22 @@ clobbering the user's native choice. Verified devices + coverage: see the qualif
 One live adapter (`grapheneos-chargelimit-v1`) for GrapheneOS's own "Limit to 80%" (Settings → Battery → Charging
 optimization). **ROM-identity adapter, ordered after the Lineage pair and BEFORE `pixel`** in `AdapterRegistry` —
 GrapheneOS ships only on Pixels, and the Pixel probe (any Google/Pixel*) would otherwise swallow the device as a
-matched-but-diagnostics-only stock Pixel. Gate: `DeviceInfo.isGrapheneOs` (core `app.grapheneos.*` packages via
-PackageManager `<queries>` — NO property/feature/fingerprint marker exists; verified empty on a real device) +
-`hasBatteryChargeLimit` (world-readable key presence — the capability signal, deliberately NOT part of identity) +
-system user. No lab adapter: a GrapheneOS build without the key stays on this adapter as diagnostics-only with
-`contributionWanted`.
+matched-but-diagnostics-only stock Pixel. Gate: `DeviceInfo.isGrapheneOs` (core `app.grapheneos.*` FLAG_SYSTEM
+packages via PackageManager `<queries>` — NO property/feature/fingerprint marker exists; verified on a real
+device) + system user. **Key presence is not — and cannot be — a gate condition**: the key is `@Protected`
+(below), so the unprivileged probe reads absent regardless; the feature is assumed present on any GrapheneOS
+build (their platform ships it for every Google device). No lab adapter; `contributionWanted = false`.
 
 Single key `global battery_charge_limit`: `1` = fixed 80% cap (bypass charging; hard-wired, no threshold key) →
-`FixedLimit(80)`, `0` = off → `Unrestricted`; absent/other → `Unknown(unrecognizedValue=true)` (factory-absent
-semantics unverified — refuse, don't guess). WSS-writable, **no Shizuku**. SYNC_READBACK with read-back equality;
-session override = Unrestricted; protective default = FixedLimit(80); `reapply == apply` (no observer-poke — see
-below); reconnect gesture **unsupported** (structurally: the gesture's override write lands strictly after the
-replug broadcast, which the ROM has already sampled past).
+`FixedLimit(80)`, `0` **or absent** → `Unrestricted` (upstream reads it via `BoolSetting(..., default false)` —
+absent IS the factory off state); other → `Unknown(unrecognizedValue=true)`. **Reads and writes are Shizuku-only**:
+GrapheneOS declares the key `@Protected(read = SYSTEM_UI, readWrite = SETTINGS)` (frameworks_base `c30c6393`) and
+throws SecurityException for every other package *including WSS holders* (`e87c93a2`); the shell UID is the one
+usable exemption, which is exactly the Shizuku user service's `settings get/put` path. `preferShizukuForWrites`;
+direct reads come back unreadable and `readSyncDirectFirst` falls through to Shizuku. SYNC_READBACK with read-back
+equality; session override = Unrestricted; protective default = FixedLimit(80); `reapply == apply` (no
+observer-poke — see below); reconnect gesture **unsupported** (structurally: the gesture's override write lands
+strictly after the replug broadcast, which the ROM has already sampled past).
 
 **The defining quirk: `policyLatchesAtPlug = true`.** GrapheneOS samples the key only at plug-session start; an
 external write updates the Settings UI live but has no hardware effect until the next unplug→replug (the native

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -270,11 +270,12 @@ class ChargingRepository @Inject constructor(
     }
 
     /**
-     * Sync-readback adapters use world-readable / unprivileged keys, so the DIRECT provider read is
+     * Most sync-readback adapters use world-readable keys, so the DIRECT provider read is
      * authoritative and — unlike a Shizuku user-service bind, which can block up to ~15s on a cold process
      * ([ShizukuController.service]) — never stalls. Read direct first so that bind is never on the critical
-     * path (the widget/tile refresh after a tap); consult Shizuku only as a fallback when the direct read is
-     * not authoritative on some ROM. A nominally "ready" but misbehaving Shizuku service therefore can no
+     * path (the widget/tile refresh after a tap); consult Shizuku as the fallback when the direct read is
+     * not authoritative — including GrapheneOS's @Protected key, where the direct read is always denied
+     * and Shizuku (shell UID) is the only readable path. A nominally "ready" but misbehaving Shizuku service therefore can no
      * longer delay verification.
      */
     private suspend fun readSyncWithFallback(adapter: ChargingAdapter): ChargeObservation? {
@@ -603,11 +604,12 @@ class ChargingRepository @Inject constructor(
 
 /**
  * Read a sync-readback adapter's configured state, preferring the [direct] provider and consulting
- * [shizuku] (may be null when not ready) only as a fallback. Direct reads of these adapters' world-readable
- * keys are authoritative and cannot stall, so an *authoritative* direct read — [ChargeObservation.Verified]
+ * [shizuku] (may be null when not ready) only as a fallback. A direct read of a world-readable key is
+ * authoritative and cannot stall, so an *authoritative* direct read — [ChargeObservation.Verified]
  * or a readable-but-unrecognized OEM value — short-circuits without ever binding the Shizuku user service
- * (both backends read the same settings provider, so Shizuku could not report anything stronger). Only a
- * genuinely unreadable direct result falls back to Shizuku.
+ * (both backends read the same settings provider, so Shizuku could not report anything stronger). A
+ * genuinely unreadable direct result falls back to Shizuku — the routine case for GrapheneOS's @Protected
+ * key, which the provider denies to Amply but not to the shell UID.
  */
 internal suspend fun readSyncDirectFirst(
     adapter: ChargingAdapter,

--- a/app/src/main/java/eu/darken/amply/charging/core/DeviceInfo.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/DeviceInfo.kt
@@ -88,8 +88,11 @@ data class DeviceInfo(
                     Settings.Global.getString(it.contentResolver, KEY_PROTECT_BATTERY) != null
                 }.getOrDefault(false)
             } ?: false,
-            // GrapheneOS's charge-limit key, world-readable in `global`. Presence is the capability
-            // gate (the OS only ships the toggle where its implementation works); fail closed.
+            // GrapheneOS's charge-limit key. NOT a gate: GrapheneOS marks the key @Protected, so
+            // this unprivileged read throws SecurityException (→ false) on real GrapheneOS whether
+            // the key exists or not — verified via the issue-#49 beta report. Kept as a diagnostic
+            // signal only: true would indicate a ROM exposing a same-named key WITHOUT the
+            // GrapheneOS restriction, which is worth seeing in a device-support report.
             hasBatteryChargeLimit = context?.let {
                 runCatching {
                     Settings.Global.getString(it.contentResolver, KEY_BATTERY_CHARGE_LIMIT) != null

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
@@ -58,11 +58,13 @@ interface ChargingAdapter {
     val reconnectGestureSupported: Boolean get() = false
 
     /**
-     * Prefer Shizuku over direct WSS for writes. Set by adapters whose keys live in the `system`
-     * namespace: `WRITE_SECURE_SETTINGS` covers secure/global but not system, so a direct write
-     * would silently fail — Shizuku (shell UID) can write system. Reads are unaffected (system is
-     * world-readable). Direct WSS is still tried as a last resort, and read-back verification
-     * catches a write that did not land.
+     * Prefer Shizuku over direct WSS for writes. Two adapter classes set it: keys in the `system`
+     * namespace (OnePlus/ColorOS — `WRITE_SECURE_SETTINGS` covers secure/global but not system, so
+     * a direct write silently fails while reads stay world-readable), and per-key access-controlled
+     * keys (GrapheneOS's `@Protected` charge limit — the provider rejects reads AND writes from
+     * everyone but its own system packages and the shell UID, WSS or not; there the direct read
+     * comes back unreadable and the sync-read fallback consults Shizuku). Direct WSS is still tried
+     * as a last resort, and read-back verification catches a write that did not land.
      */
     val preferShizukuForWrites: Boolean get() = false
 

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapter.kt
@@ -23,7 +23,16 @@ import javax.inject.Singleton
  * .claude/skills/device-qualification/):
  *
  * - `global battery_charge_limit` — "Limit to 80%": `1` = hard 80% cap (with bypass charging),
- *   `0` = off. Hard-wired to 80, no threshold key. World-readable; writes need only WSS.
+ *   `0` = off. Hard-wired to 80, no threshold key.
+ *
+ * **Access is Shizuku-only.** GrapheneOS declares the key `@Protected(read = SYSTEM_UI, readWrite =
+ * SETTINGS)` (frameworks_base c30c6393) and its SettingsProvider throws SecurityException on both
+ * reads and writes from every other package — including WRITE_SECURE_SETTINGS holders; the check is
+ * package-based and runs after the permission check (e87c93a2). The one exemption Amply can use is
+ * the shell UID ("ADB is used for testing" in their enforcement), which is exactly how the Shizuku
+ * user service executes `settings get/put`. Verified on-device via the issue-#49 beta run: the
+ * unprivileged key probe returned false while the same report showed the limit enforcing
+ * (charging state 4), i.e. reads fail closed as designed.
  *
  * The defining quirk is [policyLatchesAtPlug]: GrapheneOS samples the key only at the START of a
  * plug session. An external write updates the Settings UI live but has no hardware effect until
@@ -39,10 +48,17 @@ import javax.inject.Singleton
  * this ROM. The reconnect gesture stays unsupported: its override write lands strictly after the
  * replug broadcast, which this ROM has already sampled past.
  *
- * Identity is package-based ([DeviceInfo.isGrapheneOs]); capability is the key's presence — the OS
- * ships the toggle exactly where its implementation works, and GrapheneOS is a single vendor on a
- * narrow Pixel-only device set, so no codename allowlist is needed. Registered BEFORE the Pixel
- * adapter, whose Google+Pixel probe would otherwise swallow every GrapheneOS device.
+ * Identity is package-based ([DeviceInfo.isGrapheneOs]). The key's presence is deliberately NOT a
+ * gate condition: `@Protected` makes it unprobeable from app context (the unprivileged read is
+ * denied whether the key exists or not), so the feature is treated as present on any GrapheneOS
+ * build — the Xiaomi-precedent assumption, with the same accepted failure mode: on a hypothetical
+ * build without the feature, a shell-UID write can still create the row and read it back, so Amply
+ * would claim configured control that no charging component consumes. That is a harmless false
+ * claim (no battery hazard — nothing enforces anything), and the hardware decode stays honest
+ * (state 4 never appears). Their charge-limit implementation ships in the platform for every
+ * Google device (BatteryChargeLimit.isGoogleDevice()), which is every device GrapheneOS supports,
+ * so the assumption has no known counterexample. Registered BEFORE the Pixel adapter, whose
+ * Google+Pixel probe would otherwise swallow every GrapheneOS device.
  */
 @Singleton
 class GrapheneOsChargingAdapter @Inject constructor() : ChargingAdapter {
@@ -57,6 +73,12 @@ class GrapheneOsChargingAdapter @Inject constructor() : ChargingAdapter {
     override val verification = VerificationStrategy.SYNC_READBACK
     override val policyLatchesAtPlug = true
 
+    // Not because the namespace needs it (global is WSS-writable elsewhere) but because the key is
+    // @Protected: a direct write throws SecurityException no matter which permissions Amply holds,
+    // while the shell UID is exempt. Reads share the restriction; readSyncDirectFirst's direct
+    // attempt comes back unreadable and falls through to the Shizuku backend.
+    override val preferShizukuForWrites = true
+
     override val observedSettingUris
         get() = listOf(Settings.Global.getUriFor(KEY_CHARGE_LIMIT))
 
@@ -64,16 +86,17 @@ class GrapheneOsChargingAdapter @Inject constructor() : ChargingAdapter {
         val matched = device.isGrapheneOs
         return AdapterSupport(
             matched = matched,
-            controlEnabled = matched && device.hasBatteryChargeLimit && device.isSystemUser,
+            // No key-presence condition: @Protected denies the unprivileged probe regardless of
+            // whether the key exists, so presence is assumed on GrapheneOS (see the class doc).
+            controlEnabled = matched && device.isSystemUser,
             detail = when {
                 !matched -> R.string.adapter_detail_requires_grapheneos
-                !device.hasBatteryChargeLimit -> R.string.adapter_detail_grapheneos_no_key
                 !device.isSystemUser -> R.string.adapter_detail_secondary_user
                 else -> R.string.adapter_detail_grapheneos_ready
             },
-            // A GrapheneOS build without the key is exactly what the contribution wizard can map
-            // (e.g. a future release that moves or renames it).
-            contributionWanted = matched && !device.hasBatteryChargeLimit,
+            // The keys are fully mapped; there is nothing for a contribution to discover, and the
+            // guided wizard's capture (Shizuku, shell UID) would only re-find the known key.
+            contributionWanted = false,
         )
     }
 
@@ -85,11 +108,12 @@ class GrapheneOsChargingAdapter @Inject constructor() : ChargingAdapter {
             )
         }
         return when (limit.value) {
-            VALUE_OFF -> ChargeObservation.Verified(ChargePolicy.Unrestricted, backend.kind)
+            // Absence IS the factory off state, by upstream definition: GrapheneOS reads the key
+            // through BoolSetting(Scope.GLOBAL, BATTERY_CHARGE_LIMIT, /* default */ false)
+            // (frameworks_base c30c6393), so a never-toggled device has no row and charges
+            // unrestricted. Decoding it as such is what lets a session run on a fresh install.
+            null, VALUE_OFF -> ChargeObservation.Verified(ChargePolicy.Unrestricted, backend.kind)
             VALUE_LIMITED -> ChargeObservation.Verified(ChargePolicy.FixedLimit(LIMIT_PERCENT), backend.kind)
-            // Includes absence: the gate required the key, so a missing value mid-run is an anomaly,
-            // and the factory-absent state is unverified — refuse rather than guess (a session start
-            // refuses on this instead of overwriting a state it cannot restore).
             else -> ChargeObservation.Unknown(
                 R.string.charging_reason_value_unrecognized.toCaString(
                     KEY_CHARGE_LIMIT, limit.value.toString(),

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -1236,12 +1236,16 @@ private fun DashboardScreenAwaitingReplugPreview() = PreviewWrapper {
                 device = DeviceInfo("Google", "Pixel 9 Pro XL", 37, "preview"),
                 adapterName = "GrapheneOS charge limit".toCaString(),
                 adapterId = "grapheneos-chargelimit-v1",
-                adapterDetail = "Changes take effect the next time the charger is reconnected".toCaString(),
+                adapterDetail = ("Charging control requires Shizuku; changes take effect the next " +
+                    "time the charger is reconnected").toCaString(),
                 supportedPolicies = listOf(
                     ChargePolicy.FixedLimit(80),
                     ChargePolicy.Unrestricted,
                 ),
                 syncVerification = true,
+                // GrapheneOS marks the key @Protected: only the shell UID (Shizuku) can touch it,
+                // so the realistic ready state is Shizuku-connected, direct access irrelevant.
+                writeRequiresShizuku = true,
                 controlEnabled = true,
                 access = AccessSnapshot(
                     direct = BackendStatus(
@@ -1250,14 +1254,14 @@ private fun DashboardScreenAwaitingReplugPreview() = PreviewWrapper {
                         detail = "Charge-control access granted".toCaString(),
                     ),
                     shizuku = BackendStatus(
-                        available = false,
-                        granted = false,
-                        detail = "Shizuku not installed".toCaString(),
+                        available = true,
+                        granted = true,
+                        detail = "Shizuku connected".toCaString(),
                     ),
                 ),
                 observation = ChargeObservation.Verified(
                     ChargePolicy.Unrestricted,
-                    BackendKind.DIRECT_WSS,
+                    BackendKind.SHIZUKU,
                 ),
                 pending = PendingRequest(
                     ChargePolicy.Unrestricted,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,8 +138,7 @@
     <string name="adapter_detail_requires_oplus">Requires a OnePlus, Oppo, or Realme device on ColorOS 15</string>
     <string name="adapter_detail_oplus_ready">Charging control requires Shizuku on this device</string>
     <string name="adapter_detail_requires_grapheneos">Requires GrapheneOS</string>
-    <string name="adapter_detail_grapheneos_no_key">GrapheneOS detected, but its charge-limit setting is not present on this build</string>
-    <string name="adapter_detail_grapheneos_ready">Changes take effect the next time the charger is reconnected</string>
+    <string name="adapter_detail_grapheneos_ready">Charging control requires Shizuku; changes take effect the next time the charger is reconnected</string>
     <string name="adapter_detail_requires_lineageos">Requires a qualified LineageOS device</string>
     <string name="adapter_detail_lineageos_no_provider">LineageOS charging control is not available on this build</string>
     <string name="adapter_detail_lineageos_ready">Charging control requires Shizuku on this device</string>
@@ -414,7 +413,7 @@
     <string name="dashboard_shizuku_title">Better with Shizuku</string>
     <string name="dashboard_shizuku_body">Shizuku gives Amply exact policy readback instead of relying on hardware state and the last request.</string>
     <string name="dashboard_shizuku_required_title">Shizuku required to change charging</string>
-    <string name="dashboard_shizuku_required_body">This device stores its charging setting where only Shizuku can change it. Connect Shizuku to switch policies; without it Amply can still show the current state.</string>
+    <string name="dashboard_shizuku_required_body">This device stores its charging setting where only Shizuku can change it. Connect Shizuku to switch policies; until then the charging controls stay disabled.</string>
     <string name="dashboard_shizuku_allow">Allow access</string>
     <string name="dashboard_shizuku_open">Open Shizuku</string>
     <string name="dashboard_adb_copied">ADB command copied</string>

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
@@ -106,11 +106,13 @@ class AdapterRegistrySelectionTest {
     }
 
     @Test
-    fun `grapheneos without the key stays on its adapter as diagnostics-only`() {
+    fun `grapheneos keeps control without the key probe`() {
+        // The real-device shape: @Protected denies the unprivileged probe, so the key always reads
+        // absent from app context (issue-#49 beta report) — control must not gate on it.
         val selection = registry.select(graphene(key = false))
         selection.adapter?.id shouldBe "grapheneos-chargelimit-v1"
-        selection.support.controlEnabled shouldBe false
-        selection.support.contributionWanted shouldBe true
+        selection.support.controlEnabled shouldBe true
+        selection.support.contributionWanted shouldBe false
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/ContributionEligibilityTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/ContributionEligibilityTest.kt
@@ -73,13 +73,13 @@ class ContributionEligibilityTest {
     }
 
     @Test
-    fun `grapheneos with the key does not solicit, without it it does`() {
+    fun `grapheneos never solicits a contribution regardless of the key probe`() {
+        // The unprivileged key probe is @Protected-denied on real GrapheneOS, so its result carries
+        // no information; the keys are fully mapped and nothing is left to discover.
         val ready = device("Google", model = "Pixel 9 Pro XL", sdk = 37)
             .copy(hasChargingOptimization = false, hasGrapheneOsPackages = true, hasBatteryChargeLimit = true)
         registry.select(ready).support.contributionWanted shouldBe false
-
-        // A future GrapheneOS build that drops or moves the key is exactly what the wizard can map.
-        registry.select(ready.copy(hasBatteryChargeLimit = false)).support.contributionWanted shouldBe true
+        registry.select(ready.copy(hasBatteryChargeLimit = false)).support.contributionWanted shouldBe false
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapterTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapterTest.kt
@@ -58,13 +58,15 @@ class GrapheneOsChargingAdapterTest {
     }
 
     @Test
-    fun `a missing key keeps control off and asks for a contribution`() {
+    fun `the unprobeable key never gates control`() {
+        // @Protected denies the unprivileged key probe on real GrapheneOS (hasBatteryChargeLimit is
+        // always false there — verified via the issue-#49 beta report), so presence is assumed.
         val support = adapter.probe(graphene(key = false))
 
         support.matched shouldBe true
-        support.controlEnabled shouldBe false
-        support.detail shouldBe R.string.adapter_detail_grapheneos_no_key
-        support.contributionWanted shouldBe true
+        support.controlEnabled shouldBe true
+        support.detail shouldBe R.string.adapter_detail_grapheneos_ready
+        support.contributionWanted shouldBe false
     }
 
     @Test
@@ -79,19 +81,17 @@ class GrapheneOsChargingAdapterTest {
     @Test
     fun `read maps both values`() = runTest {
         adapter.read(backend("1")) shouldBe
-            ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.DIRECT_WSS)
+            ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.SHIZUKU)
         adapter.read(backend("0")) shouldBe
-            ChargeObservation.Verified(ChargePolicy.Unrestricted, BackendKind.DIRECT_WSS)
+            ChargeObservation.Verified(ChargePolicy.Unrestricted, BackendKind.SHIZUKU)
     }
 
     @Test
-    fun `an absent key is unrecognized, not a policy`() = runTest {
-        // The gate required presence; factory-absent semantics are unverified. Refusing keeps a
-        // session start from overwriting a state this adapter cannot restore.
-        val observed = adapter.read(FakeBackend())
-
-        observed.shouldBeInstanceOf<ChargeObservation.Unknown>()
-        observed.unrecognizedValue shouldBe true
+    fun `an absent key is the factory off state`() = runTest {
+        // Upstream reads the key via BoolSetting(..., default false): a never-toggled device has no
+        // row and charges unrestricted, so absence decodes as exactly that.
+        adapter.read(FakeBackend()) shouldBe
+            ChargeObservation.Verified(ChargePolicy.Unrestricted, BackendKind.SHIZUKU)
     }
 
     @Test
@@ -177,7 +177,8 @@ class GrapheneOsChargingAdapterTest {
         adapter.verification shouldBe VerificationStrategy.SYNC_READBACK
         adapter.policyLatchesAtPlug shouldBe true
         adapter.reconnectGestureSupported shouldBe false
-        adapter.preferShizukuForWrites shouldBe false
+        // Not a namespace need: the key is @Protected and only the shell UID (Shizuku) may touch it.
+        adapter.preferShizukuForWrites shouldBe true
     }
 
     private fun backend(value: String) =
@@ -189,7 +190,8 @@ class GrapheneOsChargingAdapterTest {
         private val failWrites: Boolean = false,
         private val dropWrites: Boolean = false,
     ) : AccessBackend {
-        override val kind = BackendKind.DIRECT_WSS
+        // The realistic provenance on GrapheneOS: only the shell UID (Shizuku) can read the key.
+        override val kind = BackendKind.SHIZUKU
         val writes = mutableListOf<SettingMutation>()
 
         override suspend fun status() = BackendStatus(true, true, "test".toCaString())

--- a/app/src/test/java/eu/darken/amply/main/core/DeviceSupportReporterTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/core/DeviceSupportReporterTest.kt
@@ -120,9 +120,9 @@ class DeviceSupportReporterTest {
     }
 
     @Test
-    fun `a grapheneos report carries identity and key presence`() {
-        // The triage-relevant pairing: identity without the key means the wizard should discover it;
-        // identity with the key means the live gate should have engaged.
+    fun `a grapheneos report carries identity and the key probe result`() {
+        // The probe is @Protected-denied on real GrapheneOS, so false is the expected value there;
+        // true would flag a ROM exposing a same-named key WITHOUT the GrapheneOS restriction.
         val text = formatReport(report(isGrapheneOs = true, hasBatteryChargeLimit = true))
         text shouldContain "is_grapheneos=true"
         text shouldContain "has_battery_charge_limit=true"


### PR DESCRIPTION
### What changed

GrapheneOS charge control now requires Shizuku. The first beta on a real device (#49) showed the app detecting GrapheneOS but refusing control with "charge limit setting is not present" — the setting exists, but GrapheneOS deliberately blocks all third-party access to it, including apps holding `WRITE_SECURE_SETTINGS`. Only the shell (which Shizuku provides) is allowed through. With Shizuku connected, everything works as designed: switching the limit, the one-time full charge with the unplug/replug step, and exact state readback. Without Shizuku the app now shows the same "Shizuku required" guidance used on OnePlus/ColorOS devices instead of a wrong "setting not present" message. A fresh install that never touched the native toggle is now also handled (previously it would have refused sessions).

### Technical Context

- Root cause with receipts: GrapheneOS marks the key `@Protected(read = SYSTEM_UI, readWrite = SETTINGS)` (frameworks_base `c30c6393`); their SettingsProvider throws `SecurityException` for every other package *after* the WSS permission check, with the shell UID explicitly exempt ("ADB is used for testing", `e87c93a2`). The tester's earlier successful adb runs were unknowingly the Shizuku-path qualification.
- The key-presence gate had to go, not just weaken: `@Protected` denies the unprivileged probe whether the key exists or not, so presence carries zero information from app context. Presence is now assumed on GrapheneOS (the Xiaomi-precedent assumption; accepted failure mode is a harmless false claim of configured control on a hypothetical build without the feature — the row would still be writable, but nothing enforces and the hardware decode stays honest).
- Absent-key decode flipped from refuse to `Unrestricted` because upstream source resolves it: GrapheneOS reads the key via `BoolSetting(..., default false)`, so absent *is* the factory off state.
- No read-path code change: `readSyncDirectFirst` already treats the blocked direct read as non-authoritative and falls through to the Shizuku backend. Deserves close review: the probe/gate change in `GrapheneOsChargingAdapter` and the shared `dashboard_shizuku_required_body` copy fix (its "can still show the current state" claim was Oplus-only truth).
- On-device evidence from the beta is recorded in the qualification ledger: package detection verified from app context, unprivileged access denied as designed (fail closed). The Shizuku path end-to-end on real hardware awaits the next beta report in #49, which CI cannot cover.
