### PR TITLE
Charging: Add HyperOS 3 Battery Protection support for qualified Xiaomi devices

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,8 +11,10 @@ timeout.
 Several control adapters exist — four OEM adapters plus two custom-ROM adapters (LineageOS, GrapheneOS). **Pixel charging optimization** is capability-gated to Pixel 6a and newer phones on
 Android 15+ when Google's charging-optimization controller is present. **Samsung battery protection** (global
 `protect_battery` keys) is gated to verified One UI generations — One UI 8 multi-mode, and the legacy One UI 4/5
-toggle — on the system user. **Xiaomi charging protection** (secure `security_pc_secure_protect_mode_key`,
-binary Adaptive/Unrestricted) is gated to the HyperOS 2.x ROM (`ro.mi.os.version.code == 2`) on Xiaomi devices.
+toggle — on the system user. **Xiaomi charging protection** (secure `security_pc_secure_protect_mode_key`)
+has two adapters: binary Adaptive/Unrestricted gated to the HyperOS 2.x ROM (`ro.mi.os.version.code == 2`), and a
+HyperOS 3 three-mode variant adding a FixedLimit(80) hard cap — gated to HyperOS 3 **plus a qualified-codename
+allowlist** (mode `2` is not HyperOS-3-wide and cannot be probed at runtime).
 **OnePlus/ColorOS charging protection** (mutually-exclusive `system` keys `regular_/smart_charge_protection_switch_state`
 = FixedLimit(80)/Adaptive) is gated to ColorOS 15 (`ro.build.version.oplusrom == 15`) across the Oplus family
 (OnePlus/Oppo/Realme) — **writes require Shizuku** (system namespace). **LineageOS charging control** (the private
@@ -26,7 +28,7 @@ system user; **reads are unprivileged (ContentResolver), writes require Shizuku*
 packages including WSS holders, with only the shell UID exempt. The ROM **latches the key at plug-session start**
 (`policyLatchesAtPlug`), so external writes take effect at the next unplug→replug — handled by a
 pending-until-replug verification state and a 30s session grace window; the reconnect gesture is unsupported
-there. Other Pixels, Samsung on unverified One UI versions (6/7, 9+), non-HyperOS-2 Xiaomi devices,
+there. Other Pixels, Samsung on unverified One UI versions (6/7, 9+), unqualified Xiaomi devices,
 non-ColorOS-15 Oplus devices, and unqualified LineageOS builds remain diagnostics-only. See the qualification
 ledger (`.claude/skills/device-qualification/`) for the verified devices and mappings.
 

--- a/.claude/rules/privileged-access.md
+++ b/.claude/rules/privileged-access.md
@@ -79,13 +79,26 @@ without a qualified device; record results in the qualification ledger (`device-
 
 ### Xiaomi
 
-Xiaomi control requires **all** of: Xiaomi manufacturer (covers Redmi/POCO, which report Xiaomi as
-manufacturer), `ro.mi.os.version.code == 2` (HyperOS 2.x — the ROM feature is version-scoped, not
-model-scoped), and the system user. Use `ro.mi.os.version.code`, NOT the frozen legacy
-`ro.miui.ui.version.code`. Do not widen to HyperOS 3+ without qualifying a device; record results in the qualification ledger (`device-qualification` skill). The single key is per-user `secure`, applied synchronously. Two deliberate
-assumptions: the feature is treated as present on any HyperOS 2 device (a device lacking it reads the key
-absent → a harmless false claim of control), and daemon-level enforcement of external writes is pending
-long-term observation (see Known gaps below).
+Two live adapters over the same per-user `secure` key (applied synchronously). Use `ro.mi.os.version.code`, NOT
+the frozen legacy `ro.miui.ui.version.code`.
+
+**HyperOS 2** (`xiaomi-hyperos2-v1`) requires **all** of: Xiaomi manufacturer (covers Redmi/POCO, which report
+Xiaomi as manufacturer), `ro.mi.os.version.code == 2` (the two-mode feature is version-scoped, not model-scoped),
+and the system user. Two deliberate assumptions: the feature is treated as present on any HyperOS 2 device (a
+device lacking it reads the key absent → a harmless false claim of control), and daemon-level enforcement of
+external writes is pending long-term observation (see Known gaps below).
+
+**HyperOS 3** (`xiaomi-hyperos3-v1`, adds mode `2` = Battery protection, hard cap 80%) requires **all** of:
+Xiaomi manufacturer, `ro.mi.os.version.code == 3`, a **physically-qualified device codename**
+(`XiaomiHyperOs3ChargingAdapter.QUALIFIED_CODENAMES`, ships with `tanzanite`), and the system user. The gate
+CANNOT be version-only: mode `2` is model-/build-dependent within HyperOS 3 (a Poco F5 `marblein` on HyperOS
+3.0.2 carries only the two old modes), the version property exposes no minor version, and no runtime probe for
+mode-2 presence exists — the key is absent in factory state and reading it returns only the current value. Both-
+direction hardware enforcement of external shell-UID writes was demonstrated on `tanzanite` (issue #48); no
+hardware hold signal exists in `dumpsys battery`, so verification is read-back only. The boundary write domain
+for the key is `{0,1,2}` **globally** — accepted on HyperOS 2 because no Amply code path emits `2` there and the
+HyperOS 2 decode refuses it. Widen the codename allowlist only with a qualified device plus a ledger row
+(`device-qualification` skill); unqualified HyperOS 3 devices fall to the lab adapter.
 
 ### GrapheneOS
 

--- a/.claude/skills/device-qualification/SKILL.md
+++ b/.claude/skills/device-qualification/SKILL.md
@@ -51,6 +51,7 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
 | Xiaomi | Xiaomi 13T `2306EPN60G` HyperOS 2.0 (`ro.mi.os.version.code=2`) | **Partial** — mapping/readback/session verified; the adaptive 80% hold could not be triggered, so daemon-level hardware enforcement is **not yet demonstrated** | Read matrix, both-direction writes, session at 100%, unknown-value refusal, R8 beta | 2026-07-21 |
 | OnePlus (Oplus) | OnePlus Nord CE4 Lite `CPH2621` ColorOS 15 (`ro.build.version.oplusrom=V15.0.0`) | Full — enforcement directly observable (device holds at 80%); external writes stick | Two mutually-exclusive `system` keys (Charging limit / Smart charging), WSS-only write rejected + Shizuku write succeeds for all three policies, WSS-only UX (controls disabled + Shizuku-required banner) | 2026-07-21 |
 | GrapheneOS | Pixel 9 Pro XL `komodo`, GrapheneOS 2026080501 / Android 17 — **REMOTE qualification via issue #49** (tester-run protocol, not maintainer hardware) | **Enforcement observed**: held at 80% with shield, `dumpsys battery` status=4/Charging state=4/policy=2 (limit on) vs 2/1/1 (off); shell-UID writes move the Settings UI live, **latch at plug-session start** — mid-session writes have no hardware effect until unplug→replug, replug reliably applies the current value | Key isolation (`settings list` diff → single `global battery_charge_limit` 0/1), write→UI both directions, mid-session no-op both directions, replug latch both directions, hardware signal both states. **NOT run**: app-context access tiers (WSS write from Amply, `app.grapheneos.*` package visibility), sessions/boot recovery, wireless, factory-absent key state, secondary user | 2026-08-12 |
+| Xiaomi (HyperOS 3) | Redmi Note 14 `24117RN76G` (`tanzanite`), HyperOS 3.0.302 / Android 16 (`ro.mi.os.version.code=3`) — **REMOTE qualification via issue #48** (contributor-run protocol, not maintainer hardware) | **Both-direction enforcement of EXTERNAL shell-UID writes observed** (the same write path as Amply's Shizuku service): `settings put … 2` below the cap → Battery protection active, Settings UI follows immediately, held at 80% for ~20 min under active use (voltage 4228 mV holding vs 4391 mV charging, charge counter 4283 vs 4341 corroborate; sysfs `current_now` permission-denied, so no current reading); `settings put … 0` mid-hold → charging resumes past 80 immediately. **No hardware hold signal**: `dumpsys battery` reports `status: 2` / `Charging state: 0` / `Charging policy: 0` in both states → read-back-only verification | Key mapping (three modes incl. `2` = Battery protection @80), external write → UI both directions, sustained hold, mid-hold release. **NOT run** (GrapheneOS-precedent landing; verify on the next beta via issue #48): app-context access tiers, sessions/boot recovery, factory-absent key state, wireless, R8 | 2026-08-14 |
 | GrapheneOS (follow-up) | Same device, **0.3.2-beta0 on-device report via issue #49** | **Package detection VERIFIED from app context** (`is_grapheneos=true` with the FLAG_SYSTEM check); **unprivileged key read DENIED** — `has_battery_charge_limit=false` while the very same report showed `battery_charging_status=4` (limit enforcing). Root cause in GrapheneOS source: the key is `@Protected(read = SYSTEM_UI, readWrite = SETTINGS)` (frameworks_base `c30c6393`); SettingsProvider throws SecurityException for all other packages **including WSS holders**, with the shell UID explicitly exempt ("ADB is used for testing", `e87c93a2`) — so the tester's earlier adb runs ARE the Shizuku-path evidence. Factory-absent semantics resolved from source: `BoolSetting(..., default false)` → absent = off | Detection + fail-closed probe verified live; adapter re-gated to Shizuku-only in response | 2026-08-13 |
 
 ## Known gaps
@@ -136,7 +137,8 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
   - **Wireless charging and secondary users**: NOT RUN (gated to system user).
 - **Xiaomi** — adaptive hardware enforcement of external writes unconfirmed; treat the adapter as provisional until
   the 80% hold is physically observed.
-  - **HyperOS 3 candidate mapping (contribution report, 2026-08-07 — unqualified, stays diagnostics-only).** A
+  - **HyperOS 3 candidate mapping (contribution report, 2026-08-07 — unqualified at the time; since landed,
+    see the LANDED bullet below).** A
     Redmi Note 14 `24117RN76G` (`tanzanite`, Android 16 / SDK 36, `ro.mi.os.version.code=3`, ROM
     `3.0.302.0.WOGMIXM.C08`) reported via the contribution wizard that the **same key**
     `secure/security_pc_secure_protect_mode_key` now carries **three** modes: `0` = Charge fully and
@@ -174,10 +176,9 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
       evidence is level observation plus voltage/counter deltas, not a current measurement, and both dumps
       show `status: 2` / `Charging state: 0` / `Charging policy: 0` — HyperOS 3 exposes **no hardware hold
       signal**, so a future adapter gets readback-only verification (like Samsung, unlike Pixel/GrapheneOS).
-      This answers the decisive daemon-enforcement question for `tanzanite` mode `2`; still open before
-      support can ship: gate design (mode `2` is not HyperOS-3-wide — marblein below), the reviewed boundary
-      write-domain widening `{"0","1"}` → `+"2"` (`ChargingControlUserService`), factory/absent-key semantics
-      on HyperOS 3, and sessions/access-tiers/R8 on a test build (contributor is willing).
+      This answers the decisive daemon-enforcement question for `tanzanite` mode `2`; the remaining items
+      (gate design, boundary widening, factory/absent-key semantics, sessions/access-tiers/R8) are tracked in
+      the landing bullet below.
     - **Second HyperOS 3 data point (support mail, 2026-08-13): the hard-cap mode is NOT HyperOS-3-wide.** A
       Poco F5 `23049PCD8I` (`marblein`, Android 15 / SDK 35, HyperOS 3.0.2, ROM `OS3.0.2.0.VMRINXM`) reported
       via the contribution wizard only the two HyperOS-2-style modes on the same key (`1` = Intelligent
@@ -187,5 +188,20 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
       one row in the privacy review (mapping possibly incomplete), and the device was previously rooted with
       FDE.ai driving the charge limit. Thread: support mail "Amply device-support discovery", 2026-08-13; the
       contributor was asked whether the settings screen shows any third mode / 80% option.
+    - **LANDED 2026-08-14: `xiaomi-hyperos3-v1`, gated to a qualified-codename allowlist (`tanzanite` only) —
+      GrapheneOS-precedent landing** (remote enforcement qualification via issue #48, see the Verified devices
+      row; app-level items open, all failing closed, to be verified by the contributor on the next beta):
+      - **Absent-key decode unverified**: absent decodes as Intelligent/Adaptive, mirroring HyperOS 2's
+        factory-state assumption; HyperOS 3 factory semantics are unknown. Worst case if wrong: a session
+        restore writes `1` onto a factory state that was not Intelligent — bounded, no battery hazard.
+        Next-beta ask: `settings delete secure security_pc_secure_protect_mode_key`, then `settings get` +
+        observe which mode the native UI shows.
+      - **Sessions / boot recovery / access tiers (WSS-only vs Shizuku) / R8**: NOT RUN on HyperOS 3;
+        the mechanism is the shared session engine + the same `secure`-namespace write path qualified on
+        HyperOS 2, but on-device confirmation is pending the next beta.
+      - **Adaptive (mode `1`) enforcement undemonstrated** — identical provisional status as HyperOS 2 (the
+        top-level Xiaomi gap above); only mode `2` has demonstrated hardware enforcement.
+      - The gate cannot widen past the codename allowlist: record any new HyperOS 3 device here plus a
+        Verified-devices row before adding its codename to `XiaomiHyperOs3ChargingAdapter.QUALIFIED_CODENAMES`.
 - **Pixel** — wireless at-threshold hold/charge-past and the widget under Shizuku-only remain unexercised (both share
   the verified wired mechanism).

--- a/.claude/skills/device-qualification/SKILL.md
+++ b/.claude/skills/device-qualification/SKILL.md
@@ -161,7 +161,23 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
       **external** writes, the decisive question for Amply and open even on qualified HyperOS 2, remains
       unproven. Follow-up runs requested in the issue #48 thread: sustained hold at 80 with `current_now`, and
       the both-direction external-write test (adb `settings put` to `2` below the cap → hold; back to `0`
-      mid-hold → charging resumes past 80).
+      mid-hold → charging resumes past 80). Delivered 2026-08-14 — see the enforcement bullet below.
+    - **Both-direction external-write enforcement DEMONSTRATED (2026-08-14, issue #48, same `tanzanite`
+      device).** The contributor ran the requested protocol via on-device adb shell — the **shell UID, the same
+      write path Amply's Shizuku service uses**. (1) Below 80% plugged, UI manually set to "Charge fully",
+      `settings put secure security_pc_secure_protect_mode_key 2` → Battery Protection activated and the
+      Settings UI reflected it immediately, so the daemon reacts to external key writes, not just its own UI.
+      (2) Held at 80% for ~20 minutes plugged under active use without gaining a point; sysfs
+      `current_now` was permission-denied so there is no current reading, but the dumps corroborate the hold
+      indirectly (voltage 4228 mV at the hold vs 4391 mV after resume; charge counter 4283 vs 4341). (3)
+      `settings put … 0` mid-hold → charging resumed immediately, UI followed, level passed 80. Caveats: hold
+      evidence is level observation plus voltage/counter deltas, not a current measurement, and both dumps
+      show `status: 2` / `Charging state: 0` / `Charging policy: 0` — HyperOS 3 exposes **no hardware hold
+      signal**, so a future adapter gets readback-only verification (like Samsung, unlike Pixel/GrapheneOS).
+      This answers the decisive daemon-enforcement question for `tanzanite` mode `2`; still open before
+      support can ship: gate design (mode `2` is not HyperOS-3-wide — marblein below), the reviewed boundary
+      write-domain widening `{"0","1"}` → `+"2"` (`ChargingControlUserService`), factory/absent-key semantics
+      on HyperOS 3, and sessions/access-tiers/R8 on a test build (contributor is willing).
     - **Second HyperOS 3 data point (support mail, 2026-08-13): the hard-cap mode is NOT HyperOS-3-wide.** A
       Poco F5 `23049PCD8I` (`marblein`, Android 15 / SDK 35, HyperOS 3.0.2, ROM `OS3.0.2.0.VMRINXM`) reported
       via the contribution wizard only the two HyperOS-2-style modes on the same key (`1` = Intelligent

--- a/.claude/skills/oem-adapters/SKILL.md
+++ b/.claude/skills/oem-adapters/SKILL.md
@@ -29,21 +29,33 @@ diagnostics-only lab adapter. An external `protect_battery=0` makes One UI forge
 to the OEM default on re-enable), so Amply restores the exact prior policy itself rather than trusting Samsung's
 bookkeeping. Verified devices + coverage: see the qualification ledger (`device-qualification` skill).
 
-## Xiaomi Adapter
+## Xiaomi Adapters
 
-One live adapter (`xiaomi-hyperos2-v1`), gated to the HyperOS ROM version (the setting is a ROM
-feature, not a per-model one): manufacturer Xiaomi (covers Redmi/POCO — they report Xiaomi as
-manufacturer) + `ro.mi.os.version.code == 2` (HyperOS 2.x) + system user. Use `ro.mi.os.version.code`,
-NOT the frozen legacy `ro.miui.ui.version.code`. Single key
-`secure/security_pc_secure_protect_mode_key`: `0`=charge fully, `1`=Intelligent (heuristic 80% hold →
-`ChargePolicy.Adaptive`), absent=Intelligent (factory state). No hard-cap mode exists **on HyperOS 2**; a
-HyperOS 3 contribution report (2026-08-07) shows the same key with a third value `2`="Battery protection" —
-a candidate hard-cap mode, unqualified (see the `device-qualification` skill). SYNC_READBACK
-with read-back equality; session override = Unrestricted; protective default = Adaptive. HyperOS 1,
-pre-HyperOS MIUI, and HyperOS 3 fall to `XiaomiLabAdapter` (diagnostics + contribution). Two
-documented assumptions: the feature is treated as present on any HyperOS 2 device (a device lacking it
-reads the key absent → a harmless false claim of control), and daemon-level enforcement of external
-writes is pending long-term observation (see the `device-qualification` skill).
+Two live adapters over the single key `secure/security_pc_secure_protect_mode_key` (both in
+`XiaomiChargingAdapter.kt`). Use `ro.mi.os.version.code`, NOT the frozen legacy `ro.miui.ui.version.code`.
+Manufacturer Xiaomi covers Redmi/POCO — they report Xiaomi as manufacturer.
+
+- **HyperOS 2 (`xiaomi-hyperos2-v1`)** — gated to the HyperOS ROM version (the two-mode setting is a ROM
+  feature, not a per-model one): manufacturer Xiaomi + `ro.mi.os.version.code == 2` + system user. Values:
+  `0`=charge fully, `1`=Intelligent (heuristic 80% hold → `ChargePolicy.Adaptive`), absent=Intelligent
+  (factory state); `2` does not exist on HyperOS 2 and decodes `Unknown(unrecognizedValue)`. Session
+  override = Unrestricted; protective default = Adaptive. Two documented assumptions: the feature is treated
+  as present on any HyperOS 2 device (a device lacking it reads the key absent → a harmless false claim of
+  control), and daemon-level enforcement of external writes is pending long-term observation.
+- **HyperOS 3 (`xiaomi-hyperos3-v1`)** — same key plus `2`="Battery protection" (hard cap →
+  `FixedLimit(80)`; both-direction enforcement of external shell-UID writes demonstrated on `tanzanite`,
+  issue #48). Gate: manufacturer Xiaomi + `ro.mi.os.version.code == 3` + **qualified-codename allowlist**
+  (`QUALIFIED_CODENAMES`, ships `tanzanite`) + system user. Version-only gating is impossible: mode `2` is
+  model-/build-dependent within HyperOS 3 (`marblein` on 3.0.2 has only 0/1), the property has no minor
+  version, and mode-2 presence cannot be probed (key absent in factory state). Session override =
+  Unrestricted; protective default = FixedLimit(80) — the only Xiaomi mode with demonstrated enforcement.
+  Absent=Intelligent mirrors HyperOS 2 but is **unverified on HyperOS 3** (pending the issue-#48
+  qualification run). No hardware decode: `dumpsys battery` exposes no hold signal on HyperOS 3.
+
+Both are SYNC_READBACK with read-back equality; writes are WSS-capable (`secure` namespace). HyperOS 1,
+pre-HyperOS MIUI, and unqualified HyperOS 3 devices fall to `XiaomiLabAdapter` (diagnostics + contribution).
+The boundary write domain for the key is `{0,1,2}` globally (see `privileged-access.md`). Qualification
+evidence: `device-qualification` skill.
 
 ## OnePlus / ColorOS Adapter
 

--- a/app/src/main/java/eu/darken/amply/charging/core/access/shizuku/ChargingControlUserService.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/access/shizuku/ChargingControlUserService.kt
@@ -199,8 +199,12 @@ internal object SettingWritePolicy {
             // Pixel charging optimization
             "charge_optimization_mode" to setOf("0", "1"),
             "adaptive_charging_enabled" to setOf("0", "1"),
-            // Xiaomi HyperOS charging protection
-            "security_pc_secure_protect_mode_key" to setOf("0", "1"),
+            // Xiaomi HyperOS charging protection. "2" = HyperOS 3 "Battery protection" (hard cap 80,
+            // qualified on tanzanite — issue #48 / ledger). The domain is global, so "2" is also
+            // boundary-writable on HyperOS 2 devices: accepted, no Amply code path emits it there
+            // (the HyperOS 2 adapter maps no policy to it and its decode refuses it) — the boundary
+            // owns the per-key domain, not per-ROM routing.
+            "security_pc_secure_protect_mode_key" to setOf("0", "1", "2"),
         ),
         "global" to mapOf(
             // GrapheneOS charge limit (1 = fixed 80% cap; the ROM latches it at plug-session start)

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/AdapterRegistry.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/AdapterRegistry.kt
@@ -23,6 +23,7 @@ class AdapterRegistry @Inject constructor(
     samsungLegacy: SamsungLegacyChargingAdapter,
     samsungLab: SamsungLabAdapter,
     xiaomi: XiaomiChargingAdapter,
+    xiaomiHyperOs3: XiaomiHyperOs3ChargingAdapter,
     xiaomiLab: XiaomiLabAdapter,
     onePlus: OnePlusChargingAdapter,
     onePlusLab: OnePlusLabAdapter,
@@ -38,7 +39,7 @@ class AdapterRegistry @Inject constructor(
     // Live adapters otherwise match only their verified scopes; same-OEM misses fall to the lab adapters.
     private val adapters = listOf(
         lineage, lineageLab, grapheneOs,
-        pixel, samsungModern, samsungLegacy, samsungLab, xiaomi, xiaomiLab, onePlus, onePlusLab,
+        pixel, samsungModern, samsungLegacy, samsungLab, xiaomi, xiaomiHyperOs3, xiaomiLab, onePlus, onePlusLab,
     )
 
     fun select(device: DeviceInfo = DeviceInfo.current(context)): AdapterSelection {

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/XiaomiChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/XiaomiChargingAdapter.kt
@@ -23,10 +23,10 @@ import javax.inject.Singleton
  * The setting is a HyperOS ROM feature rather than a per-model one, so control is gated to the
  * HyperOS **major version** (2.x, from `ro.mi.os.version.code`) plus the Xiaomi manufacturer
  * (which also covers Redmi/POCO) and the system user (the secure namespace is per-user while
- * charging hardware is device-wide). HyperOS 1, pre-HyperOS MIUI, and HyperOS 3 fall through to
- * the diagnostics-only lab adapter until qualified. A HyperOS 3 contribution report shows the
- * same key with an added value 2 = "Battery protection" (candidate hard cap, unqualified — see
- * the device-qualification ledger); the unrecognized-value decode below refuses it safely.
+ * charging hardware is device-wide). HyperOS 1 and pre-HyperOS MIUI fall through to the
+ * diagnostics-only lab adapter. HyperOS 3 is handled by [XiaomiHyperOs3ChargingAdapter] on
+ * qualified devices (same key, added value 2 = "Battery protection"); the unrecognized-value
+ * decode below still refuses a `2` safely — the mode does not exist on HyperOS 2.
  *
  * Assumption (deliberate): the feature is treated as present on any HyperOS 2
  * device. A HyperOS 2 device that genuinely lacks Battery protection also reports the key absent,
@@ -97,25 +97,136 @@ class XiaomiChargingAdapter @Inject constructor() : ChargingAdapter {
     override val observedSettingUris
         get() = listOf(Settings.Secure.getUriFor(KEY_MODE))
 
-    override fun nativeSettingsIntent(context: Context): Intent {
-        // No exported deep-link to the protection screen was found; the MIUI battery page
-        // (one tap away from it) resolves via the generic power-usage action.
-        val specific = Intent(Intent.ACTION_POWER_USAGE_SUMMARY).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        return if (specific.resolveActivity(context.packageManager) != null) {
-            specific
-        } else {
-            Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-    }
+    override fun nativeSettingsIntent(context: Context): Intent = xiaomiBatterySettingsIntent(context)
 
     companion object {
         const val KEY_MODE = "security_pc_secure_protect_mode_key"
         const val VALUE_CHARGE_FULLY = "0"
         const val VALUE_INTELLIGENT = "1"
 
-        // HyperOS 2.x (ro.mi.os.version.code). The mapping was verified on HyperOS 2.0; HyperOS 3
-        // stays unqualified (reported to add value 2 = "Battery protection" — see the
-        // device-qualification ledger), mirroring the One UI range gates.
+        // HyperOS 2.x (ro.mi.os.version.code). The mapping was verified on HyperOS 2.0,
+        // mirroring the One UI range gates. HyperOS 3 has its own codename-gated adapter.
         const val QUALIFIED_HYPEROS_VERSION = 2
+    }
+}
+
+/**
+ * Xiaomi HyperOS 3 charging protection — same key as HyperOS 2 with an added third mode:
+ * 0 = charge fully, 1 = "Intelligent charging" (adaptive), 2 = "Battery protection" (hard cap
+ * at 80% — issue #48 demonstrated both-direction hardware enforcement of external shell-UID
+ * writes on `tanzanite`, applied synchronously, Settings UI following each write).
+ *
+ * Unlike HyperOS 2 this gate needs a **qualified-codename allowlist** on top of the major
+ * version: mode 2 is NOT HyperOS-3-wide (a Poco F5 `marblein` on HyperOS 3.0.2 carries only
+ * modes 0/1), `ro.mi.os.version.code` exposes no minor version, and no runtime probe for
+ * mode-2 presence exists — the key is absent in factory state and reading it only returns the
+ * current value. Unqualified HyperOS 3 devices fall through to the lab adapter.
+ *
+ * `dumpsys battery` exposes no hardware hold signal on HyperOS 3 (`status: 2`,
+ * `Charging state: 0`, `Charging policy: 0` while demonstrably holding at the cap), so
+ * verification is settings read-back only.
+ */
+@Singleton
+class XiaomiHyperOs3ChargingAdapter @Inject constructor() : ChargingAdapter {
+    override val id = "xiaomi-hyperos3-v1"
+    override val displayName = R.string.adapter_name_xiaomi_protection.toCaString()
+
+    override val supportedPolicies = listOf(
+        ChargePolicy.FixedLimit(CAP_PERCENT),
+        ChargePolicy.Adaptive,
+        ChargePolicy.Unrestricted,
+    )
+
+    // Battery protection is the only Xiaomi mode with demonstrated hardware enforcement;
+    // Intelligent charging's hold remains unobserved on both HyperOS generations.
+    override val defaultProtectivePolicy = ChargePolicy.FixedLimit(CAP_PERCENT)
+    override val verification = VerificationStrategy.SYNC_READBACK
+
+    override fun probe(device: DeviceInfo): AdapterSupport {
+        val matched = device.manufacturer.equals("Xiaomi", ignoreCase = true) &&
+            device.hyperOsVersion == QUALIFIED_HYPEROS_VERSION &&
+            device.codename in QUALIFIED_CODENAMES
+        return AdapterSupport(
+            matched = matched,
+            controlEnabled = matched && device.isSystemUser,
+            detail = when {
+                !matched -> R.string.adapter_detail_requires_xiaomi_hyperos3
+                !device.isSystemUser -> R.string.adapter_detail_secondary_user
+                else -> R.string.adapter_detail_xiaomi_ready
+            },
+            contributionWanted = false,
+        )
+    }
+
+    override suspend fun read(backend: AccessBackend): ChargeObservation {
+        val mode = backend.read(SettingNamespace.SECURE, XiaomiChargingAdapter.KEY_MODE)
+        if (!mode.readable) {
+            return ChargeObservation.Unknown(
+                mode.error ?: R.string.charging_reason_settings_unreadable.toCaString(),
+            )
+        }
+        return when (mode.value) {
+            // Absent = intelligent mirrors the HyperOS 2 factory-state assumption but is
+            // UNVERIFIED on HyperOS 3 — pending the issue-#48 qualification run's
+            // factory/absent-key check; adjust if the evidence contradicts it.
+            null, XiaomiChargingAdapter.VALUE_INTELLIGENT ->
+                ChargeObservation.Verified(ChargePolicy.Adaptive, backend.kind)
+
+            XiaomiChargingAdapter.VALUE_CHARGE_FULLY ->
+                ChargeObservation.Verified(ChargePolicy.Unrestricted, backend.kind)
+
+            VALUE_BATTERY_PROTECTION ->
+                ChargeObservation.Verified(ChargePolicy.FixedLimit(CAP_PERCENT), backend.kind)
+
+            else -> ChargeObservation.Unknown(
+                R.string.charging_reason_value_unrecognized.toCaString(XiaomiChargingAdapter.KEY_MODE, mode.value),
+                unrecognizedValue = true,
+            )
+        }
+    }
+
+    override suspend fun apply(policy: ChargePolicy, backend: AccessBackend): Boolean {
+        val value = when (policy) {
+            // Value-match, not `is`: the OEM cap is hard-wired to 80, any other percent would
+            // be misrepresented by mode 2.
+            ChargePolicy.FixedLimit(CAP_PERCENT) -> VALUE_BATTERY_PROTECTION
+            ChargePolicy.Adaptive -> XiaomiChargingAdapter.VALUE_INTELLIGENT
+            ChargePolicy.Unrestricted -> XiaomiChargingAdapter.VALUE_CHARGE_FULLY
+            is ChargePolicy.FixedLimit, ChargePolicy.PauseAtFull -> return false
+        }
+        if (!backend.write(SettingMutation(SettingNamespace.SECURE, XiaomiChargingAdapter.KEY_MODE, value))) {
+            return false
+        }
+        val observed = read(backend)
+        return observed is ChargeObservation.Verified && observed.policy == policy
+    }
+
+    override val observedSettingUris
+        get() = listOf(Settings.Secure.getUriFor(XiaomiChargingAdapter.KEY_MODE))
+
+    override fun nativeSettingsIntent(context: Context): Intent = xiaomiBatterySettingsIntent(context)
+
+    companion object {
+        const val VALUE_BATTERY_PROTECTION = "2"
+        const val CAP_PERCENT = 80
+        const val QUALIFIED_HYPEROS_VERSION = 3
+
+        /**
+         * Widen ONLY with a physically-qualified device plus a Verified-devices ledger row
+         * (device-qualification skill). Version-only gating is impossible here: mode 2 is
+         * model-/build-dependent within HyperOS 3 and cannot be probed at runtime.
+         */
+        val QUALIFIED_CODENAMES = setOf("tanzanite")
+    }
+}
+
+// No exported deep-link to the protection screen was found; the MIUI battery page
+// (one tap away from it) resolves via the generic power-usage action.
+private fun xiaomiBatterySettingsIntent(context: Context): Intent {
+    val specific = Intent(Intent.ACTION_POWER_USAGE_SUMMARY).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    return if (specific.resolveActivity(context.packageManager) != null) {
+        specific
+    } else {
+        Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
 }

--- a/app/src/main/java/eu/darken/amply/diagnostics/core/ContributionAllowlist.kt
+++ b/app/src/main/java/eu/darken/amply/diagnostics/core/ContributionAllowlist.kt
@@ -19,8 +19,9 @@ object ContributionAllowlist {
         // Pixel charging optimization
         SettingId(SettingNamespace.SECURE, "charge_optimization_mode") to setOf("0", "1"),
         SettingId(SettingNamespace.SECURE, "adaptive_charging_enabled") to setOf("0", "1"),
-        // Xiaomi HyperOS charging protection
-        SettingId(SettingNamespace.SECURE, "security_pc_secure_protect_mode_key") to setOf("0", "1"),
+        // Xiaomi HyperOS charging protection ("2" = HyperOS 3 Battery protection, a named OEM mode
+        // observed on two devices — not user data)
+        SettingId(SettingNamespace.SECURE, "security_pc_secure_protect_mode_key") to setOf("0", "1", "2"),
         // GrapheneOS charging optimization
         SettingId(SettingNamespace.GLOBAL, "battery_charge_limit") to setOf("0", "1"),
         // Samsung battery protection

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,7 @@
     <string name="adapter_detail_secondary_user">Charging protection is device-wide; control is limited to the main user</string>
     <string name="adapter_detail_samsung_ready">Changes apply to the hardware immediately</string>
     <string name="adapter_detail_requires_xiaomi">Requires a verified Xiaomi device on HyperOS 2</string>
+    <string name="adapter_detail_requires_xiaomi_hyperos3">Requires a qualified Xiaomi device on HyperOS 3</string>
     <string name="adapter_detail_xiaomi_ready">Changes apply to the hardware immediately</string>
     <string name="adapter_detail_requires_oplus">Requires a OnePlus, Oppo, or Realme device on ColorOS 15</string>
     <string name="adapter_detail_oplus_ready">Charging control requires Shizuku on this device</string>

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryPersistenceTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryPersistenceTest.kt
@@ -28,6 +28,7 @@ import eu.darken.amply.charging.core.adapter.SamsungLabAdapter
 import eu.darken.amply.charging.core.adapter.SamsungLegacyChargingAdapter
 import eu.darken.amply.charging.core.adapter.SamsungModernChargingAdapter
 import eu.darken.amply.charging.core.adapter.XiaomiChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiHyperOs3ChargingAdapter
 import eu.darken.amply.charging.core.adapter.XiaomiLabAdapter
 import eu.darken.amply.common.AppDataStore
 import eu.darken.amply.common.serialization.SerializationModule
@@ -110,6 +111,7 @@ class ChargingRepositoryPersistenceTest {
                 samsungLegacy = SamsungLegacyChargingAdapter(),
                 samsungLab = SamsungLabAdapter(),
                 xiaomi = XiaomiChargingAdapter(),
+                xiaomiHyperOs3 = XiaomiHyperOs3ChargingAdapter(),
                 xiaomiLab = XiaomiLabAdapter(),
                 onePlus = OnePlusChargingAdapter(),
                 onePlusLab = OnePlusLabAdapter(),

--- a/app/src/test/java/eu/darken/amply/charging/core/DeviceInfoLineageDetectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/DeviceInfoLineageDetectionTest.kt
@@ -15,6 +15,7 @@ import eu.darken.amply.charging.core.adapter.SamsungLabAdapter
 import eu.darken.amply.charging.core.adapter.SamsungLegacyChargingAdapter
 import eu.darken.amply.charging.core.adapter.SamsungModernChargingAdapter
 import eu.darken.amply.charging.core.adapter.XiaomiChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiHyperOs3ChargingAdapter
 import eu.darken.amply.charging.core.adapter.XiaomiLabAdapter
 import eu.darken.amply.common.ca.toCaString
 import io.kotest.matchers.shouldBe
@@ -52,6 +53,7 @@ class DeviceInfoLineageDetectionTest {
             samsungLegacy = SamsungLegacyChargingAdapter(),
             samsungLab = SamsungLabAdapter(),
             xiaomi = XiaomiChargingAdapter(),
+            xiaomiHyperOs3 = XiaomiHyperOs3ChargingAdapter(),
             xiaomiLab = XiaomiLabAdapter(),
             onePlus = OnePlusChargingAdapter(),
             onePlusLab = OnePlusLabAdapter(),

--- a/app/src/test/java/eu/darken/amply/charging/core/access/shizuku/ChargingControlUserServiceTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/access/shizuku/ChargingControlUserServiceTest.kt
@@ -64,6 +64,8 @@ class ChargingControlUserServiceTest {
         SettingWritePolicy.validate("secure", "adaptive_charging_enabled", "0")
         SettingWritePolicy.validate("secure", "security_pc_secure_protect_mode_key", "0")
         SettingWritePolicy.validate("secure", "security_pc_secure_protect_mode_key", "1")
+        // "2" = HyperOS 3 Battery protection (qualified on tanzanite, issue #48).
+        SettingWritePolicy.validate("secure", "security_pc_secure_protect_mode_key", "2")
         SettingWritePolicy.validate("global", "protect_battery", "3")
         SettingWritePolicy.validate("global", "battery_protection_threshold", "95")
         SettingWritePolicy.validate("system", "regular_charge_protection_switch_state", "1")
@@ -72,7 +74,6 @@ class ChargingControlUserServiceTest {
     @Test
     fun `write policy rejects out-of-domain values`() {
         listOf(
-            Triple("secure", "security_pc_secure_protect_mode_key", "2"),
             Triple("secure", "security_pc_secure_protect_mode_key", "999"),
             Triple("secure", "charge_optimization_mode", "2"),
             Triple("global", "protect_battery", "2"),

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterMutationDomainTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterMutationDomainTest.kt
@@ -24,6 +24,7 @@ class AdapterMutationDomainTest {
         SamsungModernChargingAdapter(),
         SamsungLegacyChargingAdapter(),
         XiaomiChargingAdapter(),
+        XiaomiHyperOs3ChargingAdapter(),
         OnePlusChargingAdapter(),
     )
 

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
@@ -35,6 +35,7 @@ class AdapterRegistrySelectionTest {
         samsungLegacy = SamsungLegacyChargingAdapter(),
         samsungLab = SamsungLabAdapter(),
         xiaomi = XiaomiChargingAdapter(),
+        xiaomiHyperOs3 = XiaomiHyperOs3ChargingAdapter(),
         xiaomiLab = XiaomiLabAdapter(),
         onePlus = OnePlusChargingAdapter(),
         onePlusLab = OnePlusLabAdapter(),
@@ -151,11 +152,34 @@ class AdapterRegistrySelectionTest {
         registry.select(
             DeviceInfo("Xiaomi", "2306EPN60G", 35, "test", hyperOsVersion = 1),
         ).adapter?.id shouldBe "xiaomi-lab"
+        // HyperOS 3 without a qualified codename falls through via the hyperos3 allowlist.
         registry.select(
             DeviceInfo("Xiaomi", "2306EPN60G", 35, "test", hyperOsVersion = 3),
         ).adapter?.id shouldBe "xiaomi-lab"
         registry.select(
             DeviceInfo("Xiaomi", "M2101K6G", 33, "test"),
+        ).adapter?.id shouldBe "xiaomi-lab"
+    }
+
+    @Test
+    fun `a qualified HyperOS 3 codename selects the hyperos3 adapter with control`() {
+        val selection = registry.select(
+            DeviceInfo("Xiaomi", "24117RN76G", 36, "test", codename = "tanzanite", hyperOsVersion = 3, isSystemUser = true),
+        )
+        selection.adapter?.id shouldBe "xiaomi-hyperos3-v1"
+        selection.support.controlEnabled shouldBe true
+    }
+
+    @Test
+    fun `an unqualified HyperOS 3 codename falls through to the xiaomi lab adapter`() {
+        // marblein (HyperOS 3.0.2) carries only the two HyperOS-2-style modes — the reason the
+        // hyperos3 gate is a codename allowlist and not version-only.
+        registry.select(
+            DeviceInfo("Xiaomi", "23049PCD8I", 35, "test", codename = "marblein", hyperOsVersion = 3, isSystemUser = true),
+        ).adapter?.id shouldBe "xiaomi-lab"
+        // A future HyperOS major falls through too, even on a qualified codename.
+        registry.select(
+            DeviceInfo("Xiaomi", "24117RN76G", 37, "test", codename = "tanzanite", hyperOsVersion = 4, isSystemUser = true),
         ).adapter?.id shouldBe "xiaomi-lab"
     }
 

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/ContributionEligibilityTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/ContributionEligibilityTest.kt
@@ -28,6 +28,7 @@ class ContributionEligibilityTest {
         samsungLegacy = SamsungLegacyChargingAdapter(),
         samsungLab = SamsungLabAdapter(),
         xiaomi = XiaomiChargingAdapter(),
+        xiaomiHyperOs3 = XiaomiHyperOs3ChargingAdapter(),
         xiaomiLab = XiaomiLabAdapter(),
         onePlus = OnePlusChargingAdapter(),
         onePlusLab = OnePlusLabAdapter(),

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/XiaomiHyperOs3ChargingAdapterTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/XiaomiHyperOs3ChargingAdapterTest.kt
@@ -17,46 +17,55 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
-class XiaomiChargingAdapterTest {
-    private val adapter = XiaomiChargingAdapter()
+class XiaomiHyperOs3ChargingAdapterTest {
+    private val adapter = XiaomiHyperOs3ChargingAdapter()
 
-    private fun xiaomi(
-        model: String = "2306EPN60G",
-        hyperOs: Int? = 2,
+    private fun xiaomi3(
+        model: String = "24117RN76G",
+        codename: String = "tanzanite",
+        hyperOs: Int? = 3,
         systemUser: Boolean = true,
         manufacturer: String = "Xiaomi",
     ) = DeviceInfo(
         manufacturer = manufacturer,
         model = model,
-        sdk = 35,
+        codename = codename,
+        sdk = 36,
         fingerprint = "test",
         hyperOsVersion = hyperOs,
         isSystemUser = systemUser,
     )
 
     @Test
-    fun `any HyperOS 2 Xiaomi device matches regardless of model`() {
-        adapter.probe(xiaomi()).matched shouldBe true
-        adapter.probe(xiaomi()).controlEnabled shouldBe true
-        adapter.probe(xiaomi()).detail shouldBe R.string.adapter_detail_xiaomi_ready
+    fun `a qualified codename on HyperOS 3 matches with control`() {
+        val support = adapter.probe(xiaomi3())
 
-        // The gate is the ROM version, not the model: a different HyperOS 2 model still matches.
-        adapter.probe(xiaomi(model = "23078PND5G")).matched shouldBe true
-        // Redmi/POCO report Xiaomi as manufacturer, so they qualify on HyperOS 2 too.
-        adapter.probe(xiaomi(model = "23021RAAEG")).matched shouldBe true
+        support.matched shouldBe true
+        support.controlEnabled shouldBe true
+        support.detail shouldBe R.string.adapter_detail_xiaomi_ready
+    }
+
+    @Test
+    fun `unqualified codenames fall through`() {
+        // marblein (Poco F5, HyperOS 3.0.2) is the real counterexample: same key, only modes 0/1,
+        // no Battery protection — the reason this gate cannot be version-only.
+        adapter.probe(xiaomi3(codename = "marblein", model = "23049PCD8I")).matched shouldBe false
+        adapter.probe(xiaomi3(codename = "")).matched shouldBe false
     }
 
     @Test
     fun `other HyperOS generations and non-Xiaomi devices do not match`() {
-        adapter.probe(xiaomi(hyperOs = 1)).matched shouldBe false // HyperOS 1 unverified
-        adapter.probe(xiaomi(hyperOs = 3)).matched shouldBe false // handled by the hyperos3 sibling when qualified
-        adapter.probe(xiaomi(hyperOs = null)).matched shouldBe false // pre-HyperOS MIUI
-        adapter.probe(xiaomi(manufacturer = "samsung")).matched shouldBe false
+        // HyperOS 2 stays with the hyperos2 adapter even for a qualified codename.
+        adapter.probe(xiaomi3(hyperOs = 2)).matched shouldBe false
+        // A future major version needs its own qualification, even on a qualified codename.
+        adapter.probe(xiaomi3(hyperOs = 4)).matched shouldBe false
+        adapter.probe(xiaomi3(hyperOs = null)).matched shouldBe false
+        adapter.probe(xiaomi3(manufacturer = "samsung")).matched shouldBe false
     }
 
     @Test
     fun `secondary user disables control`() {
-        val support = adapter.probe(xiaomi(systemUser = false))
+        val support = adapter.probe(xiaomi3(systemUser = false))
 
         support.matched shouldBe true
         support.controlEnabled shouldBe false
@@ -64,21 +73,22 @@ class XiaomiChargingAdapterTest {
     }
 
     @Test
-    fun `read maps both modes and treats the absent key as intelligent`() = runTest {
+    fun `read maps all three modes and treats the absent key as intelligent`() = runTest {
+        adapter.read(FakeBackend(values = mutableMapOf(XiaomiChargingAdapter.KEY_MODE to "2"))) shouldBe
+            ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.DIRECT_WSS)
         adapter.read(FakeBackend(values = mutableMapOf(XiaomiChargingAdapter.KEY_MODE to "1"))) shouldBe
             ChargeObservation.Verified(ChargePolicy.Adaptive, BackendKind.DIRECT_WSS)
         adapter.read(FakeBackend(values = mutableMapOf(XiaomiChargingAdapter.KEY_MODE to "0"))) shouldBe
             ChargeObservation.Verified(ChargePolicy.Unrestricted, BackendKind.DIRECT_WSS)
-        // Factory state: key absent until first change; OEM UI treats it as intelligent.
+        // Absent = intelligent mirrors HyperOS 2 but is UNVERIFIED on HyperOS 3 — pending the
+        // issue-#48 qualification run's factory/absent-key check.
         adapter.read(FakeBackend()) shouldBe
             ChargeObservation.Verified(ChargePolicy.Adaptive, BackendKind.DIRECT_WSS)
     }
 
     @Test
     fun `unrecognized values are flagged as such`() = runTest {
-        // "2" is a real HyperOS 3 mode (Battery protection) that does not exist on HyperOS 2 —
-        // this adapter deliberately refuses it rather than guessing.
-        val observed = adapter.read(FakeBackend(values = mutableMapOf(XiaomiChargingAdapter.KEY_MODE to "2")))
+        val observed = adapter.read(FakeBackend(values = mutableMapOf(XiaomiChargingAdapter.KEY_MODE to "3")))
 
         observed.shouldBeInstanceOf<ChargeObservation.Unknown>()
         observed.unrecognizedValue shouldBe true
@@ -93,15 +103,17 @@ class XiaomiChargingAdapterTest {
     }
 
     @Test
-    fun `apply writes the single mode key`() = runTest {
+    fun `apply writes the single mode key for all three policies`() = runTest {
         val backend = FakeBackend()
 
-        adapter.apply(ChargePolicy.Unrestricted, backend) shouldBe true
+        adapter.apply(ChargePolicy.FixedLimit(80), backend) shouldBe true
         adapter.apply(ChargePolicy.Adaptive, backend) shouldBe true
+        adapter.apply(ChargePolicy.Unrestricted, backend) shouldBe true
 
         backend.writes shouldContainExactly listOf(
-            SettingMutation(SettingNamespace.SECURE, XiaomiChargingAdapter.KEY_MODE, "0"),
+            SettingMutation(SettingNamespace.SECURE, XiaomiChargingAdapter.KEY_MODE, "2"),
             SettingMutation(SettingNamespace.SECURE, XiaomiChargingAdapter.KEY_MODE, "1"),
+            SettingMutation(SettingNamespace.SECURE, XiaomiChargingAdapter.KEY_MODE, "0"),
         )
     }
 
@@ -109,7 +121,8 @@ class XiaomiChargingAdapterTest {
     fun `apply rejects unsupported policies without writing`() = runTest {
         val backend = FakeBackend()
 
-        adapter.apply(ChargePolicy.FixedLimit(80), backend) shouldBe false
+        // The OEM cap is hard-wired to 80 — any other percent must be refused, not approximated.
+        adapter.apply(ChargePolicy.FixedLimit(85), backend) shouldBe false
         adapter.apply(ChargePolicy.PauseAtFull, backend) shouldBe false
 
         backend.writes shouldBe emptyList()
@@ -117,18 +130,20 @@ class XiaomiChargingAdapterTest {
 
     @Test
     fun `apply fails on rejected or dropped writes`() = runTest {
-        adapter.apply(ChargePolicy.Adaptive, FakeBackend(failWrites = true)) shouldBe false
+        adapter.apply(ChargePolicy.FixedLimit(80), FakeBackend(failWrites = true)) shouldBe false
         // Write reports success but the value never lands: read-back equality must fail.
-        // (Absent decodes as Adaptive, so use Unrestricted for the dropped-write check.)
-        adapter.apply(ChargePolicy.Unrestricted, FakeBackend(dropWrites = true)) shouldBe false
+        // (Absent decodes as Adaptive, so use a non-Adaptive policy for the dropped-write check.)
+        adapter.apply(ChargePolicy.FixedLimit(80), FakeBackend(dropWrites = true)) shouldBe false
     }
 
     @Test
     fun `session capabilities`() {
         adapter.sessionOverridePolicy shouldBe ChargePolicy.Unrestricted
-        adapter.defaultProtectivePolicy shouldBe ChargePolicy.Adaptive
+        adapter.defaultProtectivePolicy shouldBe ChargePolicy.FixedLimit(80)
         adapter.verification shouldBe VerificationStrategy.SYNC_READBACK
         adapter.reconnectGestureSupported shouldBe false
+        adapter.preferShizukuForWrites shouldBe false
+        adapter.policyLatchesAtPlug shouldBe false
     }
 
     private class FakeBackend(

--- a/app/src/test/java/eu/darken/amply/diagnostics/core/ContributionReportTest.kt
+++ b/app/src/test/java/eu/darken/amply/diagnostics/core/ContributionReportTest.kt
@@ -61,6 +61,19 @@ class ContributionReportTest {
     }
 
     @Test
+    fun `xiaomi hyperos3 battery protection value auto-discloses while unknown modes stay redacted`() {
+        val key = secure("security_pc_secure_protect_mode_key")
+        // "2" = HyperOS 3 Battery protection, a named OEM mode in the public domain.
+        deriveMatrix(
+            listOf(obs("full", key to "0"), obs("protect", key to "2")),
+        ).single().disclosure shouldBe Disclosure.AUTO
+        // A hypothetical fourth mode is not, and keeps the whole row opt-in.
+        deriveMatrix(
+            listOf(obs("full", key to "0"), obs("mystery", key to "3")),
+        ).single().disclosure shouldBe Disclosure.REDACTED
+    }
+
+    @Test
     fun `unknown key is redacted`() {
         deriveMatrix(
             listOf(

--- a/app/src/test/java/eu/darken/amply/diagnostics/core/DefaultContributionRepositoryTest.kt
+++ b/app/src/test/java/eu/darken/amply/diagnostics/core/DefaultContributionRepositoryTest.kt
@@ -19,6 +19,7 @@ import eu.darken.amply.charging.core.adapter.SamsungLabAdapter
 import eu.darken.amply.charging.core.adapter.SamsungLegacyChargingAdapter
 import eu.darken.amply.charging.core.adapter.SamsungModernChargingAdapter
 import eu.darken.amply.charging.core.adapter.XiaomiChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiHyperOs3ChargingAdapter
 import eu.darken.amply.charging.core.adapter.XiaomiLabAdapter
 import eu.darken.amply.common.ca.toCaString
 import io.kotest.matchers.collections.shouldContainExactly
@@ -60,6 +61,7 @@ class DefaultContributionRepositoryTest {
         samsungLegacy = SamsungLegacyChargingAdapter(),
         samsungLab = SamsungLabAdapter(),
         xiaomi = XiaomiChargingAdapter(),
+        xiaomiHyperOs3 = XiaomiHyperOs3ChargingAdapter(),
         xiaomiLab = XiaomiLabAdapter(),
         onePlus = OnePlusChargingAdapter(),
         onePlusLab = OnePlusLabAdapter(),


### PR DESCRIPTION
## What changed

Adds charge control for HyperOS 3's Battery Protection mode on qualified Xiaomi devices, starting with the Redmi Note 14 (`tanzanite`). On these devices Amply can now read and set all three native modes: Battery protection (fixed 80% cap), Intelligent charging, and Charge fully. The temporary full-charge session uses Charge fully as the override and restores the prior mode as on other supported devices. Unqualified HyperOS 3 devices keep the diagnostics-only experience with the contribution wizard.

## Technical Context

- The gate is HyperOS 3 plus a qualified-codename allowlist, not version-only: mode `2` is model-/build-dependent within HyperOS 3 (a Poco F5 on HyperOS 3.0.2 has only the two old modes), `ro.mi.os.version.code` has no minor version, and mode-2 presence can't be probed at runtime (the key is absent in factory state; a read only returns the current value).
- Hardware evidence (issue #48, tanzanite): external shell-UID writes — the same path the Shizuku service uses — move charging in both directions (write `2` below the cap holds at 80% for ~20 min; write `0` mid-hold resumes past 80), Settings UI follows each write, applied synchronously. No hardware hold signal exists in `dumpsys battery`, so verification is settings read-back only. The Verified-devices ledger row lands in this PR alongside the gate.
- This is a GrapheneOS-precedent remote landing: app-level items (factory/absent-key semantics, sessions, access tiers, R8) are recorded as failing-closed known gaps in the ledger, to be verified by the contributor on the next beta via issue #48. The absent-key decode (absent = Intelligent) mirrors HyperOS 2 and is flagged in code comments.
- The one reviewed safety-boundary change: `SettingWritePolicy` widens the key's write domain to `{"0","1","2"}`. The domain is global, so `2` becomes boundary-writable on HyperOS 2 too — accepted because no Amply code path emits it there and the HyperOS 2 decode refuses it. `AdapterMutationDomainTest` pins the adapter/boundary pairing.
- Closest review focus: the new adapter's `apply` must value-match `FixedLimit(80)` exactly (the OEM cap is hard-wired), and the registry insertion must not disturb the HyperOS 2 or lab fallthrough paths — both are pinned by new tests.

Closes #48. Supersedes #63 (its ledger commit is folded into this branch).
