### PR TITLE
Upgrade: Verify the purchase state before starting a Play checkout

### DIFF
--- a/app/src/gplay/java/eu/darken/amply/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/core/UpgradeRepoGplay.kt
@@ -2,7 +2,6 @@ package eu.darken.amply.upgrade.core
 
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
-import com.android.billingclient.api.Purchase
 import eu.darken.amply.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.amply.common.debug.logging.Logging.Priority.INFO
 import eu.darken.amply.common.debug.logging.Logging.Priority.VERBOSE
@@ -14,6 +13,7 @@ import eu.darken.amply.upgrade.core.billing.BillingData
 import eu.darken.amply.upgrade.core.billing.BillingManager
 import eu.darken.amply.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.amply.upgrade.core.billing.ItemAlreadyOwnedBillingException
+import eu.darken.amply.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.amply.upgrade.core.billing.PurchasedSku
 import eu.darken.amply.upgrade.core.billing.Sku
 import eu.darken.amply.upgrade.core.billing.SkuDetails
@@ -269,7 +269,18 @@ class UpgradeRepoGplay @Inject constructor(
                     // Reconciled only if the restore actually returned the SKU Play claims is owned —
                     // a grace-only isPro doesn't count, the entitlement is still missing.
                     if (restored?.upgrades?.any { it.sku == sku } != true) {
-                        onError(e)
+                        if (restored?.pending?.isNotEmpty() == true) {
+                            // Play blocks re-purchasing a product whose payment it is still
+                            // processing. "Already owned" is technically what Play said, but the
+                            // dialog's restore tips are the wrong advice: nothing to restore, and the
+                            // entitlement lands by itself once the payment clears.
+                            log(TAG, INFO) { "Already-owned recovery found a pending payment" }
+                            onError(PendingPurchaseBillingException(e))
+                        } else {
+                            // Couldn't reconcile the entitlement (account mismatch, Play quirk) —
+                            // fall back to the already-owned dialog with restore tips.
+                            onError(e)
+                        }
                     }
                 }
 
@@ -314,13 +325,16 @@ class UpgradeRepoGplay @Inject constructor(
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = billingManager.querySkus(*skus)
 
     /**
-     * Strict subscription lookup for the pre-purchase gate: fresh SUBS-only query with explicit
-     * failure. No grace substitution and no cross-product-type tolerance — callers must treat any
-     * error as "couldn't verify" and fail closed.
+     * Strict purchase-state lookup for the pre-purchase gates: a fresh COMPLETE round-trip with
+     * explicit failure. No grace substitution and no partial tolerance (unlike [refresh] and
+     * [restorePurchaseNow]) — callers must treat any error as "couldn't verify" and fail closed.
+     * Covers both product types and pending payments, because both can make a purchase wrong: a
+     * renewing subscription (double billing) and a payment Play is still processing (Play rejects the
+     * re-purchase).
      */
-    suspend fun queryCurrentSubscriptions(): Collection<Purchase> {
-        log(TAG) { "queryCurrentSubscriptions()" }
-        return billingManager.querySubscriptions()
+    suspend fun verifyPurchaseStateNow(): Info {
+        log(TAG) { "verifyPurchaseStateNow()" }
+        return Info(billingData = billingManager.refreshStrict(), isSettled = true)
     }
 
     override suspend fun refresh() {
@@ -449,7 +463,8 @@ class UpgradeRepoGplay @Inject constructor(
      * [restorePurchaseNow]. Only relinquishes the upgrade if we haven't had it for a while (grace
      * period). READ-ONLY: this runs on replayed shared-flow data too, so it must never stamp the
      * grace cache — see [recordProState]. [settled] comes from the caller, never from `billingData`
-     * nullness: the grace branch returns an Info with `billingData = null` that may well be settled.
+     * nullness: a null-data Info can be perfectly settled (a real empty snapshot), and the grace
+     * branch carries the data through anyway.
      */
     private suspend fun BillingData?.toUpgradeInfo(settled: Boolean): Info {
         // Branch on MAPPED upgrades, not raw purchases: a purchase list containing only products this
@@ -464,7 +479,11 @@ class UpgradeRepoGplay @Inject constructor(
         log(TAG) { "toUpgradeInfo(): lastProAt=${snapshot.lastProAt}, data=$this" }
         return if (isWithinGrace(snapshot.lastProAt, graceWindowMs(snapshot.lastProSku))) {
             log(TAG, VERBOSE) { "Not currently pro, but were recently — staying pro through the grace window" }
-            Info(gracePeriod = true, billingData = null, isSettled = settled)
+            // billingData is carried through, not dropped: this branch is only reached when the
+            // mapped upgrades are empty, so entitlement stays empty either way — but a pending
+            // payment must stay visible, and a grace user waiting on one is exactly who needs the
+            // explanation.
+            Info(gracePeriod = true, billingData = this, isSettled = settled)
         } else {
             mapped
         }
@@ -513,6 +532,20 @@ class UpgradeRepoGplay @Inject constructor(
             }
             ?.distinct()
             ?: emptySet()
+
+        /**
+         * Any owned purchase Play still bills on a schedule. Deliberately computed from the RAW
+         * PURCHASED purchases instead of [upgrades]: the mapping drops products this app doesn't
+         * know, and the pre-purchase gate must keep blocking on a renewing subscription with an
+         * unknown or legacy product ID — being wrong there means billing the user twice for the same
+         * upgrade. Both product types are scanned; a one-time purchase reports `isAutoRenewing =
+         * false`, so the broader input cannot produce a false positive.
+         *
+         * Computed on access, not in the initializer: an Info is built for every mapping pass, and
+         * only the purchase gate needs this.
+         */
+        val hasAutoRenewingSubscription: Boolean
+            get() = billingData?.purchases?.any { it.isAutoRenewing } == true
 
         override val isPro: Boolean = upgrades.isNotEmpty() || gracePeriod
 

--- a/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/BillingData.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/BillingData.kt
@@ -20,8 +20,15 @@ data class BillingData(
     val pendingPurchases: Collection<Purchase> = emptyList(),
 )
 
-internal fun Collection<Purchase>.purchased(): List<Purchase> =
-    filter { it.purchaseState == PurchaseState.PURCHASED }
+/**
+ * Owned right now. The ONLY state that may grant an entitlement, stamp the grace cache or be
+ * acknowledged — a PENDING purchase is a payment Play is still processing, and acknowledging one is
+ * rejected permanently.
+ */
+internal val Purchase.isPurchased: Boolean
+    get() = purchaseState == PurchaseState.PURCHASED
+
+internal fun Collection<Purchase>.purchased(): List<Purchase> = filter { it.isPurchased }
 
 internal fun Collection<Purchase>.pending(): List<Purchase> =
     filter { it.purchaseState == PurchaseState.PENDING }

--- a/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/BillingException.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/BillingException.kt
@@ -29,6 +29,16 @@ class ItemAlreadyOwnedBillingException(cause: Throwable) :
     BillingException("Item is already owned.", cause)
 
 /**
+ * A purchase can't proceed because the account already has a payment Play is still processing.
+ *
+ * Typed so the UI can answer with the informational pending dialog instead of the already-owned error
+ * and its restore tips: restoring cannot help — Play refuses to re-sell a product with a pending
+ * payment, and the entitlement arrives on its own once the payment clears.
+ */
+class PendingPurchaseBillingException(cause: Throwable? = null) :
+    BillingException("A purchase with a pending payment already exists.", cause)
+
+/**
  * Play can't sell us this product/offer right now: it was omitted from the product-details response,
  * came back ambiguous (duplicate rows), or is reported as unavailable.
  *

--- a/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/BillingManager.kt
@@ -150,13 +150,18 @@ open class BillingManager @Inject constructor(
                                 // isFailureSettled forever with no retry. withTimeoutOrNull, NOT
                                 // withTimeout: TimeoutCancellationException is a CancellationException
                                 // and would kill this loop.
-                                withTimeoutOrNull(initialRefreshTimeoutMs) {
+                                val initialRefresh = withTimeoutOrNull(initialRefreshTimeoutMs) {
                                     connection.refreshPurchases()
                                 } ?: throw BillingException("Initial purchase refresh timed out")
 
                                 failStreak = 0
                                 connectionHolder.value = connection
                                 log(TAG, INFO) { "Billing connection established" }
+                                // AFTER publishing: a partial refresh is still a usable connection (a
+                                // pending-only cold start must not starve billingData), but its
+                                // bookkeeping — episode clock, dead-binder teardown — has to run, and
+                                // an invalidation may only tear down an INSTALLED connection.
+                                processReconciliation(initialRefresh)
                             }
                             // The provider flow stays open for the connection's lifetime; a normal
                             // completion means the connection is gone without an error — treat it
@@ -427,6 +432,37 @@ open class BillingManager @Inject constructor(
         }
     }
 
+    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
+    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
+    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
+    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
+    // useConnection's).
+    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
+        // A partial refresh no longer reaches useConnection's dead-binder detection (it returns
+        // instead of throwing), so the teardown that used to ride the throw path happens here. Cause
+        // chain, not the exception itself: the failure arrives user-friendly-mapped. Deliberately no
+        // holder CAS: the failing connection may already have been replaced, and the accepted cost of
+        // that rare race is one extra failed action while the loop reconnects.
+        val clientError = refresh.partialError?.let {
+            (it as? BillingClientException) ?: (it.cause as? BillingClientException)
+        }
+        if (clientError != null && clientError.result.responseCode in INVALIDATING_CODES) {
+            log(TAG, WARN) {
+                "Refresh reported the connection dead (${clientError.result.responseCode}), invalidating."
+            }
+            invalidations.trySend(Unit)
+        }
+
+        if (!refresh.isComplete && !refresh.hasConfirmedProPurchase) {
+            // A reconciliation that couldn't confirm the upgrade. Stamped with the refresh's COMMIT
+            // time, never now-at-send: a confirmation that committed between this refresh and the
+            // send (e.g. a pending payment completing) must stay NEWER than this failure, or the
+            // grace episode it closed would be reopened.
+            log(TAG, WARN) { "Partial refresh without a confirmed purchase at ${refresh.occurredAt}" }
+            connectionFailuresChannel.trySend(refresh.occurredAt)
+        }
+    }
+
     private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T {
         // Every caller here is active demand (opening the upgrade screen, restore/buy taps, purchase
         // acks) — cut a pending reconnect backoff short. A no-op while healthy.
@@ -481,18 +517,26 @@ open class BillingManager @Inject constructor(
         // upgradeInfo replay cache. The freshBillingData emission happens inside the reducer's
         // commit, in commit order — not here.
         val fresh = useConnection { refreshPurchases() }
+        processReconciliation(fresh)
         return fresh.purchases.toBillingData()
     }
 
-    // Strict SUBS-only query for the pre-purchase subscription gate: unlike refresh(), a failure here
-    // propagates (user-friendly-mapped) instead of being masked by the other product type.
-    open suspend fun querySubscriptions(): Collection<Purchase> = try {
-        useConnection { querySubscriptions() }
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        log(TAG, WARN) { "querySubscriptions() failed: ${e.asLog()}" }
-        throw e.tryMapUserFriendly()
+    /**
+     * Strict variant for the pre-purchase gates: unlike [refresh], anything short of a COMPLETE
+     * reconciliation throws (user-friendly-mapped) instead of returning what it happened to find — a
+     * gate must be able to tell "not owned" apart from "couldn't verify" and fail closed.
+     */
+    open suspend fun refreshStrict(): BillingData {
+        log(TAG) { "refreshStrict()" }
+        val fresh = useConnection { refreshPurchases() }
+        if (!fresh.isComplete) {
+            // partialError is set for every incomplete refresh; the fallback only exists so a future
+            // incompleteness without a captured cause still fails closed instead of passing.
+            val error = fresh.partialError ?: BillingException("Purchase refresh was incomplete")
+            log(TAG, WARN) { "refreshStrict() incomplete: ${error.asLog()}" }
+            throw error.tryMapUserFriendly()
+        }
+        return fresh.purchases.toBillingData()
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/BillingManager.kt
@@ -432,17 +432,12 @@ open class BillingManager @Inject constructor(
         }
     }
 
-    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
-    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
-    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
-    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
-    // useConnection's).
-    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
-        // A partial refresh no longer reaches useConnection's dead-binder detection (it returns
-        // instead of throwing), so the teardown that used to ride the throw path happens here. Cause
-        // chain, not the exception itself: the failure arrives user-friendly-mapped. Deliberately no
-        // holder CAS: the failing connection may already have been replaced, and the accepted cost of
-        // that rare race is one extra failed action while the loop reconnects.
+    // A partial refresh no longer reaches useConnection's dead-binder detection (it returns instead
+    // of throwing), so the teardown that used to ride the throw path happens here. Cause chain, not
+    // the exception itself: the failure arrives user-friendly-mapped. Deliberately no holder CAS:
+    // the failing connection may already have been replaced, and the accepted cost of that rare race
+    // is one extra failed action while the loop reconnects.
+    private fun invalidateOnDeadConnection(refresh: BillingConnection.PurchaseRefresh) {
         val clientError = refresh.partialError?.let {
             (it as? BillingClientException) ?: (it.cause as? BillingClientException)
         }
@@ -452,6 +447,15 @@ open class BillingManager @Inject constructor(
             }
             invalidations.trySend(Unit)
         }
+    }
+
+    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
+    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
+    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
+    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
+    // useConnection's).
+    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
+        invalidateOnDeadConnection(refresh)
 
         if (!refresh.isComplete && !refresh.hasConfirmedProPurchase) {
             // A reconciliation that couldn't confirm the upgrade. Stamped with the refresh's COMMIT
@@ -529,6 +533,11 @@ open class BillingManager @Inject constructor(
     open suspend fun refreshStrict(): BillingData {
         log(TAG) { "refreshStrict()" }
         val fresh = useConnection { refreshPurchases() }
+        // A gate that hit a dying connection must still trigger the reconnect (the throw below
+        // bypasses useConnection's detection, which already returned), or every later purchase check
+        // keeps reusing the corpse. No-op on a complete refresh. The episode clock stays out of this
+        // path: an aborted gate is not a reconciliation outcome.
+        invalidateOnDeadConnection(fresh)
         if (!fresh.isComplete) {
             // partialError is set for every incomplete refresh; the fallback only exists so a future
             // incompleteness without a captured cause still fails closed instead of passing.

--- a/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/client/BillingConnection.kt
@@ -21,6 +21,9 @@ import eu.darken.amply.upgrade.core.billing.BillingManager.Companion.tryMapUserF
 import eu.darken.amply.upgrade.core.billing.OfferUnavailableBillingException
 import eu.darken.amply.upgrade.core.billing.Sku
 import eu.darken.amply.upgrade.core.billing.SkuDetails
+import eu.darken.amply.upgrade.core.billing.isPurchased
+import eu.darken.amply.upgrade.core.billing.pending
+import eu.darken.amply.upgrade.core.billing.purchased
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -212,13 +215,40 @@ class BillingConnection(
     }
 
     /**
-     * The purchases of a refresh plus whether it covered both product types: a partial result (one
-     * query failed) is still authoritative for what it FOUND, but must not be treated as proof of
-     * absence for the type that couldn't be checked.
+     * The full outcome of a refresh: what it committed, what it actually CONFIRMED, and how far it
+     * got. A partial result (one query failed) is still authoritative for what it FOUND, but must not
+     * be treated as proof of absence for the type that couldn't be checked — so callers that need to
+     * fail closed, or to feed the grace episode clock, get the provenance instead of having to infer
+     * it from the merged view.
      */
     data class PurchaseRefresh(
+        /**
+         * The committed reducer state (queries merged with retained snapshots and surviving events) —
+         * the same view the reactive [purchases] flow emits.
+         */
         val purchases: Collection<Purchase>,
+        /**
+         * ONLY what these queries returned as owned: never retained state of a failed type, so a
+         * consumer can tell "Play said so just now" from "we still remember this".
+         */
+        val confirmed: Collection<Purchase> = emptyList(),
+        /**
+         * A confirmed PURCHASED purchase of a product this app knows. Fail-safe default: "we couldn't
+         * confirm the upgrade" is the direction that keeps the grace bookkeeping honest.
+         */
+        val hasConfirmedProPurchase: Boolean = false,
         val isComplete: Boolean,
+        /**
+         * Commit time under `reducerLock` — the same instant stamped on this refresh's [FreshUpdate],
+         * so a confirmation and a later failure signal are ordered by when they HAPPENED.
+         */
+        val occurredAt: Long = System.currentTimeMillis(),
+        /**
+         * Why the refresh is incomplete (the failed type's already user-friendly-mapped exception),
+         * null when complete. Carried rather than thrown: a partial refresh that found something is
+         * still useful, only the caller can decide whether partial is good enough.
+         */
+        val partialError: Throwable? = null,
     )
 
     // Serializes concurrent refreshes (manual, background, auto-restore): an older query that got
@@ -246,6 +276,13 @@ class BillingConnection(
             // authoritative even when its sibling failed — verified absence (e.g. a refunded IAP)
             // must not be discarded just because the SUB query errored.
             val isComplete = iap.isSuccess && sub.isSuccess
+            // Only what the queries CONFIRMED as owned — retained stale data of a failed type stays
+            // out (it would keep re-stamping the grace window), and so do pending purchases (they
+            // prove no ownership).
+            val confirmed = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty())
+                .purchased()
+                .sortedByDescending { it.purchaseTime }
+            var committedAt = 0L
             val committed = synchronized(reducerLock) {
                 val next = state.value.withQueryResults(
                     iap = iap.getOrNull(),
@@ -253,19 +290,18 @@ class BillingConnection(
                     genAtQueryStart = genAtQueryStart,
                 )
                 state.value = next
+                committedAt = System.currentTimeMillis()
                 if (iap.isSuccess || sub.isSuccess) {
-                    // Only what the queries CONFIRMED as owned — retained stale data of a failed
-                    // type stays out of the fresh stream (it would keep re-stamping the grace
-                    // window), and so do pending purchases (they prove no ownership).
-                    val confirmed = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty())
-                        .filter { it.purchaseState == PurchaseState.PURCHASED }
-                        .sortedByDescending { it.purchaseTime }
-                    // A surviving overlay entry (purchase event newer than the query start, or of a
-                    // failed type) means this result does NOT prove total absence: it must not count
-                    // as a full snapshot, or an empty query racing a fresh purchase event would start
-                    // a false unconfirmed-grace episode.
-                    val provesAbsence = isComplete && next.overlay.isEmpty()
-                    freshUpdatesChannel.trySend(FreshUpdate(confirmed, isFullSnapshot = provesAbsence))
+                    // A surviving OWNED overlay entry (purchase event newer than the query start, or
+                    // of a failed type) means this result does NOT prove total absence: it must not
+                    // count as a full snapshot, or an empty query racing a fresh purchase event would
+                    // start a false unconfirmed-grace episode. A surviving PENDING entry proves
+                    // nothing about ownership, so it must not suppress the bookkeeping either — a
+                    // payment in progress would otherwise freeze the episode clock.
+                    val provesAbsence = isComplete && next.overlay.none { it.purchase.isPurchased }
+                    freshUpdatesChannel.trySend(
+                        FreshUpdate(confirmed, isFullSnapshot = provesAbsence, occurredAt = committedAt),
+                    )
                 }
                 next
             }
@@ -273,21 +309,30 @@ class BillingConnection(
             // Support-log anchor, at INFO because purchase complaints arrive as debug recordings.
             // Logs what these queries CONFIRMED, kept distinct from the committed view: merged()
             // retains a failed type's previous purchases, so reporting it as "what Play returned"
-            // would be false certainty. Product IDs only — never the Purchase, which carries order
-            // and token data.
+            // would be false certainty. Pending ids are listed separately — "bought it, still not
+            // upgraded" reports are exactly this state. Product IDs only — never the Purchase, which
+            // carries order and token data.
             log(TAG, INFO) {
-                val confirmedIds = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()).flatMap { it.products }
-                "refreshPurchases(): confirmed=$confirmedIds, isComplete=$isComplete, " +
+                val returned = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+                val confirmedIds = returned.purchased().flatMap { it.products }
+                val pendingIds = returned.pending().flatMap { it.products }
+                "refreshPurchases(): confirmed=$confirmedIds, pending=$pendingIds, isComplete=$isComplete, " +
                     "iapOk=${iap.isSuccess}, subOk=${sub.isSuccess}, merged=${committed.merged().size}"
             }
 
-            // Throws when nothing OWNED was found and a query failed, so the caller can tell "not
-            // owned" apart from "couldn't verify" (a pending purchase owns nothing).
-            combinePurchaseResults(iap, sub)
+            // Throws when the refresh learned nothing usable and a query failed, so the caller can
+            // tell "not owned" apart from "couldn't verify".
+            combinePurchaseResults(iap, sub, skuTypeOf)
 
             PurchaseRefresh(
                 purchases = committed.merged(),
+                confirmed = confirmed,
+                hasConfirmedProPurchase = confirmed.any { purchase ->
+                    purchase.products.any { skuTypeOf(it) != null }
+                },
                 isComplete = isComplete,
+                occurredAt = committedAt,
+                partialError = iap.exceptionOrNull() ?: sub.exceptionOrNull(),
             )
         }
     }
@@ -331,41 +376,6 @@ class BillingConnection(
         return purchaseData.filter {
             it.purchaseState == PurchaseState.PURCHASED || it.purchaseState == PurchaseState.PENDING
         }
-    }
-
-    /**
-     * Strict SUBS-only query for the pre-purchase subscription gate: unlike [refreshPurchases], a
-     * failure propagates (no cross-type tolerance) — callers must be able to fail closed on
-     * "couldn't verify". Commits through the reducer like any query, so the reactive [purchases] flow
-     * picks up the fresh renewal state, and emits a partial fresh update: it proves what the SUBS
-     * query found, never the absence of anything it didn't cover.
-     */
-    suspend fun querySubscriptions(): Collection<Purchase> = refreshMutex.withLock {
-        log(TAG) { "querySubscriptions()" }
-        val genAtQueryStart = state.value.eventGen
-        val subs = queryPurchases(BillingClient.ProductType.SUBS)
-        val committed = synchronized(reducerLock) {
-            val next = state.value.withQueryResults(
-                iap = null,
-                sub = subs,
-                genAtQueryStart = genAtQueryStart,
-            )
-            state.value = next
-            freshUpdatesChannel.trySend(
-                FreshUpdate(subs.filter { it.purchaseState == PurchaseState.PURCHASED }, isFullSnapshot = false),
-            )
-            next
-        }
-        // The COMMITTED view, not the raw response: a purchase event that arrived after the query
-        // started survives the commit as a newer overlay and must reach the gate too — otherwise a
-        // just-purchased renewing sub could slip past the fail-closed double-billing check.
-        // Non-IAP overlays only; untyped (unknown product) entries stay in on the safe side.
-        val byToken = LinkedHashMap<String, Purchase>()
-        subs.forEach { byToken[it.purchaseToken] = it }
-        committed.overlay
-            .filter { it.type != Sku.Type.IAP }
-            .forEach { byToken[it.purchase.purchaseToken] = it.purchase }
-        byToken.values.sortedByDescending { it.purchaseTime }
     }
 
     suspend fun acknowledgePurchase(purchase: Purchase): BillingResult {
@@ -550,23 +560,30 @@ class BillingConnection(
         }
 
         /**
-         * Combines the two product-type query results: a COMPLETED purchase found by either type is
-         * authoritative; an error is propagated whenever nothing found is actually owned, so callers
-         * can tell "not owned" apart from "couldn't verify one product type". A pending purchase
-         * grants nothing, so it must not swallow the sibling type's failure — it is still returned
-         * (the UI needs it) whenever a completed purchase is present or no query failed. Treating
-         * any found purchase as authoritative is safe because every product this app sells is a Pro
-         * SKU (see [OurSku.PRO_SKUS]). Pure and unit-tested.
+         * Combines the two product-type query results: an error is only propagated when the refresh
+         * learned nothing usable, so callers can tell "not owned" apart from "couldn't verify one
+         * product type". A PURCHASED result of ANY product suppresses the error — every product this
+         * app sells is an upgrade SKU (see [OurSku.PRO_SKUS]), so it is by construction relevant. A
+         * PENDING result only counts when it maps to a KNOWN upgrade SKU: it grants nothing, and an
+         * unknown pending product says nothing about the type whose query failed, so treating it as
+         * a find would swallow a real "couldn't verify". Pure and unit-tested.
          */
         internal fun combinePurchaseResults(
             iap: Result<Collection<Purchase>>,
             sub: Result<Collection<Purchase>>,
+            typeOf: (String) -> Sku.Type? = DEFAULT_SKU_TYPE_RESOLVER,
         ): Collection<Purchase> {
-            val found = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
-            if (found.none { it.purchaseState == PurchaseState.PURCHASED }) {
-                (iap.exceptionOrNull() ?: sub.exceptionOrNull())?.let { throw it }
+            val returned = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+            val found = returned.filter { purchase ->
+                purchase.isPurchased || purchase.products.any { typeOf(it) != null }
             }
-            return found.sortedByDescending { it.purchaseTime }
+            return when {
+                found.isNotEmpty() -> found.sortedByDescending { it.purchaseTime }
+                else -> {
+                    (iap.exceptionOrNull() ?: sub.exceptionOrNull())?.let { throw it }
+                    emptyList()
+                }
+            }
         }
     }
 }

--- a/app/src/gplay/java/eu/darken/amply/upgrade/ui/UpgradeEvents.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/ui/UpgradeEvents.kt
@@ -13,7 +13,16 @@ sealed interface UpgradeEvents {
      */
     data object RestoreInconclusive : UpgradeEvents
     data object SubscriptionStillRenewing : UpgradeEvents
-    data object SubscriptionCheckFailed : UpgradeEvents
+
+    /**
+     * Play answered, no completed purchase exists, but a payment is still being processed. Purely
+     * informational: nothing to fix, nothing to restore — the upgrade unlocks by itself once Play
+     * clears the payment, and a new purchase would be rejected (or double-charge) in the meantime.
+     */
+    data object PurchasePending : UpgradeEvents
+
+    /** The pre-purchase check with Play didn't finish, so the purchase was not started. */
+    data object PurchaseCheckFailed : UpgradeEvents
 
     /** A billing failure that has no dedicated dialog; the host renders its mapped copy. */
     data class Error(val error: Throwable) : UpgradeEvents

--- a/app/src/gplay/java/eu/darken/amply/upgrade/ui/UpgradeScreenHost.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/ui/UpgradeScreenHost.kt
@@ -48,6 +48,7 @@ fun UpgradeScreenHost(
     var showRestoreInconclusive by rememberSaveable { mutableStateOf(false) }
     var showStillRenewing by rememberSaveable { mutableStateOf(false) }
     var showCheckFailed by rememberSaveable { mutableStateOf(false) }
+    var showPurchasePending by rememberSaveable { mutableStateOf(false) }
     // Plain remember, unlike its siblings: a Throwable is only nominally Serializable — our billing
     // exceptions carry non-serializable payloads (a Sku, a BillingResult), so saving one would crash
     // on the very rotation it is meant to survive. Losing an error dialog is the cheaper failure.
@@ -74,7 +75,8 @@ fun UpgradeScreenHost(
                 UpgradeEvents.RestoreFailed -> showRestoreFailed = true
                 UpgradeEvents.RestoreInconclusive -> showRestoreInconclusive = true
                 UpgradeEvents.SubscriptionStillRenewing -> showStillRenewing = true
-                UpgradeEvents.SubscriptionCheckFailed -> showCheckFailed = true
+                UpgradeEvents.PurchaseCheckFailed -> showCheckFailed = true
+                UpgradeEvents.PurchasePending -> showPurchasePending = true
                 is UpgradeEvents.Error -> error = event.error
             }
         }
@@ -125,9 +127,23 @@ fun UpgradeScreenHost(
     if (showCheckFailed) {
         AlertDialog(
             onDismissRequest = { showCheckFailed = false },
-            text = { Text(stringResource(R.string.upgrade_screen_sub_check_failed_message)) },
+            text = { Text(stringResource(R.string.upgrade_screen_purchase_check_failed_message)) },
             confirmButton = {
                 TextButton(onClick = { showCheckFailed = false }) {
+                    Text(stringResource(R.string.upgrade_dismiss_action))
+                }
+            },
+        )
+    }
+
+    if (showPurchasePending) {
+        // Purely informational: there is nothing to fix and nothing to restore, so dismissing is the
+        // only action.
+        AlertDialog(
+            onDismissRequest = { showPurchasePending = false },
+            text = { Text(stringResource(R.string.upgrade_screen_pending_dialog_message)) },
+            confirmButton = {
+                TextButton(onClick = { showPurchasePending = false }) {
                     Text(stringResource(R.string.upgrade_dismiss_action))
                 }
             },

--- a/app/src/gplay/java/eu/darken/amply/upgrade/ui/UpgradeUiState.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/ui/UpgradeUiState.kt
@@ -74,7 +74,7 @@ internal enum class SubscriptionAction {
  * Display-only ownership mapping from the (replayed) upgradeInfo. Conservative: if ANY record for the
  * sub SKU still claims auto-renew (e.g. a retained purchase event next to fresher query data), treat
  * it as renewing — that can only under-offer the one-time purchase, never enable it wrongly; the
- * actual purchase gate re-verifies against a fresh SUBS query in the ViewModel.
+ * actual purchase gate re-verifies against a fresh, complete Play check in the ViewModel.
  */
 internal fun UpgradeRepoGplay.Info.toOwnership() = Ownership(
     hasIap = upgrades.any { it.sku == OurSku.Iap.PRO_UPGRADE },

--- a/app/src/gplay/java/eu/darken/amply/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/ui/UpgradeViewModel.kt
@@ -15,6 +15,7 @@ import eu.darken.amply.upgrade.core.OurSku
 import eu.darken.amply.upgrade.core.UpgradeRepoGplay
 import eu.darken.amply.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.amply.upgrade.core.billing.OfferUnavailableBillingException
+import eu.darken.amply.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.amply.upgrade.core.billing.Sku
 import eu.darken.amply.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
@@ -76,9 +77,10 @@ class UpgradeViewModel @Inject constructor(
     private val activeOp = MutableStateFlow<BusyOp?>(null)
     private val retryTrigger = MutableStateFlow(0)
 
-    // Test seam: the diagnostics threshold compares wall-clock time, which coroutine test dispatchers
-    // can't advance.
+    // Test seams: the diagnostics threshold compares wall-clock time and the gate's bound runs on a
+    // real dispatcher, neither of which a coroutine test dispatcher can advance.
     internal var clock: () -> Long = { System.currentTimeMillis() }
+    internal var verifyTimeoutMs: Long = VERIFY_TIMEOUT_MS
 
     /**
      * The unconfirmed-episode stamp, re-emitted when the episode crosses the diagnostics threshold:
@@ -165,8 +167,10 @@ class UpgradeViewModel @Inject constructor(
             null
         }
         // Owners and grace users don't depend on offer prices: their status and management actions
-        // render immediately and price problems are not their problem.
-        val priceIndependent = ownership.ownsAnything || grace != null
+        // render immediately and price problems are not their problem. A user waiting on a pending
+        // payment is in the same position — the pending hint is their answer, and both offers are
+        // locked anyway, so a price failure must not replace it with an error screen.
+        val priceIndependent = ownership.ownsAnything || grace != null || current.pending.isNotEmpty()
 
         val done = queries as? SkuQueries.Done
         if (done == null) {
@@ -295,44 +299,80 @@ class UpgradeViewModel @Inject constructor(
         return true
     }
 
+    /**
+     * Outcome of the pre-purchase check with Play. Both purchase paths share it: they buy
+     * alternatives of the same entitlement from the same account, so a check only one of them runs is
+     * exactly how a double charge slips through. [Blocked] means the user was already told why.
+     */
+    private sealed interface PurchaseGate {
+        data class Clear(val info: UpgradeRepoGplay.Info) : PurchaseGate
+        data object Blocked : PurchaseGate
+    }
+
+    // Fails closed: no fresh, complete answer from Play (error, timeout) means no purchase. Bounded,
+    // because the repo waits for a healthy connection indefinitely and a tap must not park the
+    // single-flight guard through an outage.
+    private suspend fun runPurchaseGate(): PurchaseGate {
+        val info = try {
+            withTimeoutOrNull(verifyTimeoutMs) { upgradeRepo.verifyPurchaseStateNow() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Purchase verification errored: ${e.asLog()}" }
+            events.tryEmit(UpgradeEvents.Error(e))
+            return PurchaseGate.Blocked
+        }
+        if (info == null) {
+            log(TAG, WARN) { "Purchase verification timed out" }
+            events.tryEmit(UpgradeEvents.PurchaseCheckFailed)
+            return PurchaseGate.Blocked
+        }
+        if (info.pending.isNotEmpty()) {
+            // Play rejects a purchase while it is still processing a payment for this account, and
+            // the alternative product would charge twice for the same features.
+            log(TAG, INFO) { "Purchase blocked: a payment is still pending" }
+            events.tryEmit(UpgradeEvents.PurchasePending)
+            return PurchaseGate.Blocked
+        }
+        return PurchaseGate.Clear(info)
+    }
+
+    // A launch that failed on a pending payment is not an error the user can act on: it gets the
+    // informational dialog instead of the already-owned copy and its restore tips.
+    private fun onLaunchError(error: Throwable) {
+        if (error is PendingPurchaseBillingException) {
+            events.tryEmit(UpgradeEvents.PurchasePending)
+        } else {
+            events.tryEmit(UpgradeEvents.Error(error))
+        }
+    }
+
     fun onGoIap(activity: Activity) {
         log(TAG) { "onGoIap($activity)" }
         viewModelScope.launch {
             // Single-flight: repeated taps must not stack verifications or billing launches.
             if (!acquireOp(BusyOp.IAP)) return@launch
             try {
-                // Hard gate against double-billing: verify against a FRESH SUBS-only query — the
-                // replayed upgradeInfo can be stale or built from partial results. Fails closed: no
-                // verified "not set to renew" (or no sub at all), no one-time purchase.
-                val subscriptions = try {
-                    withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.queryCurrentSubscriptions() }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log(TAG, WARN) { "Subscription verification errored: ${e.asLog()}" }
-                    events.tryEmit(UpgradeEvents.Error(e))
+                val gate = runPurchaseGate()
+                if (gate !is PurchaseGate.Clear) return@launch
+                // Hard gate against double-billing, against the FRESH result — the replayed
+                // upgradeInfo can be stale or built from partial results. Asked of the RAW purchases
+                // (see Info.hasAutoRenewingSubscription), never of the mapped upgrades: a renewing
+                // subscription with an unknown or legacy product ID must block the one-time purchase
+                // too, or the user pays for the upgrade twice.
+                if (gate.info.hasAutoRenewingSubscription) {
+                    log(TAG, INFO) { "IAP purchase blocked: subscription is still set to renew" }
+                    events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
                     return@launch
                 }
-                when {
-                    subscriptions == null -> {
-                        log(TAG, WARN) { "Subscription verification timed out" }
-                        events.tryEmit(UpgradeEvents.SubscriptionCheckFailed)
-                    }
-
-                    subscriptions.any { it.isAutoRenewing } -> {
-                        log(TAG, INFO) { "IAP purchase blocked: subscription is still set to renew" }
-                        events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
-                    }
-
-                    // Suspends until the Play sheet launch resolved, so the single-flight guard
-                    // covers the whole tap-to-sheet window, not just the verification.
-                    else -> upgradeRepo.launchBillingFlowNow(
-                        activity,
-                        OurSku.Iap.PRO_UPGRADE,
-                        null,
-                        onError = { events.tryEmit(UpgradeEvents.Error(it)) },
-                    )
-                }
+                // Suspends until the Play sheet launch resolved, so the single-flight guard covers
+                // the whole tap-to-sheet window, not just the verification.
+                upgradeRepo.launchBillingFlowNow(
+                    activity,
+                    OurSku.Iap.PRO_UPGRADE,
+                    null,
+                    onError = ::onLaunchError,
+                )
             } finally {
                 activeOp.value = null
             }
@@ -353,6 +393,32 @@ class UpgradeViewModel @Inject constructor(
         viewModelScope.launch {
             if (!acquireOp(BusyOp.SUBSCRIPTION)) return@launch
             try {
+                // Same fresh check as the one-time path: a pending payment (for either product) must
+                // block this launch too — Play would reject it, or bill it on top.
+                val gate = runPurchaseGate()
+                if (gate !is PurchaseGate.Clear) return@launch
+                // The reactive UI can be stale (the purchase was made on another device), and Play
+                // happily sells the subscription alongside an owned one-time purchase — the user
+                // would pay for the upgrade twice. The strict refresh already committed into the
+                // shared billing data, so the screen re-renders to the ownership state, and the
+                // restore-success toast explains why nothing launched. Deliberately the MAPPED
+                // upgrades, not isPro: grace users (mapped upgrades empty) may legitimately
+                // re-purchase.
+                if (gate.info.upgrades.isNotEmpty()) {
+                    log(TAG, INFO) { "Subscription purchase blocked: fresh check found an owned upgrade" }
+                    events.tryEmit(UpgradeEvents.RestoreSucceeded)
+                    return@launch
+                }
+                // Same breadth as the one-time path's renewal guard: an auto-renewing subscription
+                // with an unknown or legacy product ID (which maps to zero upgrades, so the block
+                // above passed) must still block a new subscription — two renewing subscriptions for
+                // the same features is the same double-billing. Reuses the existing
+                // manage-subscription dialog.
+                if (gate.info.hasAutoRenewingSubscription) {
+                    log(TAG, INFO) { "Subscription purchase blocked: another subscription is still set to renew" }
+                    events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
+                    return@launch
+                }
                 // launchBillingFlowNow suspends until the launch resolved, so the guard covers the
                 // whole tap-to-sheet window. The flow itself runs on the repo's own scope, so closing
                 // the screen mid-launch doesn't abort the purchase.
@@ -360,7 +426,7 @@ class UpgradeViewModel @Inject constructor(
                     activity,
                     OurSku.Sub.PRO_UPGRADE,
                     offer,
-                    onError = { events.tryEmit(UpgradeEvents.Error(it)) },
+                    onError = ::onLaunchError,
                 )
             } finally {
                 activeOp.value = null

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -50,10 +50,11 @@
     <string name="upgrade_screen_restore_pending_hint">One of your purchases is still awaiting payment approval. It unlocks by itself once Google Play completes it.</string>
     <string name="upgrade_screen_restore_inconclusive_message">The check with Google Play didn\'t finish in time, so your purchase status is still unknown. Nothing has changed on your account.</string>
 
-    <!-- Pre-purchase subscription gate. -->
+    <!-- Pre-purchase gate, shared by both purchase paths. -->
     <string name="upgrade_screen_sub_still_renewing_title">Subscription still active</string>
     <string name="upgrade_screen_sub_still_renewing_message">Google Play reports that your subscription is still set to renew. To buy the one-time upgrade, cancel the subscription in Google Play first, then come back here.\n\nJust cancelled it? Give Google Play a moment and try again. Also make sure you are using the same Google account.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Couldn\'t check your subscription status with Google Play. Please try again in a moment.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Couldn\'t check your purchases with Google Play. Please try again in a moment.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play found a purchase with a pending payment and is still processing it. Your upgrade unlocks automatically once the payment goes through.</string>
 
     <!-- Grace: the upgrade is still active locally while Google Play can\'t re-confirm it. -->
     <string name="upgrade_screen_grace_title">Confirming your purchase</string>

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/UpgradeRepoGplayFlowTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/UpgradeRepoGplayFlowTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.amply.upgrade.core
 
+import android.app.Activity
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.common.AppDataStore
@@ -7,11 +8,17 @@ import eu.darken.amply.common.serialization.SerializationModule
 import com.android.billingclient.api.BillingResult
 import eu.darken.amply.upgrade.core.billing.BillingData
 import eu.darken.amply.upgrade.core.billing.BillingManager
+import eu.darken.amply.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.amply.upgrade.core.billing.ItemAlreadyOwnedBillingException
+import eu.darken.amply.upgrade.core.billing.PendingPurchaseBillingException
+import eu.darken.amply.upgrade.core.billing.Sku
 import eu.darken.amply.upgrade.core.billing.TestPurchases
 import eu.darken.amply.upgrade.core.billing.client.BillingConnection
 import eu.darken.amply.upgrade.core.billing.client.BillingConnectionProvider
 import eu.darken.amply.upgrade.core.billing.toBillingData
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -30,6 +37,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.File
@@ -76,12 +84,28 @@ class UpgradeRepoGplayFlowTest {
         override val freshBillingData: Flow<FreshData> = emptyFlow()
         override val purchaseFailures: Flow<BillingResult> = emptyFlow()
         override val connectionFailures: Flow<Long> = emptyFlow()
+
+        var strictAnswer: () -> BillingData = { BillingData(emptyList()) }
+        var refreshAnswer: () -> BillingData = { BillingData(emptyList()) }
+        var launchAnswer: () -> Unit = {}
+
+        override suspend fun refreshStrict(): BillingData = strictAnswer()
+
+        override suspend fun refresh(): BillingData = refreshAnswer()
+
+        override suspend fun startIapFlow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) =
+            launchAnswer()
     }
 
     private fun manager(
         billingData: Flow<BillingData>,
         failureSettled: Flow<Boolean> = MutableStateFlow(false),
-    ): BillingManager = FakeBillingManager(billingData, failureSettled)
+    ): FakeBillingManager = FakeBillingManager(billingData, failureSettled)
+
+    private fun freeManager(): FakeBillingManager = manager(MutableStateFlow(BillingData(emptyList())))
+
+    // The launch path needs an Activity to hand to Play; only its identity matters here.
+    private fun activity(): Activity = Robolectric.buildActivity(Activity::class.java).get()
 
     @Test fun `an owned purchase settles as pro`(): Unit = runBlocking {
         val repo = UpgradeRepoGplay(
@@ -191,6 +215,76 @@ class UpgradeRepoGplayFlowTest {
             repo.upgradeInfo.map { it.isSettled }.first { it } shouldBe true
         }
     }
+
+    @Test fun `a pending payment stays visible while grace keeps the upgrade`(): Unit = runBlocking {
+        // The audience that needs the explanation most: the upgrade runs on grace while Play is still
+        // processing the payment that will renew it. Dropping the data in the grace branch left them
+        // with a silent screen.
+        val cache = cache()
+        cache.stampLastProState(iapId, System.currentTimeMillis())
+        val repo = UpgradeRepoGplay(
+            manager(MutableStateFlow(listOf(TestPurchases.purchase(iapId, pending = true)).toBillingData())),
+            cache,
+        )
+
+        withTimeout(TIMEOUT_MS) {
+            val info = repo.upgradeInfo.first { it.isSettled } as UpgradeRepoGplay.Info
+            info.isPro shouldBe true
+            info.pending shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+        }
+    }
+
+    // region the strict gate lookup
+
+    @Test fun `verifyPurchaseStateNow fails closed instead of substituting grace`(): Unit = runBlocking {
+        val cache = cache()
+        cache.stampLastProState(iapId, System.currentTimeMillis())
+        val manager = freeManager().apply {
+            strictAnswer = { throw GplayServiceUnavailableException(RuntimeException("one product type failed")) }
+        }
+        val repo = UpgradeRepoGplay(manager, cache)
+
+        // Even a recent owner gets the error: a gate that can't verify must not let a purchase
+        // through on the strength of a grace window.
+        shouldThrow<GplayServiceUnavailableException> { repo.verifyPurchaseStateNow() }
+    }
+
+    @Test fun `verifyPurchaseStateNow reports the fresh split state`(): Unit = runBlocking {
+        val manager = freeManager().apply {
+            strictAnswer = {
+                listOf(
+                    TestPurchases.purchase(iapId),
+                    TestPurchases.purchase(OurSku.Sub.PRO_UPGRADE.id, token = "sub", pending = true),
+                ).toBillingData()
+            }
+        }
+        val repo = UpgradeRepoGplay(manager, cache())
+
+        val info = repo.verifyPurchaseStateNow()
+
+        info.upgrades.map { it.sku } shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+        info.pending shouldBe listOf(OurSku.Sub.PRO_UPGRADE)
+        info.isSettled shouldBe true
+    }
+
+    @Test fun `an already-owned recovery reports a pending payment instead of restore tips`(): Unit = runBlocking {
+        // Play refuses to re-sell a product whose payment it is still processing. The already-owned
+        // dialog would tell the user to restore, which cannot help.
+        val manager = freeManager().apply {
+            launchAnswer = { throw ItemAlreadyOwnedBillingException(RuntimeException("launch result")) }
+            refreshAnswer = { listOf(TestPurchases.purchase(iapId, pending = true)).toBillingData() }
+        }
+        val repo = UpgradeRepoGplay(manager, cache())
+
+        val errors = mutableListOf<Throwable>()
+        withTimeout(TIMEOUT_MS) {
+            repo.launchBillingFlowNow(activity(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+        }
+
+        errors.single().shouldBeInstanceOf<PendingPurchaseBillingException>()
+    }
+
+    // endregion
 
     @Test fun `wasEverPro tracks whether this install ever confirmed a purchase`(): Unit = runBlocking {
         val cache = cache()

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/UpgradeRepoGplayInfoTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/UpgradeRepoGplayInfoTest.kt
@@ -70,6 +70,42 @@ class UpgradeRepoGplayInfoTest {
         info.pending shouldBe listOf(OurSku.Sub.PRO_UPGRADE)
     }
 
+    @Test fun `a pending payment for a product this app doesn't sell is dropped`() {
+        UpgradeRepoGplay.Info(
+            billingData = listOf(TestPurchases.purchase("com.example.other", pending = true)).toBillingData(),
+        ).pending.isEmpty() shouldBe true
+    }
+
+    @Test fun `a renewing subscription is seen even when its product is unknown`() {
+        // The pre-purchase gate asks this, and it reads the RAW purchases on purpose: a subscription
+        // whose product ID this build doesn't know (legacy SKU, renamed product) still renews and
+        // still bills, so it has to keep blocking a second purchase.
+        UpgradeRepoGplay.Info(
+            billingData = listOf(
+                TestPurchases.purchase("com.example.legacy.sub", autoRenewing = true),
+            ).toBillingData(),
+        ).apply {
+            upgrades.isEmpty() shouldBe true
+            hasAutoRenewingSubscription shouldBe true
+        }
+    }
+
+    @Test fun `a one-time purchase never reads as renewing`() {
+        // Which is what makes scanning both product types safe: the wider input cannot produce a
+        // false positive.
+        UpgradeRepoGplay.Info(
+            billingData = listOf(TestPurchases.purchase(iapId)).toBillingData(),
+        ).hasAutoRenewingSubscription shouldBe false
+    }
+
+    @Test fun `a pending subscription does not read as renewing`() {
+        // Nothing is being billed yet: the payment hasn't gone through, and the pending gate is what
+        // blocks this purchase, not the renewal one.
+        UpgradeRepoGplay.Info(
+            billingData = listOf(TestPurchases.purchase(subId, autoRenewing = true, pending = true)).toBillingData(),
+        ).hasAutoRenewingSubscription shouldBe false
+    }
+
     @Test fun `grace alone is enough to stay pro`() {
         val info = UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
 

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/BillingManagerTest.kt
@@ -2,18 +2,26 @@ package eu.darken.amply.upgrade.core.billing
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import eu.darken.amply.upgrade.core.OurSku
 import eu.darken.amply.upgrade.core.billing.client.BillingConnection
 import eu.darken.amply.upgrade.core.billing.client.BillingConnectionProvider
+import eu.darken.amply.upgrade.core.billing.client.FakeBillingClient
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -24,6 +32,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * The connect loop owns every retry decision in the billing stack, so what it does when Play is
@@ -36,6 +45,9 @@ import org.robolectric.annotation.Config
 class BillingManagerTest {
 
     private val testScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    private val iapId = OurSku.Iap.PRO_UPGRADE.id
+    private val subId = OurSku.Sub.PRO_UPGRADE.id
 
     @After fun teardown() {
         testScope.cancel()
@@ -57,6 +69,44 @@ class BillingManagerTest {
     private fun manager(attempts: Channel<Unit>): BillingManager = BillingManager(
         FakeProvider(ApplicationProvider.getApplicationContext(), attempts),
     )
+
+    /**
+     * A provider that hands out real [BillingConnection]s over scripted Play answers, one per
+     * connection attempt (the last one repeats). Each stays open for its lifetime, like the real one.
+     */
+    private class ConnectingProvider(
+        context: Context,
+        private val clients: List<FakeBillingClient>,
+        private val attempts: Channel<Unit>,
+    ) : BillingConnectionProvider(context) {
+        private val attemptCount = AtomicInteger(0)
+
+        override val connection: Flow<BillingConnection> = flow {
+            val client = clients[minOf(attemptCount.getAndIncrement(), clients.size - 1)]
+            attempts.trySend(Unit)
+            emit(BillingConnection(client))
+            awaitCancellation()
+        }
+    }
+
+    private fun connectedManager(
+        vararg clients: FakeBillingClient,
+        attempts: Channel<Unit> = Channel(Channel.UNLIMITED),
+    ): BillingManager = BillingManager(
+        ConnectingProvider(ApplicationProvider.getApplicationContext(), clients.toList(), attempts),
+    )
+
+    private fun client(
+        iap: FakeBillingClient.Answer = FakeBillingClient.Answer(),
+        subs: FakeBillingClient.Answer = FakeBillingClient.Answer(),
+    ) = FakeBillingClient().apply {
+        answers = mapOf(
+            BillingClient.ProductType.INAPP to iap,
+            BillingClient.ProductType.SUBS to subs,
+        )
+    }
+
+    private fun failing(responseCode: Int) = FakeBillingClient.Answer(responseCode = responseCode)
 
     @Test fun `an unreachable play settles the failure signal instead of staying silent`(): Unit = runBlocking {
         val attempts = Channel<Unit>(Channel.UNLIMITED)
@@ -109,8 +159,151 @@ class BillingManagerTest {
         withTimeout(BACKOFF_FLOOR_MS) { attempts.receive() }
     }
 
+    // region reconciliation outcomes
+
+    @Test fun `refreshStrict fails closed on an incomplete refresh`(): Unit = runBlocking {
+        val manager = connectedManager(
+            client(
+                iap = FakeBillingClient.Answer(purchases = listOf(TestPurchases.purchase(iapId))),
+                subs = failing(BillingResponseCode.SERVICE_UNAVAILABLE),
+            ),
+        )
+
+        // A gate must not treat "one product type couldn't be checked" as "nothing else is owned":
+        // that is exactly how a double purchase gets through.
+        withTimeout(TIMEOUT_MS) {
+            shouldThrow<GplayServiceUnavailableException> { manager.refreshStrict() }
+        }
+    }
+
+    @Test fun `refreshStrict returns the split data on a complete refresh`(): Unit = runBlocking {
+        val owned = TestPurchases.purchase(iapId, purchaseTime = 2_000L)
+        val pending = TestPurchases.purchase(subId, purchaseTime = 1_000L, pending = true)
+        val manager = connectedManager(
+            client(
+                iap = FakeBillingClient.Answer(purchases = listOf(owned)),
+                subs = FakeBillingClient.Answer(purchases = listOf(pending)),
+            ),
+        )
+
+        withTimeout(TIMEOUT_MS) { manager.refreshStrict() } shouldBe BillingData(
+            purchases = listOf(owned),
+            pendingPurchases = listOf(pending),
+        )
+    }
+
+    @Test fun `a partial reconciliation without a confirmed purchase signals its commit time`(): Unit = runBlocking {
+        // The pending-only cold start: Play answered for one type with a payment in progress, the
+        // other failed. Nothing confirms the upgrade, so the grace episode clock must advance.
+        val pending = TestPurchases.purchase(iapId, pending = true)
+        val before = System.currentTimeMillis()
+        val manager = connectedManager(
+            client(
+                iap = FakeBillingClient.Answer(purchases = listOf(pending)),
+                subs = failing(BillingResponseCode.SERVICE_UNAVAILABLE),
+            ),
+        )
+
+        val failedAt = withTimeout(TIMEOUT_MS) { manager.connectionFailures.first() }
+
+        (failedAt >= before) shouldBe true
+        (failedAt <= System.currentTimeMillis()) shouldBe true
+        // Still published: a partial refresh is a usable connection, and starving billingData would
+        // leave the screen at Loading forever.
+        withTimeout(TIMEOUT_MS) { manager.billingData.first() } shouldBe BillingData(
+            purchases = emptyList(),
+            pendingPurchases = listOf(pending),
+        )
+    }
+
+    @Test fun `a partial refresh that confirmed a purchase does not signal`(): Unit = runBlocking {
+        val manager = connectedManager(
+            client(
+                iap = FakeBillingClient.Answer(purchases = listOf(TestPurchases.purchase(iapId))),
+                subs = failing(BillingResponseCode.SERVICE_UNAVAILABLE),
+            ),
+        )
+
+        // The upgrade WAS confirmed by this round-trip; the failed sibling type proves nothing
+        // against it, so the episode clock must stay untouched.
+        withTimeout(TIMEOUT_MS) { manager.billingData.first() }.purchases.size shouldBe 1
+        withTimeoutOrNull(QUIET_MS) { manager.connectionFailures.first() } shouldBe null
+    }
+
+    @Test fun `an invalidating partial refresh tears the connection down`(): Unit = runBlocking {
+        // The dead-binder teardown used to ride refreshPurchases' throw path through useConnection.
+        // A partial refresh returns instead of throwing, so without the explicit invalidation the
+        // dead connection would stay installed for every later caller.
+        val attempts = Channel<Unit>(Channel.UNLIMITED)
+        connectedManager(
+            client(
+                iap = FakeBillingClient.Answer(purchases = listOf(TestPurchases.purchase(iapId))),
+                subs = failing(BillingResponseCode.SERVICE_DISCONNECTED),
+            ),
+            client(),
+            attempts = attempts,
+        )
+
+        withTimeout(TIMEOUT_MS) { attempts.receive() }
+        withTimeout(TIMEOUT_MS) { attempts.receive() }
+    }
+
+    // endregion
+
+    // region pending payments
+
+    @Test fun `billing data splits owned purchases from pending payments`(): Unit = runBlocking {
+        val owned = TestPurchases.purchase(iapId, purchaseTime = 2_000L)
+        val pending = TestPurchases.purchase(subId, purchaseTime = 1_000L, pending = true)
+        val manager = connectedManager(
+            client(
+                iap = FakeBillingClient.Answer(purchases = listOf(owned)),
+                subs = FakeBillingClient.Answer(purchases = listOf(pending)),
+            ),
+        )
+
+        // The split is what keeps a payment in progress out of every entitlement decision while still
+        // letting the UI show it.
+        withTimeout(TIMEOUT_MS) { manager.billingData.first() } shouldBe BillingData(
+            purchases = listOf(owned),
+            pendingPurchases = listOf(pending),
+        )
+    }
+
+    @Test fun `an unacknowledged purchase is acknowledged`(): Unit = runBlocking {
+        val owned = TestPurchases.purchase(iapId, acknowledged = false)
+        val playClient = client(iap = FakeBillingClient.Answer(purchases = listOf(owned)))
+        connectedManager(playClient)
+
+        withTimeout(TIMEOUT_MS) {
+            while (playClient.acknowledged.isEmpty()) delay(50)
+        }
+        // distinct(): the ack is deliberately unconditional and re-fires per emission until a fresh
+        // query supersedes the purchase snapshot, so the count is not part of the contract — which
+        // token gets acknowledged is.
+        playClient.acknowledged.distinct() shouldBe listOf(owned.purchaseToken)
+    }
+
+    @Test fun `a pending purchase is never acknowledged`(): Unit = runBlocking {
+        val pending = TestPurchases.purchase(iapId, acknowledged = false, pending = true)
+        val playClient = client(iap = FakeBillingClient.Answer(purchases = listOf(pending)))
+        val manager = connectedManager(playClient)
+
+        // The purchase reached the pipeline…
+        withTimeout(TIMEOUT_MS) { manager.billingData.first() }.pendingPurchases shouldBe listOf(pending)
+        delay(QUIET_MS)
+        // …and the ack pass left it alone. Play rejects acknowledging a pending purchase permanently:
+        // an unfiltered pass would report a failure on every pass, forever, for a purchase that has
+        // nothing to acknowledge yet.
+        playClient.acknowledged shouldBe emptyList()
+    }
+
+    // endregion
+
     private companion object {
         const val TIMEOUT_MS = 15_000L
+        // Long enough for the (synchronous) fake round-trips and their flow plumbing to have run.
+        const val QUIET_MS = 500L
         // Comfortably inside the loop's 2s first backoff, so "did not retry yet" and "retried early"
         // are both decidable without racing the timer.
         const val BACKOFF_FLOOR_MS = 1_500L

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/BillingManagerTest.kt
@@ -248,6 +248,44 @@ class BillingManagerTest {
         withTimeout(TIMEOUT_MS) { attempts.receive() }
     }
 
+    @Test fun `a strict gate failure on a dead connection still tears the connection down`(): Unit = runBlocking {
+        // The gate's throw happens AFTER useConnection already returned (the refresh hands back a
+        // partial result instead of throwing), so its dead-binder detection never sees it. Without
+        // the explicit invalidation the dying connection stays installed and every later purchase
+        // check keeps talking to the corpse.
+        val pending = TestPurchases.purchase(iapId, pending = true)
+        val attempts = Channel<Unit>(Channel.UNLIMITED)
+        val dying = client(iap = FakeBillingClient.Answer(purchases = listOf(pending)))
+        val subQueries = AtomicInteger(0)
+        // The binder dies BETWEEN the two refreshes: the connect loop's initial one is complete (so
+        // its own reconciliation invalidates nothing), and only the gate's own round-trip loses SUBS.
+        dying.beforeAnswer = { type ->
+            if (type == BillingClient.ProductType.SUBS && subQueries.incrementAndGet() == 2) {
+                dying.answers = dying.answers +
+                    (BillingClient.ProductType.SUBS to failing(BillingResponseCode.SERVICE_DISCONNECTED))
+            }
+        }
+        val manager = connectedManager(dying, client(), attempts = attempts)
+
+        // Connection 1 is established and its initial refresh committed.
+        withTimeout(TIMEOUT_MS) { manager.billingData.first() }
+        withTimeout(TIMEOUT_MS) { attempts.receive() }
+
+        withTimeout(TIMEOUT_MS) {
+            shouldThrow<GplayServiceUnavailableException> { manager.refreshStrict() }
+        }
+
+        // The dead connection was uninstalled and the loop reconnected, instead of the next caller
+        // being handed the same corpse.
+        withTimeout(TIMEOUT_MS) { attempts.receive() }
+        // That torn-down connection is a failed loop iteration and signals as one…
+        withTimeout(TIMEOUT_MS) { manager.connectionFailures.first() }
+        // …but the gate's own partial refresh must never reach the feed — a gate the user aborted
+        // mid-purchase is not a reconciliation outcome. This refresh confirmed nothing (only a
+        // payment in progress), so running it through the reconciliation path WOULD have signalled.
+        withTimeoutOrNull(QUIET_MS) { manager.connectionFailures.first() } shouldBe null
+    }
+
     // endregion
 
     // region pending payments

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/client/BillingConnectionReducerTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/client/BillingConnectionReducerTest.kt
@@ -159,21 +159,32 @@ class BillingConnectionReducerTest {
         ).shouldBeEmpty()
     }
 
-    @Test fun `a pending purchase owns nothing, so it must not swallow a failed query`() {
-        // Otherwise a pending IAP next to a broken SUBS query would read as "verified, nothing
-        // owned" — and a real subscription behind that failure would look lapsed.
+    @Test fun `a pending payment for a product we sell counts as a find`() {
+        // It grants nothing, but it IS an answer about this account: Play is processing a payment for
+        // our own SKU, so the sibling type's failure no longer has to be reported as "couldn't
+        // verify" — and the pending purchase must reach the UI either way.
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(TestPurchases.purchase(iapId, pending = true))),
+            sub = Result.failure(IllegalStateException("subs query broke")),
+        ).map { it.purchaseToken } shouldBe listOf("token-$iapId")
+    }
+
+    @Test fun `an unknown pending product proves nothing and lets the failure through`() {
+        // A product this build doesn't know says nothing about the type whose query failed, so
+        // treating it as a find would swallow a real "couldn't verify".
         shouldThrow<IllegalStateException> {
             BillingConnection.combinePurchaseResults(
-                iap = Result.success(listOf(TestPurchases.purchase(iapId, pending = true))),
+                iap = Result.success(listOf(TestPurchases.purchase("some.other.product", pending = true))),
                 sub = Result.failure(IllegalStateException("subs query broke")),
             )
         }
 
-        // Nothing failed: the pending purchase is still reported, because the UI has to show it.
+        // Nothing failed, so there is nothing to report — this function only decides whether the
+        // refresh learned enough; the purchase itself still travels through the reducer state.
         BillingConnection.combinePurchaseResults(
-            iap = Result.success(listOf(TestPurchases.purchase(iapId, pending = true))),
+            iap = Result.success(listOf(TestPurchases.purchase("some.other.product", pending = true))),
             sub = Result.success(emptyList()),
-        ).map { it.purchaseToken } shouldBe listOf("token-$iapId")
+        ).shouldBeEmpty()
     }
 
     // endregion

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/client/BillingConnectionRefreshTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/client/BillingConnectionRefreshTest.kt
@@ -1,0 +1,155 @@
+package eu.darken.amply.upgrade.core.billing.client
+
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.Purchase
+import eu.darken.amply.upgrade.core.OurSku
+import eu.darken.amply.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.amply.upgrade.core.billing.TestPurchases
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * What a refresh reports about itself. The gates and the grace bookkeeping both decide on this
+ * provenance — "Play answered for both types", "this is what it confirmed", "this is why it is
+ * incomplete" — so a refresh that mislabels itself silently mislabels every consumer downstream.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class BillingConnectionRefreshTest {
+
+    private val iapId = OurSku.Iap.PRO_UPGRADE.id
+    private val subId = OurSku.Sub.PRO_UPGRADE.id
+
+    private fun connection(
+        client: FakeBillingClient = FakeBillingClient(),
+    ): Pair<BillingConnection, FakeBillingClient> = BillingConnection(client) to client
+
+    @Test fun `a complete refresh reports what it confirmed`(): Unit = runBlocking {
+        val owned = TestPurchases.purchase(iapId)
+        val pending = TestPurchases.purchase(subId, pending = true)
+        val (connection, client) = connection()
+        client.answers = mapOf(
+            BillingClient.ProductType.INAPP to FakeBillingClient.Answer(purchases = listOf(owned)),
+            BillingClient.ProductType.SUBS to FakeBillingClient.Answer(purchases = listOf(pending)),
+        )
+
+        val refresh = connection.refreshPurchases()
+
+        refresh.isComplete shouldBe true
+        refresh.partialError shouldBe null
+        // The confirmed set is PURCHASED-only: it feeds the grace stamp, which a payment in progress
+        // must never touch. The committed view carries both, because the UI needs the pending one.
+        refresh.confirmed.map { it.purchaseToken } shouldBe listOf(owned.purchaseToken)
+        refresh.hasConfirmedProPurchase shouldBe true
+        refresh.purchases.map { it.purchaseToken }.toSet() shouldBe
+            setOf(owned.purchaseToken, pending.purchaseToken)
+    }
+
+    @Test fun `a confirmed purchase of an unknown product does not count`(): Unit = runBlocking {
+        val (connection, client) = connection()
+        client.answers = mapOf(
+            BillingClient.ProductType.INAPP to FakeBillingClient.Answer(
+                purchases = listOf(TestPurchases.purchase("some.other.product")),
+            ),
+        )
+
+        // The grace bookkeeping asks this to decide whether a partial refresh confirmed the upgrade;
+        // a product this build doesn't sell confirms nothing about it.
+        connection.refreshPurchases().hasConfirmedProPurchase shouldBe false
+    }
+
+    @Test fun `a partial refresh carries its mapped cause`(): Unit = runBlocking {
+        val pending = TestPurchases.purchase(iapId, pending = true)
+        val (connection, client) = connection()
+        client.answers = mapOf(
+            BillingClient.ProductType.INAPP to FakeBillingClient.Answer(purchases = listOf(pending)),
+            BillingClient.ProductType.SUBS to FakeBillingClient.Answer(
+                responseCode = BillingResponseCode.SERVICE_UNAVAILABLE,
+            ),
+        )
+
+        // A pending payment for a product we sell IS an answer about this account, so the refresh
+        // returns instead of throwing — but it stays incomplete, and the cause travels with it so a
+        // gate can fail closed on exactly this.
+        val refresh = connection.refreshPurchases()
+
+        refresh.isComplete shouldBe false
+        refresh.hasConfirmedProPurchase shouldBe false
+        refresh.partialError.shouldBeInstanceOf<GplayServiceUnavailableException>()
+    }
+
+    @Test fun `a refresh that learned nothing usable throws`(): Unit = runBlocking {
+        val (connection, client) = connection()
+        client.answers = mapOf(
+            BillingClient.ProductType.INAPP to FakeBillingClient.Answer(),
+            BillingClient.ProductType.SUBS to FakeBillingClient.Answer(
+                responseCode = BillingResponseCode.SERVICE_UNAVAILABLE,
+            ),
+        )
+
+        // "Not owned" and "couldn't verify" must stay distinguishable for the caller.
+        shouldThrow<GplayServiceUnavailableException> { connection.refreshPurchases() }
+    }
+
+    @Test fun `an empty refresh racing a pending event still proves absence`(): Unit = runBlocking {
+        val (connection, client) = connection()
+        client.answers = mapOf(
+            BillingClient.ProductType.INAPP to FakeBillingClient.Answer(),
+            BillingClient.ProductType.SUBS to FakeBillingClient.Answer(),
+        )
+        // A payment in progress arrives while the queries are already running, so it survives their
+        // commit as an overlay entry. It owns nothing, so it must not suppress the full-snapshot
+        // signal — otherwise the unconfirmed-episode clock would freeze for as long as the payment
+        // takes to clear.
+        client.emitEventDuringQuery(connection, TestPurchases.purchase(iapId, pending = true))
+
+        connection.refreshPurchases()
+
+        val update = withTimeout(TIMEOUT_MS) { connection.freshUpdates.first() }
+        update.isFullSnapshot shouldBe true
+        update.purchases.isEmpty() shouldBe true
+    }
+
+    @Test fun `an empty refresh racing an owned event does not prove absence`(): Unit = runBlocking {
+        val (connection, client) = connection()
+        client.answers = mapOf(
+            BillingClient.ProductType.INAPP to FakeBillingClient.Answer(),
+            BillingClient.ProductType.SUBS to FakeBillingClient.Answer(),
+        )
+        client.emitEventDuringQuery(connection, TestPurchases.purchase(iapId))
+
+        connection.refreshPurchases()
+
+        // The event's own emission comes first, then the query commit — which must not claim to have
+        // proven that nothing is owned while a newer purchase event says otherwise.
+        val updates = withTimeout(TIMEOUT_MS) { connection.freshUpdates.take(2).toList() }
+        updates.map { it.isFullSnapshot } shouldBe listOf(false, false)
+    }
+
+    // A purchase event delivered from inside the first query: only an event NEWER than the query
+    // start survives that query's commit, which is what these overlay cases are about.
+    private fun FakeBillingClient.emitEventDuringQuery(connection: BillingConnection, purchase: Purchase) {
+        var emitted = false
+        beforeAnswer = {
+            if (!emitted) {
+                emitted = true
+                connection.onPurchasesUpdated(FakeBillingClient.result(BillingResponseCode.OK), listOf(purchase))
+            }
+        }
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 10_000L
+    }
+}

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/client/FakeBillingClient.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/client/FakeBillingClient.kt
@@ -1,0 +1,164 @@
+package eu.darken.amply.upgrade.core.billing.client
+
+import android.app.Activity
+import com.android.billingclient.api.AcknowledgePurchaseParams
+import com.android.billingclient.api.AcknowledgePurchaseResponseListener
+import com.android.billingclient.api.AlternativeBillingOnlyAvailabilityListener
+import com.android.billingclient.api.AlternativeBillingOnlyInformationDialogListener
+import com.android.billingclient.api.AlternativeBillingOnlyReportingDetailsListener
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingClientStateListener
+import com.android.billingclient.api.BillingConfigResponseListener
+import com.android.billingclient.api.BillingFlowParams
+import com.android.billingclient.api.BillingProgramAvailabilityListener
+import com.android.billingclient.api.BillingProgramReportingDetailsListener
+import com.android.billingclient.api.BillingProgramReportingDetailsParams
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ConsumeParams
+import com.android.billingclient.api.ConsumeResponseListener
+import com.android.billingclient.api.ExternalOfferAvailabilityListener
+import com.android.billingclient.api.ExternalOfferInformationDialogListener
+import com.android.billingclient.api.ExternalOfferReportingDetailsListener
+import com.android.billingclient.api.GetBillingConfigParams
+import com.android.billingclient.api.InAppMessageParams
+import com.android.billingclient.api.InAppMessageResponseListener
+import com.android.billingclient.api.LaunchExternalLinkParams
+import com.android.billingclient.api.LaunchExternalLinkResponseListener
+import com.android.billingclient.api.ProductDetailsResponseListener
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchasesResponseListener
+import com.android.billingclient.api.QueryProductDetailsParams
+import com.android.billingclient.api.QueryPurchasesParams
+
+/**
+ * A scriptable stand-in for Play's client, so tests can drive the REAL [BillingConnection] (its
+ * reducer, its full-snapshot decision and its partial-failure provenance) instead of asserting
+ * against a hand-written imitation of it.
+ *
+ * Only the calls the billing stack actually makes are implemented; everything else fails loudly, so
+ * a future code path that starts using one can't be answered with a silent default.
+ */
+internal class FakeBillingClient : BillingClient() {
+
+    /** What Play answers per product type ([ProductType.INAPP] / [ProductType.SUBS]). */
+    data class Answer(
+        val responseCode: Int = BillingResponseCode.OK,
+        val purchases: List<Purchase> = emptyList(),
+    )
+
+    var answers: Map<String, Answer> = emptyMap()
+
+    /** Purchase tokens this client was asked to acknowledge, in call order. */
+    val acknowledged = mutableListOf<String>()
+
+    var acknowledgeResponseCode: Int = BillingResponseCode.OK
+
+    /**
+     * Runs with the queried product type just before Play answers it. The seam for the races that
+     * decide the reducer's ordering rules: a purchase event delivered from here lands AFTER the query
+     * started, which is the only way it survives that query's commit.
+     */
+    var beforeAnswer: ((String) -> Unit)? = null
+
+    override fun queryPurchasesAsync(params: QueryPurchasesParams, listener: PurchasesResponseListener) {
+        // zza() is the only accessor Play exposes for the requested product type; without it a fake
+        // could not answer the two concurrent per-type queries differently, which is exactly what
+        // the partial-refresh behaviour is about.
+        val type = params.zza()
+        beforeAnswer?.invoke(type)
+        val answer = answers[type] ?: Answer()
+        listener.onQueryPurchasesResponse(result(answer.responseCode), answer.purchases)
+    }
+
+    override fun acknowledgePurchase(
+        params: AcknowledgePurchaseParams,
+        listener: AcknowledgePurchaseResponseListener,
+    ) {
+        acknowledged.add(params.purchaseToken)
+        listener.onAcknowledgePurchaseResponse(result(acknowledgeResponseCode))
+    }
+
+    override fun isReady(): Boolean = true
+
+    override fun getConnectionState(): Int = ConnectionState.CONNECTED
+
+    override fun endConnection() = Unit
+
+    override fun startConnection(listener: BillingClientStateListener) =
+        listener.onBillingSetupFinished(result(BillingResponseCode.OK))
+
+    override fun isFeatureSupported(feature: String): BillingResult = result(BillingResponseCode.OK)
+
+    override fun launchBillingFlow(activity: Activity, params: BillingFlowParams): BillingResult =
+        unsupported("launchBillingFlow")
+
+    override fun queryProductDetailsAsync(
+        params: QueryProductDetailsParams,
+        listener: ProductDetailsResponseListener,
+    ): Unit = unsupported("queryProductDetailsAsync")
+
+    override fun consumeAsync(params: ConsumeParams, listener: ConsumeResponseListener): Unit =
+        unsupported("consumeAsync")
+
+    override fun getBillingConfigAsync(
+        params: GetBillingConfigParams,
+        listener: BillingConfigResponseListener,
+    ): Unit = unsupported("getBillingConfigAsync")
+
+    override fun createAlternativeBillingOnlyReportingDetailsAsync(
+        listener: AlternativeBillingOnlyReportingDetailsListener,
+    ): Unit = unsupported("createAlternativeBillingOnlyReportingDetailsAsync")
+
+    override fun isAlternativeBillingOnlyAvailableAsync(
+        listener: AlternativeBillingOnlyAvailabilityListener,
+    ): Unit = unsupported("isAlternativeBillingOnlyAvailableAsync")
+
+    override fun showAlternativeBillingOnlyInformationDialog(
+        activity: Activity,
+        listener: AlternativeBillingOnlyInformationDialogListener,
+    ): BillingResult = unsupported("showAlternativeBillingOnlyInformationDialog")
+
+    override fun createExternalOfferReportingDetailsAsync(
+        listener: ExternalOfferReportingDetailsListener,
+    ): Unit = unsupported("createExternalOfferReportingDetailsAsync")
+
+    override fun isExternalOfferAvailableAsync(listener: ExternalOfferAvailabilityListener): Unit =
+        unsupported("isExternalOfferAvailableAsync")
+
+    override fun showExternalOfferInformationDialog(
+        activity: Activity,
+        listener: ExternalOfferInformationDialogListener,
+    ): BillingResult = unsupported("showExternalOfferInformationDialog")
+
+    override fun createBillingProgramReportingDetailsAsync(
+        params: BillingProgramReportingDetailsParams,
+        listener: BillingProgramReportingDetailsListener,
+    ): Unit = unsupported("createBillingProgramReportingDetailsAsync")
+
+    override fun isBillingProgramAvailableAsync(
+        billingProgram: Int,
+        listener: BillingProgramAvailabilityListener,
+    ): Unit = unsupported("isBillingProgramAvailableAsync")
+
+    override fun launchExternalLink(
+        activity: Activity,
+        params: LaunchExternalLinkParams,
+        listener: LaunchExternalLinkResponseListener,
+    ): Unit = unsupported("launchExternalLink")
+
+    override fun showInAppMessages(
+        activity: Activity,
+        params: InAppMessageParams,
+        listener: InAppMessageResponseListener,
+    ): BillingResult = unsupported("showInAppMessages")
+
+    private fun unsupported(call: String): Nothing = error("FakeBillingClient.$call() is not scripted")
+
+    companion object {
+        fun result(responseCode: Int): BillingResult = BillingResult.newBuilder().apply {
+            setResponseCode(responseCode)
+            setDebugMessage("fake")
+        }.build()
+    }
+}

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -321,6 +321,30 @@ class GplayUpgradeViewModelTest {
 
     // endregion
 
+    // region the pending explanation on screen
+
+    @Test fun `a pending payment keeps its hint when both price queries fail`(): Unit = runBlocking {
+        // Not the acquisition-style Unavailable card: the pending explanation must survive a price
+        // outage, exactly like the grace and ownership states do. Both offers are locked anyway.
+        val manager = object : FakeBillingManager(
+            MutableStateFlow(listOf(TestPurchases.purchase(iapId, pending = true)).toBillingData()),
+        ) {
+            override suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> =
+                throw GplayServiceUnavailableException(RuntimeException("play down"))
+        }
+        val vm = viewModel(manager)
+
+        val loaded = withTimeout(TIMEOUT_MS) {
+            vm.state.first { it is GplayUpgradeUiState.Loaded } as GplayUpgradeUiState.Loaded
+        }
+
+        loaded.iapPending shouldBe true
+        loaded.iapEnabled shouldBe false
+        loaded.subscriptionEnabled shouldBe false
+    }
+
+    // endregion
+
     // region restore outcomes
 
     @Test fun `a restore that finds the purchase reports success`(): Unit = runBlocking {

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.test.core.app.ApplicationProvider
 import com.android.billingclient.api.BillingResult
-import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.TestProductDetails
 import eu.darken.amply.common.AppDataStore
 import eu.darken.amply.common.WebpageTool
@@ -16,6 +15,7 @@ import eu.darken.amply.upgrade.core.UpgradeRepoGplay
 import eu.darken.amply.upgrade.core.billing.BillingData
 import eu.darken.amply.upgrade.core.billing.BillingManager
 import eu.darken.amply.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.amply.upgrade.core.billing.ItemAlreadyOwnedBillingException
 import eu.darken.amply.upgrade.core.billing.Sku
 import eu.darken.amply.upgrade.core.billing.SkuDetails
 import eu.darken.amply.upgrade.core.billing.TestPurchases
@@ -28,6 +28,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
@@ -50,8 +51,9 @@ import org.robolectric.annotation.Config
 import java.io.File
 
 /**
- * The screen's decisions that cost money if they are wrong: whether a one-time purchase may be
- * started while a subscription still renews, and what a restore is allowed to claim afterwards.
+ * The screen's decisions that cost money if they are wrong: whether a purchase may be started at all
+ * (a renewing subscription, an already-owned upgrade, a payment Play is still processing, or a check
+ * that never finished), and what a restore is allowed to claim afterwards.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -82,8 +84,10 @@ class GplayUpgradeViewModelTest {
         override val purchaseFailures: Flow<BillingResult> = emptyFlow()
         override val connectionFailures: Flow<Long> = emptyFlow()
 
-        var subscriptionsAnswer: () -> Collection<Purchase> = { emptyList() }
+        var strictAnswer: suspend () -> BillingData = { BillingData(emptyList()) }
         var refreshAnswer: () -> BillingData = { BillingData(emptyList()) }
+        var launchAnswer: () -> Unit = {}
+        val launches: MutableList<Sku> = mutableListOf()
 
         override suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = skus.map { sku ->
             when (sku) {
@@ -98,9 +102,16 @@ class GplayUpgradeViewModelTest {
             }
         }
 
-        override suspend fun querySubscriptions(): Collection<Purchase> = subscriptionsAnswer()
+        override suspend fun refreshStrict(): BillingData = strictAnswer()
 
         override suspend fun refresh(): BillingData = refreshAnswer()
+
+        // Records what actually reached Play: the gate tests below assert that a blocked tap never
+        // gets this far.
+        override suspend fun startIapFlow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) {
+            launches.add(sku)
+            launchAnswer()
+        }
     }
 
     @Before fun setup() {
@@ -132,13 +143,13 @@ class GplayUpgradeViewModelTest {
     // The purchase paths need an Activity to hand to Play; only its identity matters here.
     private fun activity(): Activity = Robolectric.buildActivity(Activity::class.java).get()
 
-    // region the pre-purchase subscription gate
+    // region the pre-purchase gate
 
-    @Test fun `a failed subscription check fails closed`(): Unit = runBlocking {
-        // "Couldn't verify" must never be read as "no subscription": that is the reading that lets a
+    @Test fun `a failed purchase check fails closed`(): Unit = runBlocking {
+        // "Couldn't verify" must never be read as "nothing owned": that is the reading that lets a
         // user pay twice.
         val manager = freeManager().apply {
-            subscriptionsAnswer = { throw GplayServiceUnavailableException(RuntimeException("play down")) }
+            strictAnswer = { throw GplayServiceUnavailableException(RuntimeException("play down")) }
         }
         val vm = viewModel(manager)
 
@@ -146,31 +157,166 @@ class GplayUpgradeViewModelTest {
 
         val event = withTimeout(TIMEOUT_MS) { vm.events.first() }
         event.shouldBeInstanceOf<UpgradeEvents.Error>()
+        manager.launches shouldBe emptyList()
     }
 
     @Test fun `a subscription that is not set to renew lets the purchase through`(): Unit = runBlocking {
         val manager = freeManager().apply {
-            subscriptionsAnswer = { listOf(TestPurchases.purchase(subId, autoRenewing = false)) }
+            strictAnswer = { listOf(TestPurchases.purchase(subId, autoRenewing = false)).toBillingData() }
         }
         val vm = viewModel(manager)
 
         vm.onGoIap(activity())
 
-        // No blocking event: the launch itself is attempted (and fails without a real Play sheet,
-        // which surfaces as an error rather than the still-renewing refusal).
+        // No blocking event, and the launch really was attempted.
         val event = withTimeoutOrNull(QUIET_MS) { vm.events.first() }
-        (event is UpgradeEvents.SubscriptionStillRenewing) shouldBe false
+        event shouldBe null
+        manager.launches shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
     }
 
     @Test fun `a renewing subscription is refused with the manage-subscription prompt`(): Unit = runBlocking {
         val manager = freeManager().apply {
-            subscriptionsAnswer = { listOf(TestPurchases.purchase(subId, autoRenewing = true)) }
+            strictAnswer = { listOf(TestPurchases.purchase(subId, autoRenewing = true)).toBillingData() }
         }
         val vm = viewModel(manager)
 
         vm.onGoIap(activity())
 
         withTimeout(TIMEOUT_MS) { vm.events.first() } shouldBe UpgradeEvents.SubscriptionStillRenewing
+        manager.launches shouldBe emptyList()
+    }
+
+    @Test fun `a renewing subscription with an unknown product still blocks the one-time purchase`(): Unit =
+        runBlocking {
+            // The gate reads the RAW purchases, never the mapped upgrades: a subscription whose
+            // product ID this build doesn't know (legacy SKU, renamed product) still renews and still
+            // bills, so letting the one-time purchase through here charges the user twice.
+            val manager = freeManager().apply {
+                strictAnswer = {
+                    listOf(TestPurchases.purchase("some.unknown.subscription", autoRenewing = true)).toBillingData()
+                }
+            }
+            val vm = viewModel(manager)
+
+            vm.onGoIap(activity())
+
+            withTimeout(TIMEOUT_MS) { vm.events.first() } shouldBe UpgradeEvents.SubscriptionStillRenewing
+            manager.launches shouldBe emptyList()
+        }
+
+    @Test fun `a pending payment blocks the one-time purchase`(): Unit = runBlocking {
+        val manager = freeManager().apply {
+            strictAnswer = { listOf(TestPurchases.purchase(iapId, pending = true)).toBillingData() }
+        }
+        val vm = viewModel(manager)
+
+        vm.onGoIap(activity())
+
+        withTimeout(TIMEOUT_MS) { vm.events.first() } shouldBe UpgradeEvents.PurchasePending
+        manager.launches shouldBe emptyList()
+    }
+
+    @Test fun `a pending payment blocks the subscription purchase`(): Unit = runBlocking {
+        // SKU-agnostic on purpose: the two products are alternatives, so a pending payment for either
+        // one must block both — completing both charges the user twice.
+        val manager = freeManager().apply {
+            strictAnswer = { listOf(TestPurchases.purchase(iapId, pending = true)).toBillingData() }
+        }
+        val vm = viewModel(manager)
+
+        vm.onGoSubscriptionTrial(activity())
+
+        withTimeout(TIMEOUT_MS) { vm.events.first() } shouldBe UpgradeEvents.PurchasePending
+        manager.launches shouldBe emptyList()
+    }
+
+    @Test fun `a gate timeout blocks the one-time purchase`(): Unit = runBlocking {
+        val manager = freeManager().apply {
+            strictAnswer = {
+                delay(TIMEOUT_MS)
+                BillingData(emptyList())
+            }
+        }
+        val vm = viewModel(manager).apply { verifyTimeoutMs = GATE_TIMEOUT_MS }
+
+        vm.onGoIap(activity())
+
+        withTimeout(TIMEOUT_MS) { vm.events.first() } shouldBe UpgradeEvents.PurchaseCheckFailed
+        manager.launches shouldBe emptyList()
+    }
+
+    @Test fun `a gate timeout blocks the subscription purchase too`(): Unit = runBlocking {
+        // The subscription path used to launch unverified: a slow Play means we don't know whether a
+        // payment is already pending, so it must fail closed like the one-time path.
+        val manager = freeManager().apply {
+            strictAnswer = {
+                delay(TIMEOUT_MS)
+                BillingData(emptyList())
+            }
+        }
+        val vm = viewModel(manager).apply { verifyTimeoutMs = GATE_TIMEOUT_MS }
+
+        vm.onGoSubscription(activity())
+
+        withTimeout(TIMEOUT_MS) { vm.events.first() } shouldBe UpgradeEvents.PurchaseCheckFailed
+        manager.launches shouldBe emptyList()
+    }
+
+    @Test fun `a subscription purchase is blocked when the fresh check finds an owned upgrade`(): Unit =
+        runBlocking {
+            // The screen can be stale (the one-time purchase was made on another device) and Play
+            // sells the subscription right next to an owned one-time upgrade — launching here charges
+            // the user a second time.
+            val manager = freeManager().apply {
+                strictAnswer = { listOf(TestPurchases.purchase(iapId)).toBillingData() }
+            }
+            val vm = viewModel(manager)
+
+            vm.onGoSubscription(activity())
+
+            withTimeout(TIMEOUT_MS) { vm.events.first() } shouldBe UpgradeEvents.RestoreSucceeded
+            manager.launches shouldBe emptyList()
+        }
+
+    @Test fun `a subscription purchase is blocked when an unknown renewing subscription exists`(): Unit =
+        runBlocking {
+            // Unknown product ID means zero mapped upgrades, so the ownership block above lets it
+            // through. It still renews and still bills, and a second subscription for the same
+            // features is the same double charge.
+            val manager = freeManager().apply {
+                strictAnswer = {
+                    listOf(TestPurchases.purchase("some.unknown.subscription", autoRenewing = true)).toBillingData()
+                }
+            }
+            val vm = viewModel(manager)
+
+            vm.onGoSubscription(activity())
+
+            withTimeout(TIMEOUT_MS) { vm.events.first() } shouldBe UpgradeEvents.SubscriptionStillRenewing
+            manager.launches shouldBe emptyList()
+        }
+
+    @Test fun `a cleared gate lets the subscription purchase launch`(): Unit = runBlocking {
+        val vm = viewModel(freeManager())
+
+        vm.onGoSubscription(activity())
+
+        withTimeoutOrNull(QUIET_MS) { vm.events.first() } shouldBe null
+    }
+
+    @Test fun `a pending-payment launch failure surfaces as the pending dialog`(): Unit = runBlocking {
+        // Play can only report this at launch time (the gate saw a clean state moments earlier): the
+        // already-owned error dialog with its restore tips would be the wrong advice. The recovery
+        // restore finds the pending payment, so the repo reports it as such.
+        val manager = freeManager().apply {
+            launchAnswer = { throw ItemAlreadyOwnedBillingException(RuntimeException("already owned")) }
+            refreshAnswer = { listOf(TestPurchases.purchase(iapId, pending = true)).toBillingData() }
+        }
+        val vm = viewModel(manager)
+
+        vm.onGoIap(activity())
+
+        withTimeout(TIMEOUT_MS) { vm.events.first() } shouldBe UpgradeEvents.PurchasePending
     }
 
     // endregion
@@ -230,5 +376,8 @@ class GplayUpgradeViewModelTest {
     private companion object {
         const val TIMEOUT_MS = 15_000L
         const val QUIET_MS = 500L
+        // Short enough to keep the fail-closed timeout tests fast, long enough that a healthy answer
+        // would comfortably make it back.
+        const val GATE_TIMEOUT_MS = 250L
     }
 }


### PR DESCRIPTION
## What changed

Both purchase buttons now verify the account state with Google Play at tap time before opening the checkout: a payment Play is still processing, an existing Pro purchase made on another device, or a subscription still set to renew stops the launch instead of charging twice. The subscription button previously started the checkout without any verification. If the check cannot complete, the purchase does not start. Retrying a product whose payment is still pending now gets the pending explanation instead of a misleading "already owned" error, and a user waiting on a pending payment keeps seeing that explanation even if price loading fails or the entitlement is briefly bridged by the grace window.

## Technical Context

- Closes the audited gaps against the canonical sdmaid-se implementation (d4rken-org/sdmaid-se#2653 + the gate corrections in sdmaid-se PR #2662); amply's existing pending-purchase support from #57 (entitlement split, button locks, restore hint, inline pending note) is untouched.
- Adopts the canonical reconciliation shape in full (user decision): `PurchaseRefresh` carries provenance (confirmed set, commit-time occurredAt, partialError), a refresh that finds only a pending known-Pro purchase now publishes instead of failing the connection, and the partial failure feeds the grace episode clock centrally. Amply's previous throw-on-partial contract and its pinning test were rewritten accordingly.
- The strict gate (`refreshStrict`) fails closed and invalidates a connection that died mid-check; the regression test survives a mutation check (removing the invalidation call makes it fail).
- The renewal guard reads RAW purchases, not mapped SKUs, so a renewing subscription with an unknown product ID still blocks a double purchase.
- Tests drive the real `BillingConnection`/`BillingManager` through a scriptable `FakeBillingClient` (amply has no mockk); it reads the queried product type via `QueryPurchasesParams.zza()`, the only accessor Play exposes — a billing-library bump could break that loudly at compile time.
