### PR TITLE
Diagnostics: Probe the Oplus charge keys and make probe results tri-state

### DIFF
--- a/.claude/skills/device-qualification/SKILL.md
+++ b/.claude/skills/device-qualification/SKILL.md
@@ -135,6 +135,20 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
     session/recovery closed, pending-until-replug hint shown — and the exposure is one charge cycle,
     bounded by the plug session the user is already in. Deliberately NOT treated as a defect.
   - **Wireless charging and secondary users**: NOT RUN (gated to system user).
+- **Oplus (OnePlus/Oppo/Realme)** — the live gate reads `ro.build.version.oplusrom`, which **does not exist on
+  pre-rebrand ColorOS**, so every ColorOS 11-era build is invisible to it and lands on `OnePlusLabAdapter`. This is
+  correct behaviour (those builds are unqualified either way), but it made reports from them uninformative.
+  - **Oppo F11 Pro `CPH1969` (`OP4863`), Android 11 / ColorOS 11 — device-support report only, 2026-08-15. NOT a
+    qualification run: no physical test, no Shizuku, no settings capture.** The report carried
+    `oplus_rom_version=none` and nothing else about the family, because the report probed only the Samsung,
+    GrapheneOS, and LineageOS keys — the two ColorOS keys Amply already knows were never read. Absence of the
+    property could not be distinguished from an SELinux-denied read either (`SystemPropertyReader` returns `""` on
+    denial). Prompted two report changes: an unprivileged presence probe of the two `system` keys, and tri-state
+    probe results (`present|absent|read_denied`) so a refused read stops rendering as a proven negative. **Still
+    open:** whether pre-rebrand ColorOS carries those keys under any name is unknown, and no legacy property
+    (`ro.build.version.opporom`) is read, so pre-ColorOS-12 builds remain undetectable as Oplus by ROM version. A
+    device with a *working* pre-15 ColorOS charge-protection feature would need a new gate signal, not a widened
+    version constant — and the usual bar applies: physically observed charging cessation, not a settings mapping.
 - **Xiaomi** — adaptive hardware enforcement of external writes unconfirmed; treat the adapter as provisional until
   the 80% hold is physically observed.
   - **HyperOS 3 candidate mapping (contribution report, 2026-08-07 — unqualified at the time; since landed,

--- a/app/src/debug/java/eu/darken/amply/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/amply/screenshots/ScreenshotContent.kt
@@ -12,6 +12,7 @@ import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.ChargingState
 import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.SettingProbe
 import eu.darken.amply.charging.core.access.AccessSnapshot
 import eu.darken.amply.charging.core.access.BackendStatus
 import eu.darken.amply.common.ca.toCaString
@@ -244,7 +245,14 @@ private fun samsungState() = DashboardUiState(
     batteryReadout = holdingAtLimit(),
     stats = liveStats(),
     charging = ChargingState(
-        device = DeviceInfo("samsung", "SM-X210", 36, "preview", oneUiVersion = 80000, hasProtectBattery = true),
+        device = DeviceInfo(
+            "samsung",
+            "SM-X210",
+            36,
+            "preview",
+            oneUiVersion = 80000,
+            protectBatteryProbe = SettingProbe.PRESENT,
+        ),
         adapterName = "Samsung battery protection".toCaString(),
         adapterId = "samsung-oneui8-v1",
         supportedPolicies = listOf(

--- a/app/src/main/java/eu/darken/amply/charging/core/DeviceInfo.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/DeviceInfo.kt
@@ -22,11 +22,19 @@ data class DeviceInfo(
     val lineageOsVersion: String? = null,
     val hasLineageFeature: Boolean = false,
     val hasGrapheneOsPackages: Boolean = false,
-    val hasProtectBattery: Boolean = false,
-    val hasBatteryChargeLimit: Boolean = false,
+    val protectBatteryProbe: SettingProbe = SettingProbe.ABSENT,
+    val batteryChargeLimitProbe: SettingProbe = SettingProbe.ABSENT,
     val hasLineageSettingsProvider: Boolean = false,
     val isSystemUser: Boolean = true,
 ) {
+    /**
+     * Whether Samsung's battery-protection key was read back. Gates device-wide Samsung writes, so it fails closed:
+     * a refused read counts as "no key", exactly as the previous Boolean field did.
+     */
+    val hasProtectBattery: Boolean get() = protectBatteryProbe.isPresent
+
+    /** Whether a `battery_charge_limit` key was read back. Diagnostic only — see the probe site below. */
+    val hasBatteryChargeLimit: Boolean get() = batteryChargeLimitProbe.isPresent
     /**
      * Whether this is a LineageOS build. [lineageOsVersion] alone must never gate this: every
      * `ro.lineage.*` property lives in the SELinux context `custom_version_prop`, which
@@ -83,21 +91,20 @@ data class DeviceInfo(
                     }.getOrDefault(false)
                 }
             } ?: false,
-            hasProtectBattery = context?.let {
-                runCatching {
-                    Settings.Global.getString(it.contentResolver, KEY_PROTECT_BATTERY) != null
-                }.getOrDefault(false)
-            } ?: false,
-            // GrapheneOS's charge-limit key. NOT a gate: GrapheneOS marks the key @Protected, so
-            // this unprivileged read throws SecurityException (→ false) on real GrapheneOS whether
-            // the key exists or not — verified via the issue-#49 beta report. Kept as a diagnostic
-            // signal only: true would indicate a ROM exposing a same-named key WITHOUT the
-            // GrapheneOS restriction, which is worth seeing in a device-support report.
-            hasBatteryChargeLimit = context?.let {
-                runCatching {
-                    Settings.Global.getString(it.contentResolver, KEY_BATTERY_CHARGE_LIMIT) != null
-                }.getOrDefault(false)
-            } ?: false,
+            protectBatteryProbe = context?.let {
+                probeSetting { Settings.Global.getString(it.contentResolver, KEY_PROTECT_BATTERY) }
+            } ?: SettingProbe.ABSENT,
+            // GrapheneOS's charge-limit key. NOT a gate: GrapheneOS marks the key @Protected, so this
+            // unprivileged read is refused on real GrapheneOS whether the key exists or not — verified via
+            // the issue-#49 beta report, which is exactly why the outcome is tri-state and not a Boolean.
+            // Kept as a diagnostic signal only: PRESENT would indicate a ROM exposing a same-named key
+            // WITHOUT the GrapheneOS restriction, which is worth seeing in a device-support report.
+            batteryChargeLimitProbe = context?.let {
+                probeSetting { Settings.Global.getString(it.contentResolver, KEY_BATTERY_CHARGE_LIMIT) }
+            } ?: SettingProbe.ABSENT,
+            // NOTE: the Oplus charge-protection keys are deliberately NOT probed here. They gate nothing, and
+            // this snapshot is rebuilt on every dashboard refresh — a diagnostics-only key belongs on the
+            // report's IO path (see OplusKeyProbes), not in two extra synchronous binder calls per refresh.
             // Whether LineageOS's private settings provider is installed (the charge-control settings
             // surface). Fail closed; requires the <queries> provider entry so package visibility on
             // API 30+ doesn't false-negative resolution. Provider presence is not HAL-enforcement proof.

--- a/app/src/main/java/eu/darken/amply/charging/core/SettingProbe.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/SettingProbe.kt
@@ -1,0 +1,57 @@
+package eu.darken.amply.charging.core
+
+/**
+ * Outcome of an unprivileged presence probe for a single settings key.
+ *
+ * A Boolean cannot carry this. The public `Settings.*.getString` getters throw [SecurityException] for keys the
+ * caller may not read — GrapheneOS marks its charge-limit key `@Protected` and denies it to every third-party
+ * package, and from API 31 the platform denies non-`@Readable` keys to apps generally — so folding the throw into
+ * `false` claims "this OEM has no such setting" when the truth is "we were not allowed to look".
+ *
+ * That misread a real device: the issue-#49 GrapheneOS report carried `has_battery_charge_limit=false` in the same
+ * submission that showed the limit actively enforcing. Reports are the only evidence available for devices nobody
+ * owns, so an absent-vs-denied ambiguity there costs a qualification lead.
+ */
+enum class SettingProbe {
+    /** The key exists and its value was read back. */
+    PRESENT,
+
+    /**
+     * No value came back. Usually means the key does not exist on this build, but it is not proof: the platform
+     * also returns null when it cannot reach the settings provider, and this state additionally absorbs any
+     * non-security failure of the read itself. Treat it as "nothing found", not as a demonstrated negative.
+     */
+    ABSENT,
+
+    /** The read was refused. Says nothing either way about whether the key exists. */
+    READ_DENIED,
+    ;
+
+    /**
+     * Fail closed. Only an actual read-back counts as presence, so a capability gate never opens on a denied
+     * probe — matching the previous Boolean fields, where a refused read also read as false.
+     */
+    val isPresent: Boolean get() = this == PRESENT
+
+    /** Stable lowercase token for the device-support report. */
+    val reportValue: String get() = name.lowercase()
+}
+
+/**
+ * Runs an unprivileged key read and classifies the outcome.
+ *
+ * Only [SecurityException] maps to [SettingProbe.READ_DENIED]; other exceptions fall to [SettingProbe.ABSENT], which
+ * keeps the fail-closed behaviour of the `runCatching { … }.getOrDefault(false)` call sites this replaced. They are
+ * not split into a fourth "read failed" state because that state could not be trusted anyway: the platform swallows
+ * provider-acquisition and `RemoteException` failures internally and simply returns null, so an operational failure
+ * frequently never surfaces as an exception here at all.
+ *
+ * Unlike `runCatching`, this catches [Exception] rather than [Throwable], so an [Error] propagates.
+ */
+internal inline fun probeSetting(read: () -> String?): SettingProbe = try {
+    if (read() != null) SettingProbe.PRESENT else SettingProbe.ABSENT
+} catch (_: SecurityException) {
+    SettingProbe.READ_DENIED
+} catch (_: Exception) {
+    SettingProbe.ABSENT
+}

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/LabChargingAdapters.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/LabChargingAdapters.kt
@@ -51,10 +51,6 @@ class SamsungLabAdapter @Inject constructor() : DisabledLabAdapter() {
     override val id = "samsung-lab"
     override val displayName = R.string.adapter_name_samsung.toCaString()
     override fun matches(device: DeviceInfo) = device.manufacturer.equals("Samsung", ignoreCase = true)
-
-    companion object {
-        val CANDIDATE_KEYS = setOf("protect_battery", "battery_protection_threshold")
-    }
 }
 
 @Singleton
@@ -62,10 +58,6 @@ class XiaomiLabAdapter @Inject constructor() : DisabledLabAdapter() {
     override val id = "xiaomi-lab"
     override val displayName = R.string.adapter_name_xiaomi.toCaString()
     override fun matches(device: DeviceInfo) = device.manufacturer.equals("Xiaomi", ignoreCase = true)
-
-    companion object {
-        val CANDIDATE_KEYS = setOf("security_pc_secure_protect_mode_key")
-    }
 }
 
 @Singleton
@@ -82,14 +74,6 @@ class LineageLabAdapter @Inject constructor() : DisabledLabAdapter() {
     // observation of which provider LineageOS bound — useful triage context, but it decides nothing: no value
     // qualifies or disqualifies a device, only physical charging observation does.
     override val guidedCaptureUseful = false
-
-    companion object {
-        val CANDIDATE_KEYS = setOf(
-            "charging_control_enabled",
-            "charging_control_mode",
-            "charging_control_charging_limit",
-        )
-    }
 }
 
 @Singleton
@@ -104,11 +88,4 @@ class OnePlusLabAdapter @Inject constructor() : DisabledLabAdapter() {
         device.manufacturer.equals("OnePlus", ignoreCase = true) ||
             device.manufacturer.equals("Oppo", ignoreCase = true) ||
             device.manufacturer.equals("realme", ignoreCase = true)
-
-    companion object {
-        val CANDIDATE_KEYS = setOf(
-            "regular_charge_protection_switch_state",
-            "smart_charge_protection_switch_state",
-        )
-    }
 }

--- a/app/src/main/java/eu/darken/amply/diagnostics/core/ContributionAllowlist.kt
+++ b/app/src/main/java/eu/darken/amply/diagnostics/core/ContributionAllowlist.kt
@@ -27,8 +27,11 @@ object ContributionAllowlist {
         // Samsung battery protection
         SettingId(SettingNamespace.GLOBAL, "protect_battery") to setOf("0", "1", "3"),
         SettingId(SettingNamespace.GLOBAL, "battery_protection_threshold") to setOf("80", "85", "90", "95"),
-        // OnePlus/Oppo candidate
+        // OnePlus/Oppo candidates. Mutually exclusive on ColorOS: regular = FixedLimit(80), smart = Adaptive.
+        // Both are listed, or a wizard run discloses one half of the pair and redacts the other, which reads as
+        // a device that only has the fixed cap.
         SettingId(SettingNamespace.SYSTEM, "regular_charge_protection_switch_state") to setOf("0", "1"),
+        SettingId(SettingNamespace.SYSTEM, "smart_charge_protection_switch_state") to setOf("0", "1"),
     )
 
     /** Public value domain for a known charging key, or null if the key is not a known charge-protection setting. */

--- a/app/src/main/java/eu/darken/amply/main/core/DeviceSupportReporter.kt
+++ b/app/src/main/java/eu/darken/amply/main/core/DeviceSupportReporter.kt
@@ -1,22 +1,58 @@
 package eu.darken.amply.main.core
 
+import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.BatteryManager
 import android.os.Build
+import android.provider.Settings
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.amply.BuildConfig
 import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.SettingProbe
+import eu.darken.amply.charging.core.probeSetting
 import eu.darken.amply.charging.core.access.LineageHealthSummary
 import eu.darken.amply.charging.core.access.SettingsSnapshotSource
 import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.adapter.OnePlusChargingAdapter
 import eu.darken.amply.common.AmplyLinks
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.net.URLEncoder
 import javax.inject.Inject
 import javax.inject.Singleton
+
+/**
+ * Presence of the two mutually-exclusive Oplus (OnePlus/Oppo/Realme) charge-protection keys.
+ *
+ * Diagnostics only — live Oplus control is gated on the ColorOS 15 ROM version and never consults these. They are
+ * collected because that ROM property is otherwise the *sole* Oplus signal in a report, and it reads "none" on every
+ * pre-rebrand build, so a report from an unqualified Oppo/OnePlus/Realme device carries nothing at all about the
+ * family it just matched. Observed on an Oppo F11 Pro (CPH1969, ColorOS 11), whose report could not distinguish
+ * "this ROM has no charge protection" from "we never looked".
+ *
+ * Deliberately not part of [eu.darken.amply.charging.core.DeviceInfo]: that snapshot is rebuilt on every dashboard
+ * refresh from the main thread, and these are two synchronous provider calls that gate nothing.
+ */
+data class OplusKeyProbes(
+    val regular: SettingProbe,
+    val smart: SettingProbe,
+) {
+    companion object {
+        val UNPROBED = OplusKeyProbes(SettingProbe.ABSENT, SettingProbe.ABSENT)
+
+        /** Call from an IO context. Reads presence only — never a value. */
+        fun read(resolver: ContentResolver) = OplusKeyProbes(
+            regular = probeSetting {
+                Settings.System.getString(resolver, OnePlusChargingAdapter.KEY_REGULAR)
+            },
+            smart = probeSetting {
+                Settings.System.getString(resolver, OnePlusChargingAdapter.KEY_SMART)
+            },
+        )
+    }
+}
 
 /**
  * Immutable snapshot of best-effort, non-privileged device metadata used to ask the developer to add
@@ -45,8 +81,14 @@ data class DeviceSupportReport(
      * be said about HAL limit support. Null when unknown (not LineageOS, or no Shizuku) — never read as a negative.
      */
     val lineageHealth: LineageHealthSummary?,
-    val hasProtectBattery: Boolean,
-    val hasBatteryChargeLimit: Boolean,
+    /**
+     * Unprivileged key-presence probes. Tri-state on purpose: a refused read is not evidence of absence, and
+     * these reports are frequently the only evidence available for a device nobody owns.
+     */
+    val protectBatteryProbe: SettingProbe,
+    val batteryChargeLimitProbe: SettingProbe,
+    val oplusKeys: OplusKeyProbes,
+    /** Provider resolution, not a settings read — it cannot be refused, so it stays a Boolean. */
     val hasLineageSettingsProvider: Boolean,
     val adapterId: String?,
     val adapterMatched: Boolean,
@@ -93,8 +135,9 @@ class DeviceSupportReporter @Inject constructor(
             isLineageOs = device.isLineageOs,
             isGrapheneOs = device.isGrapheneOs,
             lineageHealth = lineageHealth,
-            hasProtectBattery = device.hasProtectBattery,
-            hasBatteryChargeLimit = device.hasBatteryChargeLimit,
+            protectBatteryProbe = device.protectBatteryProbe,
+            batteryChargeLimitProbe = device.batteryChargeLimitProbe,
+            oplusKeys = OplusKeyProbes.read(context.contentResolver),
             hasLineageSettingsProvider = device.hasLineageSettingsProvider,
             adapterId = selection.adapter?.id,
             adapterMatched = selection.support.matched,
@@ -127,7 +170,7 @@ internal fun sanitizeReportValue(value: String?, max: Int = 120): String {
 /** Deterministic, single stable schema. Keep field order fixed so reports are diff-friendly. */
 internal fun formatReport(report: DeviceSupportReport): String = buildString {
     appendLine("Amply device-support request")
-    appendLine("report_schema=9")
+    appendLine("report_schema=10")
     appendLine("app_version=${report.appVersionName} (${report.appVersionCode})")
     appendLine("distribution=${report.flavor}/${report.buildType}")
     appendLine("manufacturer=${report.manufacturer}")
@@ -157,8 +200,15 @@ internal fun formatReport(report: DeviceSupportReport): String = buildString {
     appendLine("lineage_cc_provider=${report.lineageHealth?.provider?.name ?: "unknown"}")
     appendLine("lineage_cc_mode=${report.lineageHealth?.mode ?: "unknown"}")
     appendLine("lineage_cc_limit_mechanism=${report.lineageHealth?.limitMechanism?.name ?: "UNKNOWN"}")
-    appendLine("has_protect_battery=${report.hasProtectBattery}")
-    appendLine("has_battery_charge_limit=${report.hasBatteryChargeLimit}")
+    // present|absent|read_denied. "read_denied" means the platform refused the read, so the key may well exist —
+    // never read it as evidence the OEM lacks the setting. "absent" means nothing came back, which is usually but
+    // not provably a real negative (see SettingProbe).
+    appendLine("probe_protect_battery=${report.protectBatteryProbe.reportValue}")
+    appendLine("probe_battery_charge_limit=${report.batteryChargeLimitProbe.reportValue}")
+    // The Oplus pair. Live control is gated on the ColorOS 15 ROM version, so these decide nothing; they exist so
+    // a report from an unqualified Oppo/OnePlus/Realme build says something about the family at all.
+    appendLine("probe_regular_charge_protection=${report.oplusKeys.regular.reportValue}")
+    appendLine("probe_smart_charge_protection=${report.oplusKeys.smart.reportValue}")
     appendLine("has_lineage_settings_provider=${report.hasLineageSettingsProvider}")
     appendLine("adapter=${report.adapterId ?: "none"}")
     appendLine("adapter_matched=${report.adapterMatched}")

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -61,6 +61,7 @@ import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.ChargingState
 import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.SettingProbe
 import eu.darken.amply.charging.core.PendingRequest
 import eu.darken.amply.charging.core.SETTLING_WINDOW_MILLIS
 import eu.darken.amply.charging.core.access.AccessSnapshot
@@ -1550,7 +1551,14 @@ private fun DashboardScreenSamsungPreview() = PreviewWrapper {
         state = DashboardUiState(
             onboardingComplete = true,
             charging = ChargingState(
-                device = DeviceInfo("samsung", "SM-X210", 36, "preview", oneUiVersion = 80000, hasProtectBattery = true),
+                device = DeviceInfo(
+                    "samsung",
+                    "SM-X210",
+                    36,
+                    "preview",
+                    oneUiVersion = 80000,
+                    protectBatteryProbe = SettingProbe.PRESENT,
+                ),
                 adapterName = "Samsung battery protection".toCaString(),
                 adapterId = "samsung-oneui8-v1",
                 supportedPolicies = listOf(

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingStateSupportLeadTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingStateSupportLeadTest.kt
@@ -29,7 +29,7 @@ class ChargingStateSupportLeadTest {
         hyperOsVersion = hyperOsVersion,
         oplusRomVersion = oplusRomVersion,
         lineageOsVersion = lineageOsVersion,
-        hasProtectBattery = hasProtectBattery,
+        protectBatteryProbe = if (hasProtectBattery) SettingProbe.PRESENT else SettingProbe.ABSENT,
         hasLineageSettingsProvider = hasLineageSettingsProvider,
     )
 
@@ -76,7 +76,7 @@ class ChargingStateSupportLeadTest {
         // A future ROM shipping the same key under a non-Google brand reaches the catch-all but
         // still carries an actionable lead; same for GrapheneOS identity without the key.
         ChargingState(
-            device = device().copy(hasBatteryChargeLimit = true),
+            device = device().copy(batteryChargeLimitProbe = SettingProbe.PRESENT),
             adapterId = null,
         ).hasSupportLead shouldBe true
         ChargingState(

--- a/app/src/test/java/eu/darken/amply/charging/core/DeviceInfoTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/DeviceInfoTest.kt
@@ -48,7 +48,7 @@ class DeviceInfoTest {
     fun `the charge-limit key alone is never grapheneos identity`() {
         // The adapter is registered ahead of the live Pixel adapter; a future stock Pixel shipping
         // a same-named key must not be swallowed as GrapheneOS.
-        device().copy(hasBatteryChargeLimit = true).isGrapheneOs shouldBe false
+        device().copy(batteryChargeLimitProbe = SettingProbe.PRESENT).isGrapheneOs shouldBe false
     }
 
     @Test
@@ -56,5 +56,29 @@ class DeviceInfoTest {
         val info = DeviceInfo.current(context = null)
         info.hasGrapheneOsPackages shouldBe false
         info.hasBatteryChargeLimit shouldBe false
+        info.batteryChargeLimitProbe shouldBe SettingProbe.ABSENT
+        info.protectBatteryProbe shouldBe SettingProbe.ABSENT
+    }
+
+    @Test
+    fun `a refused read is classified as denied, not as absence`() {
+        probeSetting { throw SecurityException("not @Readable") } shouldBe SettingProbe.READ_DENIED
+    }
+
+    @Test
+    fun `a read returning nothing is absence, and any other failure fails closed the same way`() {
+        probeSetting { null } shouldBe SettingProbe.ABSENT
+        probeSetting { "1" } shouldBe SettingProbe.PRESENT
+        // Matches the previous runCatching{…}.getOrDefault(false) behaviour for non-security failures.
+        probeSetting { throw IllegalStateException("provider died") } shouldBe SettingProbe.ABSENT
+    }
+
+    @Test
+    fun `a denied probe never opens a gate`() {
+        // The whole point of the tri-state is that it stays visible in reports WITHOUT relaxing any gate:
+        // hasProtectBattery gates device-wide Samsung writes and must read false unless the key was read back.
+        device().copy(protectBatteryProbe = SettingProbe.READ_DENIED).hasProtectBattery shouldBe false
+        device().copy(protectBatteryProbe = SettingProbe.ABSENT).hasProtectBattery shouldBe false
+        device().copy(protectBatteryProbe = SettingProbe.PRESENT).hasProtectBattery shouldBe true
     }
 }

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
@@ -2,6 +2,7 @@ package eu.darken.amply.charging.core.adapter
 
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.SettingProbe
 import eu.darken.amply.charging.core.access.LineageChargeReadout
 import eu.darken.amply.charging.core.access.LineageChargeReader
 import eu.darken.amply.common.ca.toCaString
@@ -47,7 +48,7 @@ class AdapterRegistrySelectionTest {
         sdk = 36,
         fingerprint = "test",
         oneUiVersion = oneUi,
-        hasProtectBattery = true,
+        protectBatteryProbe = SettingProbe.PRESENT,
         isSystemUser = true,
     )
 
@@ -93,7 +94,7 @@ class AdapterRegistrySelectionTest {
         codename = "komodo",
         hasChargingOptimization = false,
         hasGrapheneOsPackages = packages,
-        hasBatteryChargeLimit = key,
+        batteryChargeLimitProbe = if (key) SettingProbe.PRESENT else SettingProbe.ABSENT,
         isSystemUser = systemUser,
     )
 

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/ContributionEligibilityTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/ContributionEligibilityTest.kt
@@ -3,6 +3,7 @@ package eu.darken.amply.charging.core.adapter
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.SettingProbe
 import eu.darken.amply.charging.core.access.LineageChargeReadout
 import eu.darken.amply.charging.core.access.LineageChargeReader
 import eu.darken.amply.common.ca.toCaString
@@ -78,9 +79,14 @@ class ContributionEligibilityTest {
         // The unprivileged key probe is @Protected-denied on real GrapheneOS, so its result carries
         // no information; the keys are fully mapped and nothing is left to discover.
         val ready = device("Google", model = "Pixel 9 Pro XL", sdk = 37)
-            .copy(hasChargingOptimization = false, hasGrapheneOsPackages = true, hasBatteryChargeLimit = true)
+            .copy(
+                hasChargingOptimization = false,
+                hasGrapheneOsPackages = true,
+                batteryChargeLimitProbe = SettingProbe.PRESENT,
+            )
         registry.select(ready).support.contributionWanted shouldBe false
-        registry.select(ready.copy(hasBatteryChargeLimit = false)).support.contributionWanted shouldBe false
+        registry.select(ready.copy(batteryChargeLimitProbe = SettingProbe.ABSENT))
+            .support.contributionWanted shouldBe false
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapterTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapterTest.kt
@@ -5,6 +5,7 @@ import eu.darken.amply.charging.core.BackendKind
 import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.SettingProbe
 import eu.darken.amply.charging.core.access.AccessBackend
 import eu.darken.amply.charging.core.access.BackendStatus
 import eu.darken.amply.charging.core.access.SettingMutation
@@ -33,7 +34,7 @@ class GrapheneOsChargingAdapterTest {
         // The real GrapheneOS shape: no Settings-Intelligence controller.
         hasChargingOptimization = false,
         hasGrapheneOsPackages = packages,
-        hasBatteryChargeLimit = key,
+        batteryChargeLimitProbe = if (key) SettingProbe.PRESENT else SettingProbe.ABSENT,
         isSystemUser = systemUser,
     )
 

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/SamsungChargingAdaptersTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/SamsungChargingAdaptersTest.kt
@@ -5,6 +5,7 @@ import eu.darken.amply.charging.core.BackendKind
 import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.SettingProbe
 import eu.darken.amply.charging.core.access.AccessBackend
 import eu.darken.amply.charging.core.access.BackendStatus
 import eu.darken.amply.charging.core.access.SettingMutation
@@ -32,7 +33,7 @@ class SamsungChargingAdaptersTest {
         sdk = 36,
         fingerprint = "test",
         oneUiVersion = oneUi,
-        hasProtectBattery = hasKey,
+        protectBatteryProbe = if (hasKey) SettingProbe.PRESENT else SettingProbe.ABSENT,
         isSystemUser = systemUser,
     )
 

--- a/app/src/test/java/eu/darken/amply/diagnostics/core/ContributionReportTest.kt
+++ b/app/src/test/java/eu/darken/amply/diagnostics/core/ContributionReportTest.kt
@@ -13,6 +13,7 @@ class ContributionReportTest {
 
     private fun secure(key: String) = SettingId(SettingNamespace.SECURE, key)
     private fun global(key: String) = SettingId(SettingNamespace.GLOBAL, key)
+    private fun system(key: String) = SettingId(SettingNamespace.SYSTEM, key)
     private fun obs(label: String, vararg pairs: Pair<SettingId, String>) =
         ModeObservation(label, 0L, pairs.toMap())
 
@@ -57,6 +58,24 @@ class ContributionReportTest {
     fun `known key with an unexpected value stays redacted`() {
         deriveMatrix(
             listOf(obs("a", global("protect_battery") to "0"), obs("b", global("protect_battery") to "9")),
+        ).single().disclosure shouldBe Disclosure.REDACTED
+    }
+
+    @Test
+    fun `both oplus charge keys auto-disclose, so a wizard run never reports half the pair`() {
+        // The two ColorOS keys are mutually exclusive: regular = fixed 80% cap, smart = adaptive. Listing only
+        // one of them redacted the other's whole row, which reads as a device that has just the fixed cap.
+        val regular = system("regular_charge_protection_switch_state")
+        val smart = system("smart_charge_protection_switch_state")
+        deriveMatrix(
+            listOf(obs("off", regular to "0", smart to "0"), obs("limit", regular to "1", smart to "0")),
+        ).single().disclosure shouldBe Disclosure.AUTO
+        deriveMatrix(
+            listOf(obs("off", smart to "0"), obs("smart", smart to "1")),
+        ).single().disclosure shouldBe Disclosure.AUTO
+        // An out-of-domain value under a known key still keeps the row opt-in.
+        deriveMatrix(
+            listOf(obs("off", smart to "0"), obs("odd", smart to "7")),
         ).single().disclosure shouldBe Disclosure.REDACTED
     }
 

--- a/app/src/test/java/eu/darken/amply/main/core/DeviceSupportReporterTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/core/DeviceSupportReporterTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.amply.main.core
 
+import eu.darken.amply.charging.core.SettingProbe
 import eu.darken.amply.charging.core.access.LineageChargingProvider
 import eu.darken.amply.charging.core.access.LineageHealthSummary
 import io.kotest.matchers.shouldBe
@@ -17,7 +18,8 @@ class DeviceSupportReporterTest {
         adapterId: String? = "samsung-lab",
         isLineageOs: Boolean = false,
         isGrapheneOs: Boolean = false,
-        hasBatteryChargeLimit: Boolean = false,
+        batteryChargeLimitProbe: SettingProbe = SettingProbe.ABSENT,
+        oplusKeys: OplusKeyProbes = OplusKeyProbes.UNPROBED,
         lineageHealth: LineageHealthSummary? = null,
     ) = DeviceSupportReport(
         manufacturer = manufacturer,
@@ -37,8 +39,9 @@ class DeviceSupportReporterTest {
         isLineageOs = isLineageOs,
         isGrapheneOs = isGrapheneOs,
         lineageHealth = lineageHealth,
-        hasProtectBattery = true,
-        hasBatteryChargeLimit = hasBatteryChargeLimit,
+        protectBatteryProbe = SettingProbe.PRESENT,
+        batteryChargeLimitProbe = batteryChargeLimitProbe,
+        oplusKeys = oplusKeys,
         hasLineageSettingsProvider = false,
         adapterId = adapterId,
         adapterMatched = adapterId != null,
@@ -56,7 +59,11 @@ class DeviceSupportReporterTest {
     fun `format is deterministic and schema-tagged`() {
         val text = formatReport(report())
         text shouldStartWith "Amply device-support request"
-        text shouldContain "report_schema=9"
+        // Whole line, trailing newline included: a bare "report_schema=10" also passes for "report_schema=100".
+        text shouldContain "report_schema=10\n"
+        // The schema-9 names must be gone, not merely joined by the new ones.
+        text shouldNotContain "has_protect_battery"
+        text shouldNotContain "has_battery_charge_limit"
         text shouldContain "manufacturer=Samsung"
         text shouldContain "model=SM-S911B"
         text shouldContain "one_ui_version=61000"
@@ -65,8 +72,10 @@ class DeviceSupportReporterTest {
         text shouldContain "is_lineageos=false"
         text shouldContain "lineageos_version=none"
         text shouldContain "is_grapheneos=false"
-        text shouldContain "has_battery_charge_limit=false"
-        text shouldContain "has_protect_battery=true"
+        text shouldContain "probe_battery_charge_limit=absent"
+        text shouldContain "probe_protect_battery=present"
+        text shouldContain "probe_regular_charge_protection=absent"
+        text shouldContain "probe_smart_charge_protection=absent"
         text shouldContain "has_lineage_settings_provider=false"
         text shouldContain "adapter=samsung-lab"
         text shouldContain "contribution_wanted=true"
@@ -121,11 +130,35 @@ class DeviceSupportReporterTest {
 
     @Test
     fun `a grapheneos report carries identity and the key probe result`() {
-        // The probe is @Protected-denied on real GrapheneOS, so false is the expected value there;
-        // true would flag a ROM exposing a same-named key WITHOUT the GrapheneOS restriction.
-        val text = formatReport(report(isGrapheneOs = true, hasBatteryChargeLimit = true))
+        // "present" would flag a ROM exposing a same-named key WITHOUT the GrapheneOS restriction.
+        val text = formatReport(report(isGrapheneOs = true, batteryChargeLimitProbe = SettingProbe.PRESENT))
         text shouldContain "is_grapheneos=true"
-        text shouldContain "has_battery_charge_limit=true"
+        text shouldContain "probe_battery_charge_limit=present"
+    }
+
+    @Test
+    fun `a refused probe is reported as denied, not as absence`() {
+        // The shape @Protected produces on real GrapheneOS, and the one API 31+ produces for any non-@Readable
+        // key. It previously rendered identically to "no such key", which is how issue #49 arrived claiming the
+        // charge limit was missing while the device was actively enforcing it.
+        val text = formatReport(report(isGrapheneOs = true, batteryChargeLimitProbe = SettingProbe.READ_DENIED))
+        text shouldContain "probe_battery_charge_limit=read_denied"
+        text shouldNotContain "probe_battery_charge_limit=absent"
+    }
+
+    @Test
+    fun `an oplus report distinguishes a mapped key from an unmapped rom`() {
+        // Without these two lines a non-ColorOS-15 Oplus report carries no Oplus signal at all: the ROM property
+        // is the only other one, and it reads "none" on every pre-rebrand build (observed on an Oppo F11 Pro).
+        val fixedCap = formatReport(
+            report(
+                manufacturer = "OPPO",
+                adapterId = "oneplus-lab",
+                oplusKeys = OplusKeyProbes(regular = SettingProbe.PRESENT, smart = SettingProbe.ABSENT),
+            ),
+        )
+        fixedCap shouldContain "probe_regular_charge_protection=present"
+        fixedCap shouldContain "probe_smart_charge_protection=absent"
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/main/core/OplusKeyProbesTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/core/OplusKeyProbesTest.kt
@@ -1,0 +1,63 @@
+package eu.darken.amply.main.core
+
+import android.content.Context
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.charging.core.SettingProbe
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Wiring test for the Oplus key probe. The formatting tests hand it enum values, so nothing else would catch the
+ * probe reading the wrong key name or the wrong namespace — and the namespace is the easy mistake here, since every
+ * other key Amply probes lives in `global` or `secure` while these two are `system`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class OplusKeyProbesTest {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `a device with neither key probes absent`() {
+        OplusKeyProbes.read(context.contentResolver) shouldBe OplusKeyProbes.UNPROBED
+    }
+
+    @Test
+    fun `the fixed-cap key is read from the system namespace`() {
+        Settings.System.putString(context.contentResolver, "regular_charge_protection_switch_state", "1")
+
+        val probes = OplusKeyProbes.read(context.contentResolver)
+        probes.regular shouldBe SettingProbe.PRESENT
+        probes.smart shouldBe SettingProbe.ABSENT
+    }
+
+    @Test
+    fun `the adaptive key is read from the system namespace`() {
+        Settings.System.putString(context.contentResolver, "smart_charge_protection_switch_state", "0")
+
+        val probes = OplusKeyProbes.read(context.contentResolver)
+        probes.smart shouldBe SettingProbe.PRESENT
+        probes.regular shouldBe SettingProbe.ABSENT
+    }
+
+    @Test
+    fun `presence is reported for an off value too`() {
+        // "0" means the feature exists and is switched off — that is still a mapped key, and the report carries
+        // presence only, never the value.
+        Settings.System.putString(context.contentResolver, "regular_charge_protection_switch_state", "0")
+
+        OplusKeyProbes.read(context.contentResolver).regular shouldBe SettingProbe.PRESENT
+    }
+
+    @Test
+    fun `the same key in another namespace is not mistaken for the system one`() {
+        Settings.Secure.putString(context.contentResolver, "regular_charge_protection_switch_state", "1")
+        Settings.Global.putString(context.contentResolver, "smart_charge_protection_switch_state", "1")
+
+        OplusKeyProbes.read(context.contentResolver) shouldBe OplusKeyProbes.UNPROBED
+    }
+}


### PR DESCRIPTION
## What changed

Device-support reports now say something useful about Oppo, OnePlus, and Realme phones that aren't on ColorOS 15, and they no longer claim a setting is missing when the system simply refused to let Amply look.

A report from an Oppo F11 Pro (ColorOS 11) arrived carrying nothing at all about charge protection. Amply recognised it as an Oplus device, then checked only Samsung's, GrapheneOS's, and LineageOS's settings, never the ColorOS ones it already knows about. Reports from those devices now include whether each of the two ColorOS charge-protection settings is there.

Separately, every one of these presence checks reported "not present" both when a setting genuinely didn't exist and when Android refused the read. Those are very different answers, and conflating them already produced a wrong conclusion: a GrapheneOS report said the charge limit was missing while that phone was actively holding at 80%. Reports now distinguish present, absent, and read refused.

No change to which devices Amply can control, and no new permissions. Only setting presence is reported, never any value.

One extra ColorOS setting is now recognised as safe to disclose automatically in the "Help add support" wizard, so a contribution from an Oplus device no longer arrives with half of a paired feature hidden behind a manual reveal.

## Technical Context

- Root cause of the empty report: the live Oplus gate keys on `ro.build.version.oplusrom`, which doesn't exist on pre-rebrand ColorOS, so it was the report's only Oplus signal and it read `none`. Absence was also indistinguishable from an SELinux-denied read, since `SystemPropertyReader` returns `""` on denial.
- `OplusKeyProbes` lives on the reporter's IO path rather than in `DeviceInfo`, deliberately. `DeviceInfo.current()` is rebuilt on every dashboard refresh from the main thread by `ChargingRepository`, `MainActivity`, and the wizard VM; these two probes gate nothing, so putting them in the shared snapshot would pay two synchronous binder calls per refresh for diagnostics-only data.
- **Worth close review:** `hasProtectBattery` gates device-wide Samsung writes and both flags feed `hasSupportLead`. They survive as derived `== PRESENT` accessors specifically so a refused read still fails closed exactly as the old booleans did. Codex reviewed this point directly and confirmed no gate widened; the assertion is pinned in `DeviceInfoTest`.
- `ABSENT` is documented as "nothing found", not a proven negative. A fourth `READ_FAILED` state was considered and rejected: the platform swallows provider-acquisition and `RemoteException` failures internally and returns null, so such a state would be false precision.
- Report schema 9 → 10 (two fields renamed with new semantics, two added). Nothing in the repo parses the report format; the two remaining old-name mentions are historical prose describing an actual schema-9 report and are correct as-is.
- The `smart_charge_protection_switch_state` allowlist gap was independent of the adapter, which already handled both keys. `SettingWritePolicy` had both; only the disclosure allowlist was missing one.
- The four deleted `CANDIDATE_KEYS` sets had no references in main or test.
