### PR TITLE
Charging: Add conditional charge rules (Bluetooth and charger type)

### DIFF
--- a/app/src/debug/java/eu/darken/amply/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/amply/screenshots/ScreenshotContent.kt
@@ -91,6 +91,7 @@ private fun DashboardShot(state: DashboardUiState) = PreviewWrapper {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,13 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
+    <!-- Charge conditions: a Bluetooth-device rule needs the connect/disconnect broadcasts and the
+         bonded-device list. Runtime-requested on API 31+, install-time below that. -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+
     <queries>
         <package android:name="moe.shizuku.privileged.api" />
         <package android:name="com.google.android.settings.intelligence" />
@@ -102,6 +109,15 @@
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/amply_widget_info" />
+        </receiver>
+
+        <receiver
+            android:name=".rules.core.BluetoothRuleReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
+                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
+            </intent-filter>
         </receiver>
 
         <receiver

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionManager.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionManager.kt
@@ -29,10 +29,18 @@ class ChargeSessionManager @Inject constructor(
      * override permanent and lose the user's own baseline. The session record is durable and survives
      * process death, so handing it the true baseline makes it the single owner of that restore.
      */
+    /**
+     * [afterPersisted] runs in the window between the session record being persisted and the override
+     * write. That is the only correct place for the charge-conditions handoff: the session durably
+     * owes the restore from the moment its record exists, and clearing rule ownership any later
+     * leaves both layers claiming the baseline across a write that can fail, be cancelled, or die
+     * with the process. It must not throw — it runs inside the session mutex.
+     */
     suspend fun begin(
         nowMillis: Long = System.currentTimeMillis(),
         pluggedAtStart: Boolean? = null,
         restoreOverride: ChargePolicy? = null,
+        afterPersisted: (suspend () -> Unit)? = null,
     ): ApplyResult = mutex.withLock {
         sessionStore.currentSession()?.let {
             return@withLock ApplyResult(
@@ -106,6 +114,7 @@ class ChargeSessionManager @Inject constructor(
             // that instruction until the replug is observed.
             overrideAwaitingReplug = adapter?.policyLatchesAtPlug == true && pluggedAtStart != false,
         )
+        afterPersisted?.invoke()
         val result = repository.applyTemporary(overridePolicy)
         if (result.success) {
             // Reconcile the persist-first conservative flag with the repository's authoritative

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionManager.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionManager.kt
@@ -22,9 +22,17 @@ class ChargeSessionManager @Inject constructor(
 ) {
     private val mutex = Mutex()
 
+    /**
+     * [restoreOverride] replaces the observed current policy as the session's restore target. Set by
+     * the charge-conditions layer when a rule currently owns the policy: what is configured right now
+     * is the *rule's* temporary override, so restoring to it at the end of the session would make the
+     * override permanent and lose the user's own baseline. The session record is durable and survives
+     * process death, so handing it the true baseline makes it the single owner of that restore.
+     */
     suspend fun begin(
         nowMillis: Long = System.currentTimeMillis(),
         pluggedAtStart: Boolean? = null,
+        restoreOverride: ChargePolicy? = null,
     ): ApplyResult = mutex.withLock {
         sessionStore.currentSession()?.let {
             return@withLock ApplyResult(
@@ -78,7 +86,7 @@ class ChargeSessionManager @Inject constructor(
                 message = "The current OEM charging mode is not recognized; refusing to overwrite it",
             )
         }
-        val restorePolicy = (decision as SessionStartDecision.Start).restorePolicy
+        val restorePolicy = restoreOverride ?: (decision as SessionStartDecision.Start).restorePolicy
 
         // Persist recovery state before removing the limit. Stamp this process's identity so a later
         // pickup can tell whether the session survived a process death (interruption detection), and a

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -76,6 +76,8 @@ class ChargeSessionService : Service() {
     // Written under the dispatch lock, but read by the battery receiver/monitor loop outside it.
     @Volatile private var recoveryJob: Job? = null
     private var settingObserverRegistered = false
+    // Whether this service instance has already swept the Bluetooth profile proxies (see evaluateRules).
+    private var bluetoothReconciled = false
     @Volatile private var restoring = false
     // One-shot interruption assessment for a freshly resumed persisted session: set when
     // beginOrResume picks up an existing session, consumed by the first battery evaluation, and
@@ -303,8 +305,13 @@ class ChargeSessionService : Service() {
                 plugged = plugged,
                 plugKind = plugKind,
                 sessionActive = sessionActive,
-                reconcileBluetooth = reconcileBluetooth,
+                // Always on this instance's first pass, whichever command brought the service up: a
+                // process that was not running missed every ACL broadcast in the meantime, and the
+                // stored snapshot is only as good as the last one it received. After that the
+                // receiver keeps it current and the sweep would just cost Binder round-trips.
+                reconcileBluetooth = reconcileBluetooth || !bluetoothReconciled,
             )
+            bluetoothReconciled = true
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -212,7 +212,15 @@ class ChargeSessionService : Service() {
             // is configured right now is the rule's temporary override, so the session must restore
             // the user's real policy, not the override.
             val ruleBaseline = ruleApplier.readActiveBaseline()
-            val result = manager.begin(pluggedAtStart = currentPlugged(), restoreOverride = ruleBaseline)
+            val result = manager.begin(
+                pluggedAtStart = currentPlugged(),
+                restoreOverride = ruleBaseline,
+                // Handed over inside begin(), in the window between the session record being
+                // persisted and the override write: from that moment the session owes the restore,
+                // and clearing any later would leave both layers claiming the baseline across a
+                // write that can fail or die with the process.
+                afterPersisted = ruleApplier::clearActiveAfterSessionPersist,
+            )
             if (!result.success) {
                 log(TAG, Logging.Priority.WARN) { "Unable to start full-charge session: ${result.message}" }
                 if (fullChargeStore.currentSession() != null) SessionNotifications.showRecovery(this)
@@ -220,9 +228,6 @@ class ChargeSessionService : Service() {
                 SurfaceUpdater.updateNow(this)
                 return
             }
-            // Strictly after the session record exists: a refused or failed start must leave the rules
-            // layer owning the baseline, or nothing would owe it back.
-            if (fullChargeStore.currentSession() != null) ruleApplier.clearActiveAfterSessionPersist()
         } else {
             // Resuming a persisted session: assess whether this process is picking up work a dead
             // process left behind. Threaded (one-shot) into the first battery evaluation below.
@@ -651,16 +656,16 @@ class ChargeSessionService : Service() {
             ACTION_RESTORE -> if (recoveryJob?.isActive != true) restoreAndContinue()
             ACTION_MONITOR -> if (recoveryJob?.isActive != true) continueGestureOrStop()
             // A rule edit or a Bluetooth connection change. Gated on recovery like ACTION_MONITOR: a
-            // rule write must never race the boot-recovery convergence loop. The Bluetooth
-            // reconciliation runs here (and only here) because this is the path a process that may
-            // have missed ACL broadcasts comes back through.
+            // rule write must never race the boot-recovery convergence loop. No forced Bluetooth
+            // sweep here — the once-per-service-instance one in evaluateRules already covers the
+            // missed-broadcast case, and sweeping on every ACL event risks a lagging profile proxy
+            // writing a just-disconnected address back over the receiver's fresher snapshot.
             ACTION_EVALUATE_RULES -> if (recoveryJob?.isActive != true) {
                 val (plugged, plugKind) = currentPlug()
                 evaluateRules(
                     plugged = plugged,
                     plugKind = plugKind,
                     sessionActive = fullChargeStore.currentSession() != null,
-                    reconcileBluetooth = true,
                 )
                 continueGestureOrStop()
             }
@@ -721,6 +726,19 @@ class ChargeSessionService : Service() {
             // Assess whether this recovery is picking up work a dead process left behind, BEFORE the
             // flow mutates the pending target.
             val pickup = interruptionAssessor.captureRecoveryPickup()
+            // A persisted session already carries the baseline as its restore target, so rule
+            // bookkeeping left ACTIVE beside it is stale: recovery is about to write policies, and
+            // the rules layer must not come back afterwards claiming to own the result.
+            if (fullChargeStore.currentSession() != null) {
+                try {
+                    ruleApplier.clearActiveAfterSessionPersist()
+                } catch (e: CancellationException) {
+                    // A cancelled recovery job must actually stop here, not carry on into the flow.
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, Logging.Priority.WARN) { "Rule ownership clear failed: ${e.message}" }
+                }
+            }
             val result = BootRecoveryFlow(recoveryHooks).run()
             log(TAG) { "Boot recovery outcome: ${result.outcome}" }
             // A converged recovery restored the protective policy, so clear any lingering alarm.
@@ -849,6 +867,17 @@ class ChargeSessionService : Service() {
         // instead of leaving charging in whatever transient state the session had. An explicit persistent
         // choice is new owed work, so it gets a fresh work id.
         fullChargeStore.setPendingRecoveryTarget(policy, UUID.randomUUID().toString(), currentWorkProvenance())
+        // Suspend the rules layer here, in the same persisted-intent step and BEFORE the write: a
+        // process death between the write and a post-success suspension would leave the explicit
+        // policy configured with every rule still armed to overwrite it on the next tick.
+        val (pluggedNow, plugKindNow) = currentPlug()
+        try {
+            ruleApplier.suspendMatchingCohort(pluggedNow, plugKindNow)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, Logging.Priority.WARN) { "Rule suspension failed: ${e.message}" }
+        }
         restoring = true
         coordinator.close()
         try {
@@ -865,16 +894,6 @@ class ChargeSessionService : Service() {
                 // interruption warning it supersedes and drop the recovery notification.
                 SessionNotifications.cancelRecovery(this)
                 interruptionAssessor.onExplicitPolicyWrite()
-                // An explicit user choice outranks the rules layer. Only after the write actually
-                // landed: suspending rules for a refused write would disable them for nothing.
-                val (plugged, plugKind) = currentPlug()
-                try {
-                    ruleApplier.suspendMatchingCohort(plugged, plugKind)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log(TAG, Logging.Priority.WARN) { "Rule suspension failed: ${e.message}" }
-                }
             } else {
                 log(TAG, Logging.Priority.ERROR) { "Persistent policy write failed: ${result.message}" }
                 SessionNotifications.showRecovery(this)

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -26,6 +26,8 @@ import eu.darken.amply.common.debug.logging.logTag
 import eu.darken.amply.main.core.SurfaceUpdater
 import eu.darken.amply.monitor.core.ChargeMonitorTick
 import eu.darken.amply.monitor.core.ChargeMonitorWatcher
+import eu.darken.amply.rules.core.PlugKind
+import eu.darken.amply.rules.core.RuleApplier
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -49,6 +51,7 @@ class ChargeSessionService : Service() {
     @Inject lateinit var interruptionAssessor: InterruptionAssessor
     @Inject lateinit var processIdentity: ProcessIdentity
     @Inject lateinit var bootCountProvider: BootCountProvider
+    @Inject lateinit var ruleApplier: RuleApplier
 
     // Optional, permission-free battery observers (charge alarm, …), contributed via @IntoSet.
     @Inject lateinit var watchers: Set<@JvmSuppressWildcards ChargeMonitorWatcher>
@@ -203,7 +206,11 @@ class ChargeSessionService : Service() {
             log(TAG) { "Starting a one-time full-charge session" }
             // A brand-new session in this process is not an interruption; drop any stale assessment.
             pendingSessionAssessment = null
-            val result = manager.begin(pluggedAtStart = currentPlugged())
+            // A conditional rule may currently own the policy. Hand its baseline to the session: what
+            // is configured right now is the rule's temporary override, so the session must restore
+            // the user's real policy, not the override.
+            val ruleBaseline = ruleApplier.readActiveBaseline()
+            val result = manager.begin(pluggedAtStart = currentPlugged(), restoreOverride = ruleBaseline)
             if (!result.success) {
                 log(TAG, Logging.Priority.WARN) { "Unable to start full-charge session: ${result.message}" }
                 if (fullChargeStore.currentSession() != null) SessionNotifications.showRecovery(this)
@@ -211,6 +218,9 @@ class ChargeSessionService : Service() {
                 SurfaceUpdater.updateNow(this)
                 return
             }
+            // Strictly after the session record exists: a refused or failed start must leave the rules
+            // layer owning the baseline, or nothing would owe it back.
+            if (fullChargeStore.currentSession() != null) ruleApplier.clearActiveAfterSessionPersist()
         } else {
             // Resuming a persisted session: assess whether this process is picking up work a dead
             // process left behind. Threaded (one-shot) into the first battery evaluation below.
@@ -269,6 +279,46 @@ class ChargeSessionService : Service() {
             log(TAG, Logging.Priority.WARN) { "Watcher ${watcher.id} isEnabled failed: ${e.message}" }
             false
         }
+    }
+
+    /**
+     * Run one conditional-charge-rule evaluation.
+     *
+     * A first-class step of the evaluation path, NOT watcher work: watcher ticks are optional and
+     * bounded by a per-watcher budget, while a rule write changes the charging policy and owes a
+     * restore — it must never be cut short. It runs *after* the safety-critical session decisions
+     * above (a restore must never queue behind it) and before the optional watchers.
+     *
+     * Failure is contained the same way a watcher's is: the rules layer must not be able to stop a
+     * battery evaluation.
+     */
+    private suspend fun evaluateRules(
+        plugged: Boolean,
+        plugKind: PlugKind?,
+        sessionActive: Boolean,
+        reconcileBluetooth: Boolean = false,
+    ) {
+        try {
+            ruleApplier.evaluate(
+                plugged = plugged,
+                plugKind = plugKind,
+                sessionActive = sessionActive,
+                reconcileBluetooth = reconcileBluetooth,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, Logging.Priority.ERROR) { "Rule evaluation failed: ${e.message}" }
+        }
+    }
+
+    /** Current plug state and charger class from the sticky broadcast, for a command-driven pass. */
+    private fun currentPlug(): Pair<Boolean, PlugKind?> {
+        val raw = runCatching {
+            registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+                ?.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0)
+        }.getOrNull() ?: 0
+        return (raw != 0) to plugKindOf(raw)
     }
 
     /**
@@ -355,7 +405,9 @@ class ChargeSessionService : Service() {
         // An in-flight evaluation can outlive the quiesce in startRecovery; never race recovery.
         if (recoveryJob?.isActive == true) return
         val battery = intent ?: registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
-        val plugged = (battery?.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0) ?: 0) != 0
+        val pluggedRaw = battery?.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0) ?: 0
+        val plugged = pluggedRaw != 0
+        val plugKind = plugKindOf(pluggedRaw)
         val status = battery?.getIntExtra(
             BatteryManager.EXTRA_STATUS,
             BatteryManager.BATTERY_STATUS_UNKNOWN,
@@ -447,6 +499,8 @@ class ChargeSessionService : Service() {
                     )
                 }
             }
+            // A live session outranks the rules layer; this pass only reconciles its bookkeeping.
+            evaluateRules(plugged, plugKind, sessionActive = true)
             // Non-restore session tick: let watchers observe it (the alarm claims the cycle here).
             dispatchWatchers(plugged, percent, status, sessionOwned = true, battery, observedAtElapsed)
             return
@@ -461,6 +515,7 @@ class ChargeSessionService : Service() {
         val gestureEnabled = fullChargeStore.isQuickFullChargeEnabled()
         val adapter = if (gestureEnabled) adapterRegistry.select().adapter else null
         if (!gestureEnabled || adapter?.reconnectGestureSupported != true) {
+            evaluateRules(plugged, plugKind, sessionActive = false)
             dispatchWatchers(plugged, percent, status, sessionOwned = false, battery, observedAtElapsed)
             // Gesture inactive: keep running only if a watcher still wants the service, showing the
             // quiet monitoring notification instead of the gesture cue.
@@ -519,6 +574,7 @@ class ChargeSessionService : Service() {
                     "plugged=$plugged percent=$percent status=$status"
             }
         }
+        evaluateRules(plugged, plugKind, sessionActive = false)
         // A triggering tick is a deliberate full charge about to begin, so the alarm must treat it
         // as session-owned and NOT fire "unplug now" on the very reconnect that started the charge.
         dispatchWatchers(
@@ -587,6 +643,20 @@ class ChargeSessionService : Service() {
         when (action) {
             ACTION_RESTORE -> if (recoveryJob?.isActive != true) restoreAndContinue()
             ACTION_MONITOR -> if (recoveryJob?.isActive != true) continueGestureOrStop()
+            // A rule edit or a Bluetooth connection change. Gated on recovery like ACTION_MONITOR: a
+            // rule write must never race the boot-recovery convergence loop. The Bluetooth
+            // reconciliation runs here (and only here) because this is the path a process that may
+            // have missed ACL broadcasts comes back through.
+            ACTION_EVALUATE_RULES -> if (recoveryJob?.isActive != true) {
+                val (plugged, plugKind) = currentPlug()
+                evaluateRules(
+                    plugged = plugged,
+                    plugKind = plugKind,
+                    sessionActive = fullChargeStore.currentSession() != null,
+                    reconcileBluetooth = true,
+                )
+                continueGestureOrStop()
+            }
             ACTION_START -> {
                 // A user-initiated session supersedes boot recovery; the new session
                 // overwrites the policy anyway. Join so a cancelled re-write cannot
@@ -788,6 +858,16 @@ class ChargeSessionService : Service() {
                 // interruption warning it supersedes and drop the recovery notification.
                 SessionNotifications.cancelRecovery(this)
                 interruptionAssessor.onExplicitPolicyWrite()
+                // An explicit user choice outranks the rules layer. Only after the write actually
+                // landed: suspending rules for a refused write would disable them for nothing.
+                val (plugged, plugKind) = currentPlug()
+                try {
+                    ruleApplier.suspendMatchingCohort(plugged, plugKind)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, Logging.Priority.WARN) { "Rule suspension failed: ${e.message}" }
+                }
             } else {
                 log(TAG, Logging.Priority.ERROR) { "Persistent policy write failed: ${result.message}" }
                 SessionNotifications.showRecovery(this)
@@ -882,6 +962,23 @@ class ChargeSessionService : Service() {
         const val ACTION_RECOVER = "eu.darken.amply.action.RECOVER_CHARGE_LIMIT"
         const val ACTION_CHECK = "eu.darken.amply.action.CHECK_CHARGE_STATE"
         const val ACTION_SET_PERSISTENT_POLICY = "eu.darken.amply.action.SET_PERSISTENT_POLICY"
+        const val ACTION_EVALUATE_RULES = "eu.darken.amply.action.EVALUATE_CHARGE_RULES"
         const val EXTRA_TARGET_POLICY = "eu.darken.amply.extra.TARGET_POLICY"
+
+        /**
+         * The charger class from `BatteryManager.EXTRA_PLUGGED`. Null for unplugged and for a value
+         * this build does not know — an unknown charger must not silently satisfy a rule that names
+         * specific charger types.
+         */
+        // BATTERY_PLUGGED_DOCK postdates minSdk, but these are compile-time constants that inline —
+        // an older platform simply never reports the value.
+        @Suppress("InlinedApi")
+        internal fun plugKindOf(extraPlugged: Int): PlugKind? = when (extraPlugged) {
+            BatteryManager.BATTERY_PLUGGED_AC -> PlugKind.AC
+            BatteryManager.BATTERY_PLUGGED_USB -> PlugKind.USB
+            BatteryManager.BATTERY_PLUGGED_WIRELESS -> PlugKind.WIRELESS
+            BatteryManager.BATTERY_PLUGGED_DOCK -> PlugKind.DOCK
+            else -> null
+        }
     }
 }

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -219,7 +219,21 @@ class ChargeSessionService : Service() {
                 // persisted and the override write: from that moment the session owes the restore,
                 // and clearing any later would leave both layers claiming the baseline across a
                 // write that can fail or die with the process.
-                afterPersisted = ruleApplier::clearActiveAfterSessionPersist,
+                //
+                // Contained, because begin() runs this between persisting the session and writing
+                // the override: letting a DataStore failure escape would abort the start after the
+                // record exists, stranding a session whose override write never ran. Stale rule
+                // bookkeeping is the far cheaper failure — the next evaluation clears it against the
+                // live session anyway.
+                afterPersisted = {
+                    try {
+                        ruleApplier.clearActiveAfterSessionPersist()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log(TAG, Logging.Priority.WARN) { "Rule ownership handoff failed: ${e.message}" }
+                    }
+                },
             )
             if (!result.success) {
                 log(TAG, Logging.Priority.WARN) { "Unable to start full-charge session: ${result.message}" }

--- a/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
@@ -63,6 +63,9 @@ import eu.darken.amply.main.ui.settings.SettingsDestination
 import eu.darken.amply.main.ui.settings.SettingsScreen
 import eu.darken.amply.main.ui.settings.SettingsViewModel
 import eu.darken.amply.main.ui.settings.SupportScreen
+import eu.darken.amply.rules.ui.ChargeRuleEditorScreen
+import eu.darken.amply.rules.ui.ChargeRulesScreen
+import eu.darken.amply.rules.ui.ChargeRulesViewModel
 import eu.darken.amply.stats.ui.ChargeHistoryScreen
 import eu.darken.amply.stats.ui.StatsSessionDetailScreen
 import eu.darken.amply.stats.ui.StatsViewModel
@@ -74,6 +77,7 @@ class MainActivity : ComponentActivity() {
     private val settingsViewModel: SettingsViewModel by viewModels()
     private val contributionViewModel: ContributionWizardViewModel by viewModels()
     private val statsViewModel: StatsViewModel by viewModels()
+    private val rulesViewModel: ChargeRulesViewModel by viewModels()
 
     // Compose-observable so a widget launch that reuses an already-running activity (SINGLE_TOP →
     // onNewIntent, which does not re-run LaunchedEffect(Unit)) still triggers the permission flow.
@@ -146,6 +150,9 @@ class MainActivity : ComponentActivity() {
                     // the origin is recorded at the request instead of read off `destination` when
                     // the answer lands (the user may have navigated on by then).
                     var captureGateOrigin by rememberSaveable { mutableStateOf(SettingsDestination.BATTERY) }
+                    // The rules screen is reached from the dashboard card and from the settings hub,
+                    // so Back returns to whichever one opened it.
+                    var rulesOrigin by rememberSaveable { mutableStateOf(SettingsDestination.DASHBOARD) }
                     val enterUpgrade = { origin: SettingsDestination, manage: Boolean ->
                         // Never record the upgrade screen as its own return target: a second entry
                         // while it is already open would strand Back on this screen.
@@ -171,23 +178,36 @@ class MainActivity : ComponentActivity() {
                         detailOrigin = origin
                         destination = SettingsDestination.STATS_SESSION_DETAIL
                     }
+                    val enterRules = { origin: SettingsDestination ->
+                        rulesOrigin = origin
+                        destination = SettingsDestination.CHARGE_RULES
+                    }
+                    val rulesState by rulesViewModel.state.collectAsState()
+                    val ruleEditor by rulesViewModel.editor.collectAsState()
                 var notificationAction by remember { mutableStateOf<NotificationAction?>(null) }
+                // Which rule the pending ENABLE_CHARGE_RULE belongs to; recorded at the request
+                // because the permission answer arrives asynchronously.
+                var pendingRuleId by remember { mutableStateOf<String?>(null) }
+                val runNotificationAction: (NotificationAction?) -> Unit = { action ->
+                    when (action) {
+                        NotificationAction.START_FULL_CHARGE -> viewModel.startFullCharge()
+                        NotificationAction.ENABLE_QUICK_GESTURE -> viewModel.setQuickFullChargeEnabled(true)
+                        NotificationAction.ENABLE_CHARGE_ALARM -> viewModel.setChargeAlarmEnabled(true)
+                        NotificationAction.ENABLE_STATS -> statsViewModel.setCaptureEnabled(true)
+                        NotificationAction.ENABLE_CHARGE_RULE ->
+                            pendingRuleId?.let { rulesViewModel.setRuleEnabled(it, true) }
+                        null -> Unit
+                    }
+                }
                 val notificationLauncher = rememberLauncherForActivityResult(
                     ActivityResultContracts.RequestPermission(),
                 ) { granted ->
-                    if (granted) {
-                        when (notificationAction) {
-                            NotificationAction.START_FULL_CHARGE -> viewModel.startFullCharge()
-                            NotificationAction.ENABLE_QUICK_GESTURE -> viewModel.setQuickFullChargeEnabled(true)
-                            NotificationAction.ENABLE_CHARGE_ALARM -> viewModel.setChargeAlarmEnabled(true)
-                            NotificationAction.ENABLE_STATS -> statsViewModel.setCaptureEnabled(true)
-                            null -> Unit
-                        }
-                    }
+                    if (granted) runNotificationAction(notificationAction)
                     // A refused permission leaves the alarm switch off (an alarm that can't alert
                     // is worse than a silent one); the user can retry from the card, and the blocked
                     // warning appears once the alarm is enabled while delivery is still off.
                     notificationAction = null
+                    pendingRuleId = null
                 }
 
                 fun runWithNotifications(action: NotificationAction) {
@@ -199,12 +219,20 @@ class MainActivity : ComponentActivity() {
                         notificationAction = action
                         notificationLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                     } else {
-                        when (action) {
-                            NotificationAction.START_FULL_CHARGE -> viewModel.startFullCharge()
-                            NotificationAction.ENABLE_QUICK_GESTURE -> viewModel.setQuickFullChargeEnabled(true)
-                            NotificationAction.ENABLE_CHARGE_ALARM -> viewModel.setChargeAlarmEnabled(true)
-                            NotificationAction.ENABLE_STATS -> statsViewModel.setCaptureEnabled(true)
-                        }
+                        runNotificationAction(action)
+                    }
+                }
+
+                // Runtime-requested only from API 31; below that the manifest permission is granted
+                // at install time and the prompt does not exist.
+                val bluetoothLauncher = rememberLauncherForActivityResult(
+                    ActivityResultContracts.RequestPermission(),
+                ) { rulesViewModel.refreshBluetoothPermission() }
+                val requestBluetooth = {
+                    if (Build.VERSION.SDK_INT >= 31) {
+                        bluetoothLauncher.launch(Manifest.permission.BLUETOOTH_CONNECT)
+                    } else {
+                        rulesViewModel.refreshBluetoothPermission()
                     }
                 }
 
@@ -244,6 +272,25 @@ class MainActivity : ComponentActivity() {
                         runWithNotifications(NotificationAction.ENABLE_STATS)
                     }
                 }
+                // The same contract as the stats gate: a denial routes to the upgrade screen, a pass
+                // routes to the notification prompt (a rule keeps the monitor's quiet notification
+                // up), and a third event says the editor's working copy is ready to navigate to.
+                LaunchedEffect(Unit) {
+                    rulesViewModel.upgradeRequiredEvents.collect {
+                        enterUpgrade(SettingsDestination.CHARGE_RULES, false)
+                    }
+                }
+                LaunchedEffect(Unit) {
+                    rulesViewModel.proceedWithEnableEvents.collect { ruleId ->
+                        pendingRuleId = ruleId
+                        runWithNotifications(NotificationAction.ENABLE_CHARGE_RULE)
+                    }
+                }
+                LaunchedEffect(Unit) {
+                    rulesViewModel.openEditorEvents.collect {
+                        destination = SettingsDestination.CHARGE_RULE_EDIT
+                    }
+                }
                 LifecycleResumeEffect(Unit) {
                     viewModel.refresh()
                     // Separate from refresh(): that one runs on every battery broadcast, and a
@@ -254,6 +301,9 @@ class MainActivity : ComponentActivity() {
                     // Re-check Shizuku for the contribution wizard too, so granting access from its intro card
                     // (which pauses the activity behind Shizuku's dialog) updates the card on return.
                     contributionViewModel.refreshStatus()
+                    // The Bluetooth grant is made in a system dialog that pauses the activity, so
+                    // re-read it on return rather than trusting the value from before.
+                    rulesViewModel.refreshBluetoothPermission()
                     val nudge = viewModel.nudgeChargeService()
                     onPauseOrDispose { nudge.cancel() }
                 }
@@ -298,6 +348,13 @@ class MainActivity : ComponentActivity() {
                             SettingsDestination.BATTERY -> destination = SettingsDestination.DASHBOARD
                             // The history list is only reachable from the battery hub's top bar.
                             SettingsDestination.CHARGE_HISTORY -> destination = SettingsDestination.BATTERY
+                            // Reached from the dashboard card or the settings hub.
+                            SettingsDestination.CHARGE_RULES -> destination = rulesOrigin
+                            // The editor is only ever entered from the rules list.
+                            SettingsDestination.CHARGE_RULE_EDIT -> {
+                                rulesViewModel.closeEditor()
+                                destination = SettingsDestination.CHARGE_RULES
+                            }
                             // The session detail returns to whichever surface opened it.
                             SettingsDestination.STATS_SESSION_DETAIL -> {
                                 statsViewModel.closeSession()
@@ -339,6 +396,7 @@ class MainActivity : ComponentActivity() {
                             },
                             onAlarmTargetChange = viewModel::setChargeAlarmTarget,
                             onFixNotifications = viewModel::openNotificationSettings,
+                            onOpenConditions = { enterRules(SettingsDestination.DASHBOARD) },
                             onOpenBatteryHub = { destination = SettingsDestination.BATTERY },
                             // Re-dispatch the charge service after a failed start (charging card retry).
                             onRetryCapture = { viewModel.nudgeChargeService() },
@@ -376,6 +434,8 @@ class MainActivity : ComponentActivity() {
                             onGeneral = { destination = SettingsDestination.GENERAL },
                             gestureEnabled = state.quickFullChargeEnabled,
                             onCharging = { destination = SettingsDestination.CHARGING },
+                            activeRuleCount = state.conditions.enabledRules.size,
+                            onChargeRules = { enterRules(SettingsDestination.SETTINGS) },
                             captureEnabled = state.stats.enabled,
                             onChargingHistory = {
                                 destination = SettingsDestination.CHARGING_HISTORY_SETTINGS
@@ -463,6 +523,59 @@ class MainActivity : ComponentActivity() {
                             },
                             onAnyLevelChange = viewModel::setQuickFullChargeAnyLevel,
                         )
+                        SettingsDestination.CHARGE_RULES -> ChargeRulesScreen(
+                            state = rulesState,
+                            onBack = { destination = rulesOrigin },
+                            // Gated: the ViewModel answers with either the upgrade route or the
+                            // editor-ready event, so nobody fills in a condition and is refused at
+                            // the end.
+                            onAdd = rulesViewModel::requestAddRule,
+                            onEdit = rulesViewModel::editRule,
+                            onDelete = rulesViewModel::deleteRule,
+                            // Enabling passes the gate and the notification prompt; disabling is
+                            // direct, so a lapsed entitlement can never trap a running rule.
+                            onEnabledChange = { id, enabled ->
+                                if (enabled) {
+                                    rulesViewModel.requestEnableRule(id)
+                                } else {
+                                    rulesViewModel.setRuleEnabled(id, false)
+                                }
+                            },
+                            onMove = rulesViewModel::moveRule,
+                            onFixBluetoothPermission = requestBluetooth,
+                        )
+                        // Rendering waits for the working copy: the destination can be restored from
+                        // saved state after a process death, when there is no draft left to edit.
+                        SettingsDestination.CHARGE_RULE_EDIT -> {
+                            val editor = ruleEditor
+                            if (editor == null) {
+                                LaunchedEffect(Unit) { destination = SettingsDestination.CHARGE_RULES }
+                            } else {
+                                ChargeRuleEditorScreen(
+                                    state = editor,
+                                    onBack = {
+                                        rulesViewModel.closeEditor()
+                                        destination = SettingsDestination.CHARGE_RULES
+                                    },
+                                    onLabelChange = rulesViewModel::setEditorLabel,
+                                    onConditionKindChange = rulesViewModel::setEditorConditionKind,
+                                    onDeviceSelect = rulesViewModel::setEditorDevice,
+                                    onPlugKindToggle = rulesViewModel::toggleEditorPlugKind,
+                                    onPolicySelect = rulesViewModel::setEditorPolicy,
+                                    // A denied save answers with the upgrade event, which navigates
+                                    // afterwards — so leaving for the list here is safe either way.
+                                    onSave = {
+                                        rulesViewModel.saveEditor()
+                                        destination = SettingsDestination.CHARGE_RULES
+                                    },
+                                    onDelete = { id ->
+                                        rulesViewModel.deleteRule(id)
+                                        destination = SettingsDestination.CHARGE_RULES
+                                    },
+                                    onRequestBluetoothPermission = requestBluetooth,
+                                )
+                            }
+                        }
                         SettingsDestination.CHARGING_HISTORY_SETTINGS -> ChargingHistorySettingsScreen(
                             // Both values come from already-resolved sources (the dashboard state and
                             // the root-collected retention flow), so neither the switch nor the slider
@@ -594,6 +707,7 @@ class MainActivity : ComponentActivity() {
         ENABLE_QUICK_GESTURE,
         ENABLE_CHARGE_ALARM,
         ENABLE_STATS,
+        ENABLE_CHARGE_RULE,
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/ConditionsCard.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/ConditionsCard.kt
@@ -1,0 +1,194 @@
+package eu.darken.amply.main.ui.dashboard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.WarningAmber
+import androidx.compose.material.icons.twotone.Bolt
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import eu.darken.amply.R
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.common.compose.AmplyCardActionLabel
+import eu.darken.amply.common.compose.AmplyNavigationCard
+import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.PreviewWrapper
+import eu.darken.amply.common.compose.asComposable
+import eu.darken.amply.rules.core.ChargeRule
+import eu.darken.amply.rules.core.PlugKind
+import eu.darken.amply.rules.core.RuleCondition
+import eu.darken.amply.rules.core.RulePhase
+import eu.darken.amply.rules.core.RuleRuntimeState
+import eu.darken.amply.rules.core.policy
+import eu.darken.amply.rules.ui.conditionSummary
+import eu.darken.amply.rules.ui.displayTitle
+import eu.darken.amply.rules.ui.kindIcon
+import eu.darken.amply.upgrade.ui.ProBadge
+
+/**
+ * The dashboard's view of the conditions: the same ordered list the rules screen shows, compressed,
+ * with the one that is actually in effect marked. Order is meaning here — the topmost matching rule
+ * wins — so the card never re-sorts by state.
+ */
+@Composable
+fun ConditionsCard(
+    state: ConditionsState,
+    showProBadge: Boolean,
+    onOpen: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val enabled = state.enabledRules
+    AmplyNavigationCard(
+        onClick = onOpen,
+        onClickLabel = stringResource(R.string.dashboard_conditions_open),
+        title = stringResource(R.string.dashboard_conditions_title),
+        modifier = modifier,
+        icon = Icons.TwoTone.Bolt,
+        headerStatus = when {
+            enabled.isEmpty() -> null
+            state.activeRule != null -> stringResource(R.string.dashboard_conditions_active)
+            else -> stringResource(R.string.dashboard_conditions_waiting)
+        },
+    ) {
+        if (enabled.isEmpty()) {
+            Text(
+                stringResource(R.string.dashboard_conditions_empty_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (showProBadge) ProBadge()
+                AmplyCardActionLabel(
+                    text = stringResource(R.string.dashboard_conditions_empty_action),
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            return@AmplyNavigationCard
+        }
+        enabled.forEach { rule ->
+            val active = rule.id == state.activeRule?.id
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    rule.kindIcon,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = if (active) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                )
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        rule.displayTitle(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = if (active) FontWeight.SemiBold else FontWeight.Normal,
+                    )
+                    Text(
+                        rule.conditionSummary(),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                rule.policy?.label?.asComposable()?.let {
+                    Text(
+                        it,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = if (active) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
+                }
+            }
+        }
+        if (state.applyFailed) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    Icons.Default.WarningAmber,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.error,
+                )
+                Text(
+                    stringResource(R.string.rules_failure_warning),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}
+
+private fun previewRule(
+    id: String,
+    label: String,
+    condition: RuleCondition,
+    policy: ChargePolicy,
+) = ChargeRule(id = id, label = label, condition = condition, policyId = policy.stableId)
+
+@AmplyPreview
+@Composable
+private fun ConditionsCardPreview() = PreviewWrapper {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        val car = previewRule(
+            id = "car",
+            label = "Car",
+            condition = RuleCondition.BluetoothDevice("AA:BB:CC:DD:EE:FF", "Car audio"),
+            policy = ChargePolicy.Unrestricted,
+        )
+        val desk = previewRule(
+            id = "desk",
+            label = "Desk",
+            condition = RuleCondition.ChargerType(setOf(PlugKind.AC)),
+            policy = ChargePolicy.FixedLimit(80),
+        )
+        ConditionsCard(
+            state = ConditionsState(
+                rules = listOf(car, desk),
+                runtime = RuleRuntimeState(phase = RulePhase.ACTIVE, activeRuleId = "car"),
+            ),
+            showProBadge = false,
+            onOpen = {},
+        )
+        ConditionsCard(
+            state = ConditionsState(
+                rules = listOf(car, desk),
+                runtime = RuleRuntimeState(lastApplyFailed = true),
+            ),
+            showProBadge = false,
+            onOpen = {},
+        )
+    }
+}
+
+@AmplyPreview
+@Composable
+private fun ConditionsCardEmptyPreview() = PreviewWrapper {
+    Column(modifier = Modifier.padding(16.dp)) {
+        ConditionsCard(state = ConditionsState(), showProBadge = true, onOpen = {})
+    }
+}

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -93,6 +93,11 @@ import eu.darken.amply.battery.ui.BatteryEffect
 import eu.darken.amply.main.ui.setup.AccessSetupGuide
 import eu.darken.amply.main.ui.setup.OemGuideCard
 import eu.darken.amply.main.ui.setup.UnsupportedDeviceCard
+import eu.darken.amply.rules.core.ChargeRule
+import eu.darken.amply.rules.core.RuleCondition
+import eu.darken.amply.rules.core.RulePhase
+import eu.darken.amply.rules.core.RuleRuntimeState
+import eu.darken.amply.rules.ui.displayTitle
 import eu.darken.amply.stats.core.ChargeCurvePoint
 import eu.darken.amply.stats.core.StatsLiveSession
 import eu.darken.amply.upgrade.ui.brandTitle
@@ -111,6 +116,7 @@ fun DashboardScreen(
     onAlarmEnabledChange: (Boolean) -> Unit,
     onAlarmTargetChange: (Int) -> Unit,
     onFixNotifications: () -> Unit,
+    onOpenConditions: () -> Unit,
     onOpenBatteryHub: () -> Unit,
     onRetryCapture: () -> Unit,
     onPinWidget: () -> Unit,
@@ -284,6 +290,15 @@ fun DashboardScreen(
                         )
                     }
                     item(key = "dashboard.policy") { PolicyCard(state, onApply, onNativeSettings) }
+                    // Right below the policy it conditionally overrides, and above the reconnect
+                    // gesture — the two read as one group of "things that change the policy for you".
+                    item(key = "dashboard.conditions") {
+                        ConditionsCard(
+                            state = state.conditions,
+                            showProBadge = shouldShowUpgradePromo(state.upgrade),
+                            onOpen = onOpenConditions,
+                        )
+                    }
                     // Hidden where the adapter lacks the gesture's hardware signal (non-Pixel) —
                     // unless it is still switched on and needs a way to be turned off.
                     if (state.charging.reconnectSupported || state.quickFullChargeEnabled) {
@@ -514,6 +529,19 @@ private fun StatusCard(
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+        }
+        // Provenance, not a second policy claim: the title above already says what the policy is,
+        // this says who chose it. Withheld while a session or a settling write owns the display —
+        // those are the current authors, and naming a rule there would be wrong.
+        if (!settling && presentation != SessionPresentation.ACTIVE) {
+            state.conditions.activeRule?.let { rule ->
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    stringResource(R.string.dashboard_hero_condition, rule.displayTitle()),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
         }
         Spacer(Modifier.height(4.dp))
         Text(
@@ -958,6 +986,24 @@ private fun DashboardScreenPreview() = PreviewWrapper {
                 outcome = InterruptionOutcome.RESTORED_LATE,
                 workId = "preview",
             ),
+            // A condition currently holding the 80% limit — renders both the conditions card and the
+            // hero's provenance line, which agree with the verified policy below.
+            conditions = ConditionsState(
+                rules = listOf(
+                    ChargeRule(
+                        id = "desk",
+                        label = "Desk",
+                        condition = RuleCondition.BluetoothDevice("AA:BB:CC:DD:EE:FF", "Desk speaker"),
+                        policyId = ChargePolicy.FixedLimit(80).stableId,
+                    ),
+                ),
+                runtime = RuleRuntimeState(
+                    phase = RulePhase.ACTIVE,
+                    activeRuleId = "desk",
+                    targetPolicyId = ChargePolicy.FixedLimit(80).stableId,
+                    baselinePolicyId = ChargePolicy.Adaptive.stableId,
+                ),
+            ),
             // Held at the 80% limit: paired with the policy so the reading reads as the effect.
             batteryReadout = BatteryReadout(
                 levelPercent = 80,
@@ -1001,6 +1047,7 @@ private fun DashboardScreenPreview() = PreviewWrapper {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},
@@ -1095,6 +1142,7 @@ private fun DashboardScreenLiveChargePreview() = PreviewWrapper {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},
@@ -1169,6 +1217,7 @@ private fun DashboardScreenHwUnconfirmedPreview() = PreviewWrapper {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},
@@ -1241,6 +1290,7 @@ private fun DashboardScreenApplyingPreview() = PreviewWrapper {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},
@@ -1324,6 +1374,7 @@ private fun DashboardScreenAwaitingReplugPreview() = PreviewWrapper {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},
@@ -1393,6 +1444,7 @@ private fun DashboardScreenSessionActivePreview() = PreviewWrapper {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},
@@ -1464,6 +1516,7 @@ private fun DashboardScreenSessionRecordedPreview() = PreviewWrapper {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},
@@ -1523,6 +1576,7 @@ private fun DashboardScreenWssOnlyPreview() = PreviewWrapper {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},
@@ -1596,6 +1650,7 @@ private fun DashboardScreenSamsungPreview() = PreviewWrapper {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},
@@ -1663,6 +1718,7 @@ private fun DashboardScreenOnePlusNeedsShizukuPreview() = PreviewWrapper {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},
@@ -1718,6 +1774,7 @@ private fun DashboardScreenUnsupportedPreview() = PreviewWrapper {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
@@ -57,6 +57,10 @@ import eu.darken.amply.alarm.core.ChargeAlarmStore
 import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.battery.core.BatteryReadoutSource
 import eu.darken.amply.monitor.core.ChargeMonitorWatcher
+import eu.darken.amply.rules.core.ChargeRule
+import eu.darken.amply.rules.core.RuleApplier
+import eu.darken.amply.rules.core.RulePhase
+import eu.darken.amply.rules.core.RuleRuntimeState
 import eu.darken.amply.stats.core.CaptureServiceHealth
 import eu.darken.amply.stats.core.ChargeSessionSummary
 import eu.darken.amply.stats.core.ChargeStatsRepository
@@ -107,6 +111,8 @@ data class DashboardUiState(
     val stats: StatsDashboardState = StatsDashboardState(),
     /** A pending "Amply was interrupted while owing a restore" warning, or null when there is none. */
     val interruption: InterruptionEvent? = null,
+    /** The conditional charge rules and which one, if any, currently owns the policy. */
+    val conditions: ConditionsState = ConditionsState(),
     /**
      * The Pro entitlement, or null until it has been read at all. Nullable rather than defaulted:
      * "not upgraded" and "not yet known" have to stay distinguishable, or the promo card would flash
@@ -120,6 +126,25 @@ data class UpgradeSnapshot(
     val isPro: Boolean,
     val isSettled: Boolean,
 )
+
+/**
+ * The dashboard's slice of the charge-conditions layer. Order is meaning — the topmost matching rule
+ * wins — so the list is kept exactly as stored and the active rule is resolved by id rather than by
+ * re-deriving which one "should" be winning.
+ */
+data class ConditionsState(
+    val rules: List<ChargeRule> = emptyList(),
+    val runtime: RuleRuntimeState = RuleRuntimeState(),
+) {
+    val enabledRules: List<ChargeRule> get() = rules.filter { it.enabled }
+
+    val activeRule: ChargeRule?
+        get() = runtime.activeRuleId
+            ?.takeIf { runtime.phase != RulePhase.IDLE }
+            ?.let { id -> rules.firstOrNull { it.id == id } }
+
+    val applyFailed: Boolean get() = runtime.lastApplyFailed
+}
 
 /**
  * The upgrade ask — currently the Pro badges, and the promo card once it returns — has no business
@@ -143,6 +168,7 @@ class DashboardViewModel @Inject constructor(
     private val captureServiceHealth: CaptureServiceHealth,
     private val interruptionStore: InterruptionStore,
     private val upgradeRepo: UpgradeRepo,
+    private val ruleApplier: RuleApplier,
     private val watchers: Set<@JvmSuppressWildcards ChargeMonitorWatcher>,
 ) : ViewModel() {
     private val deviceReport = MutableStateFlow<DeviceSupportReport?>(null)
@@ -160,26 +186,35 @@ class DashboardViewModel @Inject constructor(
         fullChargeStore.quickFullChargeAnyLevel.flow,
     ) { enabled, anyLevel -> enabled to anyLevel }
 
+    // Seeded null so the dashboard renders immediately: waiting for the first billing answer would
+    // hold up the whole screen, and the promo card is the only thing that needs it.
+    private val upgradeSnapshots = upgradeRepo.upgradeInfo
+        .map<UpgradeRepo.Info, UpgradeSnapshot?> { UpgradeSnapshot(isPro = it.isPro, isSettled = it.isSettled) }
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, Logging.Priority.WARN) { "Upgrade info read failed: ${e.message}" }
+            emit(null)
+        }
+        .onStart { emit(null) }
+        .distinctUntilChanged()
+
+    // Paired with the entitlement rather than taking its own slot: the typed combine overloads stop
+    // at five, and these two are the ones the same cards read together anyway.
+    private val upgradeAndConditions = combine(
+        upgradeSnapshots,
+        combine(ruleApplier.rules, ruleApplier.runtime) { rules, runtime -> ConditionsState(rules, runtime) },
+    ) { upgrade, conditions -> upgrade to conditions }
+
     // Grouped so the outer combine keeps one slot each: the live battery readout, the alarm config,
-    // the notifications-blocked flag, the interrupted-session warning, and the entitlement.
+    // the notifications-blocked flag, the interrupted-session warning, and the entitlement + rules.
     private val unprivilegedExtras = combine(
         batteryReadoutSource.readouts(),
         chargeAlarmStore.config,
         notificationsBlocked,
         interruptionStore.event,
-        // Seeded null so the dashboard renders immediately: waiting for the first billing answer
-        // would hold up the whole screen, and the promo card is the only thing that needs it.
-        upgradeRepo.upgradeInfo
-            .map<UpgradeRepo.Info, UpgradeSnapshot?> { UpgradeSnapshot(isPro = it.isPro, isSettled = it.isSettled) }
-            .catch { e ->
-                if (e is CancellationException) throw e
-                log(TAG, Logging.Priority.WARN) { "Upgrade info read failed: ${e.message}" }
-                emit(null)
-            }
-            .onStart { emit(null) }
-            .distinctUntilChanged(),
-    ) { readout, alarm, blocked, interruption, upgrade ->
-        UnprivilegedExtras(readout, alarm, blocked, interruption, upgrade)
+        upgradeAndConditions,
+    ) { readout, alarm, blocked, interruption, (upgrade, conditions) ->
+        UnprivilegedExtras(readout, alarm, blocked, interruption, upgrade, conditions)
     }
 
     private data class UnprivilegedExtras(
@@ -188,6 +223,7 @@ class DashboardViewModel @Inject constructor(
         val notificationsBlocked: Boolean,
         val interruption: InterruptionEvent?,
         val upgrade: UpgradeSnapshot?,
+        val conditions: ConditionsState,
     )
 
     // Battery-statistics dashboard teaser. The session/count reads (which open the stats Room DB)
@@ -233,6 +269,7 @@ class DashboardViewModel @Inject constructor(
             notificationsBlocked = extras.notificationsBlocked,
             interruption = extras.interruption,
             upgrade = extras.upgrade,
+            conditions = extras.conditions,
             stats = stats,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), DashboardUiState())

--- a/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsDestination.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsDestination.kt
@@ -11,6 +11,15 @@ enum class SettingsDestination {
     CHARGING,
 
     /**
+     * The conditional charge rules. Reached from the dashboard card *and* the settings hub, so it
+     * records where to return to — see `rulesOrigin` at the composition root.
+     */
+    CHARGE_RULES,
+
+    /** The single-rule editor, always entered from (and returning to) [CHARGE_RULES]. */
+    CHARGE_RULE_EDIT,
+
+    /**
      * The recording **preferences** — the capture switch and the retention window — reached from the
      * settings hub. Not to be confused with [CHARGE_HISTORY], which is the recorded data itself.
      */

--- a/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsScreen.kt
@@ -5,13 +5,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.automirrored.twotone.OpenInNew
+import androidx.compose.material.icons.automirrored.twotone.Rule
 import androidx.compose.material.icons.automirrored.twotone.ShowChart
 import androidx.compose.material.icons.twotone.Bolt
 import androidx.compose.material.icons.twotone.Book
 import androidx.compose.material.icons.twotone.BugReport
 import androidx.compose.material.icons.twotone.Favorite
 import androidx.compose.material.icons.twotone.History
-import androidx.compose.material.icons.twotone.Rule
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.SupportAgent
@@ -113,7 +113,7 @@ fun SettingsScreen(
                     } else {
                         stringResource(R.string.settings_rules_subtitle_off)
                     },
-                    icon = Icons.TwoTone.Rule,
+                    icon = Icons.AutoMirrored.TwoTone.Rule,
                     onClick = onChargeRules,
                     // The row stays open to everyone: switching a rule off, or deleting it, must
                     // never sit behind the gate.

--- a/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.twotone.Book
 import androidx.compose.material.icons.twotone.BugReport
 import androidx.compose.material.icons.twotone.Favorite
 import androidx.compose.material.icons.twotone.History
+import androidx.compose.material.icons.twotone.Rule
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.SupportAgent
@@ -45,6 +46,8 @@ fun SettingsScreen(
     onGeneral: () -> Unit,
     gestureEnabled: Boolean,
     onCharging: () -> Unit,
+    activeRuleCount: Int,
+    onChargeRules: () -> Unit,
     captureEnabled: Boolean,
     onChargingHistory: () -> Unit,
     showDiagnostics: Boolean,
@@ -99,6 +102,22 @@ fun SettingsScreen(
                     },
                     icon = Icons.TwoTone.Bolt,
                     onClick = onCharging,
+                )
+            }
+            item { SettingsDivider() }
+            item {
+                SettingsBaseItem(
+                    title = stringResource(R.string.settings_rules_title),
+                    subtitle = if (activeRuleCount > 0) {
+                        stringResource(R.string.settings_rules_subtitle_on, activeRuleCount)
+                    } else {
+                        stringResource(R.string.settings_rules_subtitle_off)
+                    },
+                    icon = Icons.TwoTone.Rule,
+                    onClick = onChargeRules,
+                    // The row stays open to everyone: switching a rule off, or deleting it, must
+                    // never sit behind the gate.
+                    trailingContent = { if (showProBadge) ProBadge() },
                 )
             }
             item { SettingsDivider() }
@@ -214,6 +233,8 @@ private fun SettingsScreenPreview() = PreviewWrapper {
         onGeneral = {},
         gestureEnabled = true,
         onCharging = {},
+        activeRuleCount = 2,
+        onChargeRules = {},
         captureEnabled = true,
         onChargingHistory = {},
         showDiagnostics = true,
@@ -238,6 +259,8 @@ private fun SettingsScreenUpgradedPreview() = PreviewWrapper {
         onGeneral = {},
         gestureEnabled = true,
         onCharging = {},
+        activeRuleCount = 2,
+        onChargeRules = {},
         captureEnabled = true,
         onChargingHistory = {},
         showDiagnostics = false,

--- a/app/src/main/java/eu/darken/amply/rules/core/BluetoothConnections.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/BluetoothConnections.kt
@@ -81,6 +81,13 @@ class AndroidBluetoothConnectionSource @Inject constructor(
         }
     }
 
+    /**
+     * All-or-nothing by design. A partial union is worse than no answer at all: the caller REPLACES
+     * the receiver-maintained snapshot with what this returns, so a profile that timed out or failed
+     * would silently read as "nothing connected on that profile" and drop a device that is still
+     * there — deactivating its rule and restoring the baseline on the strength of a missing answer.
+     * Null instead keeps the snapshot the ACL broadcasts built, which is the honest fallback.
+     */
     @SuppressLint("MissingPermission")
     override suspend fun connectedAddresses(): Set<String>? {
         if (!hasPermission()) return null
@@ -89,15 +96,24 @@ class AndroidBluetoothConnectionSource @Inject constructor(
         // Bluetooth off means nothing is connected — a positive answer, not an unknown one.
         if (!runCatching { adapter.isEnabled }.getOrDefault(false)) return emptySet()
 
-        val connected = mutableSetOf<String>()
         // GATT is answerable straight off the manager, without a proxy round-trip.
-        runCatching { manager.getConnectedDevices(BluetoothProfile.GATT) }
-            .getOrNull()
-            ?.forEach { connected += normalizeBtAddress(it.address) }
+        val gatt = runCatching {
+            manager.getConnectedDevices(BluetoothProfile.GATT).orEmpty()
+                .map { normalizeBtAddress(it.address) }
+                .toSet()
+        }.getOrElse {
+            log(TAG, Logging.Priority.WARN) { "GATT connection query failed: ${it.message}" }
+            return null
+        }
 
+        val connected = gatt.toMutableSet()
         PROXY_PROFILES.forEach { profile ->
-            withTimeoutOrNull(PROXY_BUDGET_MILLIS) { proxyConnected(adapter, profile) }
-                ?.let { connected += it }
+            val addresses = withTimeoutOrNull(PROXY_BUDGET_MILLIS) { proxyConnected(adapter, profile) }
+            if (addresses == null) {
+                log(TAG, Logging.Priority.WARN) { "Profile $profile did not answer; skipping reconciliation" }
+                return null
+            }
+            connected += addresses
         }
         return connected
     }
@@ -107,9 +123,11 @@ class AndroidBluetoothConnectionSource @Inject constructor(
         suspendCancellableCoroutine { continuation ->
             val listener = object : BluetoothProfile.ServiceListener {
                 override fun onServiceConnected(which: Int, proxy: BluetoothProfile) {
+                    // A failed read resumes null, never an empty set: the caller replaces the whole
+                    // snapshot with this answer, so "couldn't read" must not look like "none".
                     val addresses = runCatching {
                         proxy.connectedDevices.orEmpty().map { normalizeBtAddress(it.address) }.toSet()
-                    }.getOrDefault(emptySet())
+                    }.getOrNull()
                     runCatching { adapter.closeProfileProxy(which, proxy) }
                     if (continuation.isActive) continuation.resume(addresses)
                 }

--- a/app/src/main/java/eu/darken/amply/rules/core/BluetoothConnections.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/BluetoothConnections.kt
@@ -1,0 +1,135 @@
+package eu.darken.amply.rules.core
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.amply.common.debug.logging.Logging
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+
+/** A bonded device, as the rule editor offers it. */
+data class BondedDevice(
+    val address: String,
+    val name: String?,
+)
+
+/**
+ * The Bluetooth facts the rules layer needs, behind an interface so the applier's permission and
+ * boot-count invalidation logic is JVM-testable.
+ */
+interface BluetoothConnectionSource {
+
+    /** BLUETOOTH_CONNECT (API 31+); install-time below that. */
+    fun hasPermission(): Boolean
+
+    /**
+     * Best-effort per-address reconciliation of what is connected right now. Null means "could not
+     * be resolved" — the caller then keeps the receiver-maintained snapshot rather than concluding
+     * that nothing is connected.
+     */
+    suspend fun connectedAddresses(): Set<String>?
+
+    fun bondedDevices(): List<BondedDevice>
+}
+
+/**
+ * Reconciliation exists because the ACL connect/disconnect broadcasts are the only *live* signal and
+ * they are missed whenever Amply's process is not around to receive them (a fresh boot, a force-stop,
+ * a broadcast dropped under load). Android exposes no "everything connected" query, so this asks the
+ * profile proxies Amply's rules can plausibly ride on and unions the answers.
+ *
+ * Everything here is bounded and failure-tolerant: an unavailable adapter, a denied permission or a
+ * proxy that never connects yields a partial or null answer, never a stall.
+ */
+@Singleton
+class AndroidBluetoothConnectionSource @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : BluetoothConnectionSource {
+
+    private val manager: BluetoothManager?
+        get() = runCatching { context.getSystemService(BluetoothManager::class.java) }.getOrNull()
+
+    override fun hasPermission(): Boolean = Build.VERSION.SDK_INT < 31 ||
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.BLUETOOTH_CONNECT,
+        ) == PackageManager.PERMISSION_GRANTED
+
+    @SuppressLint("MissingPermission")
+    override fun bondedDevices(): List<BondedDevice> {
+        if (!hasPermission()) return emptyList()
+        val adapter = manager?.adapter ?: return emptyList()
+        return runCatching {
+            adapter.bondedDevices.orEmpty().map {
+                BondedDevice(address = normalizeBtAddress(it.address), name = it.name)
+            }
+        }.getOrElse {
+            log(TAG, Logging.Priority.WARN) { "Bonded device listing failed: ${it.message}" }
+            emptyList()
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    override suspend fun connectedAddresses(): Set<String>? {
+        if (!hasPermission()) return null
+        val manager = manager ?: return null
+        val adapter = manager.adapter ?: return null
+        // Bluetooth off means nothing is connected — a positive answer, not an unknown one.
+        if (!runCatching { adapter.isEnabled }.getOrDefault(false)) return emptySet()
+
+        val connected = mutableSetOf<String>()
+        // GATT is answerable straight off the manager, without a proxy round-trip.
+        runCatching { manager.getConnectedDevices(BluetoothProfile.GATT) }
+            .getOrNull()
+            ?.forEach { connected += normalizeBtAddress(it.address) }
+
+        PROXY_PROFILES.forEach { profile ->
+            withTimeoutOrNull(PROXY_BUDGET_MILLIS) { proxyConnected(adapter, profile) }
+                ?.let { connected += it }
+        }
+        return connected
+    }
+
+    @SuppressLint("MissingPermission")
+    private suspend fun proxyConnected(adapter: BluetoothAdapter, profile: Int): Set<String>? =
+        suspendCancellableCoroutine { continuation ->
+            val listener = object : BluetoothProfile.ServiceListener {
+                override fun onServiceConnected(which: Int, proxy: BluetoothProfile) {
+                    val addresses = runCatching {
+                        proxy.connectedDevices.orEmpty().map { normalizeBtAddress(it.address) }.toSet()
+                    }.getOrDefault(emptySet())
+                    runCatching { adapter.closeProfileProxy(which, proxy) }
+                    if (continuation.isActive) continuation.resume(addresses)
+                }
+
+                override fun onServiceDisconnected(which: Int) {
+                    if (continuation.isActive) continuation.resume(null)
+                }
+            }
+            val requested = runCatching { adapter.getProfileProxy(context, listener, profile) }
+                .getOrDefault(false)
+            if (!requested && continuation.isActive) continuation.resume(null)
+        }
+
+    companion object {
+        private val TAG = logTag("Rules", "Bluetooth")
+
+        /** The profiles a "device is connected" rule realistically rides on. */
+        private val PROXY_PROFILES = listOf(BluetoothProfile.A2DP, BluetoothProfile.HEADSET)
+
+        /** Per-profile budget: this runs on a service-start evaluation, never on the hot path. */
+        private const val PROXY_BUDGET_MILLIS = 2_000L
+    }
+}

--- a/app/src/main/java/eu/darken/amply/rules/core/BluetoothRuleReceiver.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/BluetoothRuleReceiver.kt
@@ -1,0 +1,97 @@
+package eu.darken.amply.rules.core
+
+import android.bluetooth.BluetoothDevice
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.amply.common.debug.logging.Logging
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import eu.darken.amply.fullcharge.core.ChargeSessionService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * The only live signal for "is this device connected". Registered in the manifest so a connection
+ * that happens while Amply is not running still lands — the snapshot it writes is what the next
+ * evaluation reads, even if the service start below is refused.
+ *
+ * Deliberately limited to the two ACL actions: bond-state and adapter-state broadcasts say nothing
+ * about connectivity, and a wider filter would only cost wake-ups.
+ */
+@AndroidEntryPoint
+class BluetoothRuleReceiver : BroadcastReceiver() {
+
+    @Inject lateinit var applier: RuleApplier
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val update = parse(intent) ?: return
+        val appContext = context.applicationContext
+        val pending = goAsync()
+        CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
+            try {
+                handleUpdate(appContext, update)
+            } catch (e: Exception) {
+                log(TAG, Logging.Priority.ERROR) { "Bluetooth connection update failed: ${e.message}" }
+            } finally {
+                pending.finish()
+            }
+        }
+    }
+
+    internal suspend fun handleUpdate(context: Context, update: ConnectionUpdate) {
+        log(TAG) { "Bluetooth ${update.address} connected=${update.connected}" }
+        // Persisted first, unconditionally: the snapshot is the durable part, the nudge is best effort.
+        val relevant = applier.onBluetoothConnectionChanged(update.address, update.connected)
+        // Only wake the service when a rule actually rides on Bluetooth.
+        if (relevant) nudgeService(context)
+    }
+
+    /**
+     * A plain [Context.startService], not a foreground start: this fires from the background, where a
+     * foreground start is refused outright. The snapshot is already persisted, so a refused start
+     * costs latency only — the next service start reconciles from it.
+     */
+    private fun nudgeService(context: Context) {
+        try {
+            context.startService(
+                Intent(context, ChargeSessionService::class.java)
+                    .setAction(ChargeSessionService.ACTION_EVALUATE_RULES),
+            )
+        } catch (e: IllegalStateException) {
+            log(TAG) { "Rule evaluation nudge refused from the background: ${e.message}" }
+        } catch (e: Exception) {
+            log(TAG, Logging.Priority.WARN) { "Rule evaluation nudge failed: ${e.message}" }
+        }
+    }
+
+    internal data class ConnectionUpdate(val address: String, val connected: Boolean)
+
+    internal companion object {
+        private val TAG = logTag("Rules", "BtReceiver")
+
+        internal fun parse(intent: Intent): ConnectionUpdate? {
+            val connected = when (intent.action) {
+                BluetoothDevice.ACTION_ACL_CONNECTED -> true
+                BluetoothDevice.ACTION_ACL_DISCONNECTED -> false
+                else -> return null
+            }
+            val address = intent.deviceAddress() ?: return null
+            return ConnectionUpdate(address = address, connected = connected)
+        }
+
+        @Suppress("DEPRECATION")
+        private fun Intent.deviceAddress(): String? = runCatching {
+            if (Build.VERSION.SDK_INT >= 33) {
+                getParcelableExtra(BluetoothDevice.EXTRA_DEVICE, BluetoothDevice::class.java)
+            } else {
+                getParcelableExtra(BluetoothDevice.EXTRA_DEVICE) as BluetoothDevice?
+            }?.address
+        }.getOrNull()
+    }
+}

--- a/app/src/main/java/eu/darken/amply/rules/core/ChargeRule.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/ChargeRule.kt
@@ -1,0 +1,150 @@
+package eu.darken.amply.rules.core
+
+import eu.darken.amply.charging.core.ChargePolicy
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * The charger classes Android reports through `BatteryManager.EXTRA_PLUGGED`. Modelled as an enum
+ * rather than the raw bitmask so a stored rule keeps meaning if the platform adds a class.
+ */
+@Serializable
+enum class PlugKind {
+    @SerialName("AC") AC,
+
+    @SerialName("USB") USB,
+
+    @SerialName("WIRELESS") WIRELESS,
+
+    @SerialName("DOCK") DOCK,
+}
+
+/**
+ * What makes a rule apply. Sealed and polymorphic so the stored JSON carries an explicit subtype
+ * discriminator — a condition kind added later must not make an existing record ambiguous.
+ */
+@Serializable
+sealed interface RuleCondition {
+
+    /**
+     * Matches while a bonded Bluetooth device is connected, **regardless of plug state**: "when the
+     * car is connected" is a context, not a charging event. [address] is normalized uppercase (see
+     * [normalizeBtAddress]); [name] is a display convenience only and never participates in matching.
+     */
+    @Serializable
+    @SerialName("bluetooth")
+    data class BluetoothDevice(
+        @SerialName("address") val address: String,
+        @SerialName("name") val name: String? = null,
+    ) : RuleCondition
+
+    /**
+     * Matches only while plugged into one of [types]. An empty set matches nothing — the editor
+     * enforces at least one selection, and a hand-written empty record must not become a wildcard.
+     */
+    @Serializable
+    @SerialName("charger")
+    data class ChargerType(
+        @SerialName("types") val types: Set<PlugKind> = emptySet(),
+    ) : RuleCondition
+}
+
+/**
+ * One conditional charge rule. [policyId] is the raw [ChargePolicy.stableId] rather than a decoded
+ * policy: a rule written on a device whose adapter offers a policy this build cannot read must not
+ * take the whole rule set down with it — it decodes to null and is skipped (see [ChargeRule.policy]).
+ */
+@Serializable
+data class ChargeRule(
+    @SerialName("id") val id: String,
+    @SerialName("enabled") val enabled: Boolean = true,
+    @SerialName("label") val label: String = "",
+    @SerialName("condition") val condition: RuleCondition,
+    @SerialName("policyId") val policyId: String,
+)
+
+@Serializable
+data class ChargeRuleSet(
+    @SerialName("rules") val rules: List<ChargeRule> = emptyList(),
+)
+
+/**
+ * A rule's kind is **derived**, never stored: a rule that writes a policy reaching 100% is a charge
+ * rule, anything else is a protection rule. Storing it would let the label and the policy disagree.
+ */
+enum class RuleKind {
+    PROTECTION,
+    CHARGE,
+}
+
+val ChargeRule.policy: ChargePolicy?
+    get() = ChargePolicy.fromStableId(policyId)
+
+/** Null when [policyId] cannot be decoded by this build — such a rule never matches. */
+val ChargeRule.kind: RuleKind?
+    get() = policy?.let { if (it.allowsFullCharge) RuleKind.CHARGE else RuleKind.PROTECTION }
+
+/** Bluetooth addresses are compared case-insensitively; store and match on one canonical form. */
+fun normalizeBtAddress(address: String): String = address.trim().uppercase()
+
+/** Where the rules layer is in its crash-safe write-ahead transition. */
+@Serializable
+enum class RulePhase {
+    /** No rule owns the charging policy. */
+    @SerialName("IDLE") IDLE,
+
+    /** An activation/switch write was persisted but has not been confirmed successful. */
+    @SerialName("APPLY_PENDING") APPLY_PENDING,
+
+    /** A rule owns the charging policy; [RuleRuntimeState.baselinePolicyId] is owed back. */
+    @SerialName("ACTIVE") ACTIVE,
+
+    /** A restore write was persisted but has not been confirmed successful. */
+    @SerialName("RESTORE_PENDING") RESTORE_PENDING,
+}
+
+/**
+ * The rules layer's durable runtime bookkeeping.
+ *
+ * Policies are held as raw stable-id strings for the same reason `ChargingPreferences` does it:
+ * these fields degrade *independently*, and the one that matters most — [baselinePolicyId], the
+ * user's own policy the rules layer owes back — must survive a neighbouring field being unreadable.
+ * Decoding therefore goes through [decodeRuleRuntimeState] field by field.
+ */
+@Serializable
+data class RuleRuntimeState(
+    @SerialName("phase") val phase: RulePhase = RulePhase.IDLE,
+    /** The policy the in-flight write is aiming at (activation target, or the restore baseline). */
+    @SerialName("targetPolicyId") val targetPolicyId: String? = null,
+    @SerialName("activeRuleId") val activeRuleId: String? = null,
+    /** The user's policy from before the first activation, owed back on deactivation. */
+    @SerialName("baselinePolicyId") val baselinePolicyId: String? = null,
+    /**
+     * Rules that were matching when the user (or something external) overrode the rules layer. No
+     * activation happens while any of them still matches; the cohort clears when none of them do.
+     */
+    @SerialName("suspendedRuleIds") val suspendedRuleIds: Set<String> = emptySet(),
+    /** The last rule write failed; the ~30s monitor tick retries and the UI shows a warning. */
+    @SerialName("lastApplyFailed") val lastApplyFailed: Boolean = false,
+) {
+    val targetPolicy: ChargePolicy?
+        get() = ChargePolicy.fromStableId(targetPolicyId)
+
+    val baselinePolicy: ChargePolicy?
+        get() = ChargePolicy.fromStableId(baselinePolicyId)
+
+    val isPending: Boolean
+        get() = phase == RulePhase.APPLY_PENDING || phase == RulePhase.RESTORE_PENDING
+}
+
+/**
+ * The connected-Bluetooth set as the manifest receiver last saw it.
+ *
+ * [bootCount] scopes the snapshot to one boot: connections do not survive a reboot, and a stale set
+ * would keep a rule active for a device that is no longer there. A mismatch reads as empty.
+ */
+@Serializable
+data class BtConnectionSnapshot(
+    @SerialName("addresses") val addresses: Set<String> = emptySet(),
+    @SerialName("bootCount") val bootCount: Int? = null,
+)

--- a/app/src/main/java/eu/darken/amply/rules/core/ChargeRule.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/ChargeRule.kt
@@ -126,6 +126,14 @@ data class RuleRuntimeState(
     @SerialName("suspendedRuleIds") val suspendedRuleIds: Set<String> = emptySet(),
     /** The last rule write failed; the ~30s monitor tick retries and the UI shows a warning. */
     @SerialName("lastApplyFailed") val lastApplyFailed: Boolean = false,
+    /**
+     * Wall clock of the rules layer's last successful write, **copied from the shared write journal**
+     * (`ChargingPreferences.lastRequestedAt`) rather than sampled independently. Copying is what makes
+     * the comparison sound: a journal entry newer than this one is necessarily somebody else's write,
+     * whereas two independent clock reads could differ by a few milliseconds and make the rules layer
+     * look overwritten by itself. 0 = never written.
+     */
+    @SerialName("lastWriteAt") val lastWriteAt: Long = 0L,
 ) {
     val targetPolicy: ChargePolicy?
         get() = ChargePolicy.fromStableId(targetPolicyId)

--- a/app/src/main/java/eu/darken/amply/rules/core/ChargeRulesStore.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/ChargeRulesStore.kt
@@ -41,6 +41,7 @@ internal fun decodeRuleRuntimeState(raw: String?): RuleRuntimeState {
         baselinePolicyId = baselinePolicyId,
         suspendedRuleIds = obj.stringSet("suspendedRuleIds"),
         lastApplyFailed = obj.booleanOrDefault("lastApplyFailed"),
+        lastWriteAt = obj.longOrDefault("lastWriteAt"),
     )
 }
 
@@ -51,6 +52,9 @@ private fun JsonObject.stringOrNull(name: String): String? = primitiveOrNull(nam
 
 private fun JsonObject.booleanOrDefault(name: String, default: Boolean = false): Boolean =
     primitiveOrNull(name)?.takeUnless { it.isString }?.content?.toBooleanStrictOrNull() ?: default
+
+private fun JsonObject.longOrDefault(name: String, default: Long = 0L): Long =
+    primitiveOrNull(name)?.takeUnless { it.isString }?.content?.toLongOrNull() ?: default
 
 private fun JsonObject.stringSet(name: String): Set<String> = (this[name] as? JsonArray)
     ?.mapNotNull { (it as? JsonPrimitive)?.takeIf { p -> p.isString }?.content }

--- a/app/src/main/java/eu/darken/amply/rules/core/ChargeRulesStore.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/ChargeRulesStore.kt
@@ -1,0 +1,125 @@
+package eu.darken.amply.rules.core
+
+import androidx.datastore.preferences.core.stringPreferencesKey
+import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.datastore.createValue
+import eu.darken.amply.common.datastore.value
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Field-by-field decode of the rules runtime, following the same reasoning as
+ * `ChargingPreferences.decodePolicyState`: this record carries **owed restore work** — the user's own
+ * charging policy that a rule temporarily replaced — and a whole-record fallback would let one
+ * unreadable field (a future phase name, a malformed suspension list) silently drop it, leaving the
+ * battery on a rule's policy with nothing left that knows to put it back.
+ *
+ * The one deliberately conservative reading: an unreadable [RuleRuntimeState.phase] alongside an
+ * activation still decodes as [RulePhase.ACTIVE], not IDLE. Claiming "no rule owns the policy" while
+ * a baseline is recorded is the only failure direction that loses work.
+ */
+internal fun decodeRuleRuntimeState(raw: String?): RuleRuntimeState {
+    if (raw == null) return RuleRuntimeState()
+    val obj = runCatching { Json.parseToJsonElement(raw) as? JsonObject }.getOrNull() ?: return RuleRuntimeState()
+    val activeRuleId = obj.stringOrNull("activeRuleId")
+    val baselinePolicyId = obj.stringOrNull("baselinePolicyId")
+    val phase = obj.stringOrNull("phase")
+        ?.let { name -> RulePhase.entries.firstOrNull { it.name == name } }
+        ?: if (activeRuleId != null || baselinePolicyId != null) RulePhase.ACTIVE else RulePhase.IDLE
+    return RuleRuntimeState(
+        phase = phase,
+        targetPolicyId = obj.stringOrNull("targetPolicyId"),
+        activeRuleId = activeRuleId,
+        baselinePolicyId = baselinePolicyId,
+        suspendedRuleIds = obj.stringSet("suspendedRuleIds"),
+        lastApplyFailed = obj.booleanOrDefault("lastApplyFailed"),
+    )
+}
+
+private fun JsonObject.primitiveOrNull(name: String): JsonPrimitive? =
+    (this[name] as? JsonPrimitive)?.takeUnless { it is JsonNull }
+
+private fun JsonObject.stringOrNull(name: String): String? = primitiveOrNull(name)?.takeIf { it.isString }?.content
+
+private fun JsonObject.booleanOrDefault(name: String, default: Boolean = false): Boolean =
+    primitiveOrNull(name)?.takeUnless { it.isString }?.content?.toBooleanStrictOrNull() ?: default
+
+private fun JsonObject.stringSet(name: String): Set<String> = (this[name] as? JsonArray)
+    ?.mapNotNull { (it as? JsonPrimitive)?.takeIf { p -> p.isString }?.content }
+    ?.toSet()
+    .orEmpty()
+
+/**
+ * Persistence for the conditional charge rules, their runtime bookkeeping, and the Bluetooth
+ * connected-set the manifest receiver maintains. Three separate keys on purpose: the receiver writes
+ * the Bluetooth set on a completely different cadence than the user edits rules, and the runtime
+ * changes on every activation — folding them together would wake every collector on each.
+ *
+ * The mutators are `internal` and are called **only** from `RuleApplier`, which serializes every
+ * mutation and every evaluation under one mutex. Editing the rule set outside that lock could
+ * interleave with an in-flight activation and strand the runtime pointing at a rule that no longer
+ * exists.
+ */
+@Singleton
+class ChargeRulesStore @Inject constructor(
+    dataStore: AppDataStore,
+    json: Json,
+) {
+    // A rule set is read as a unit, and an unparseable one means "no rules" — which only ever removes
+    // overrides, never adds one — so the whole-record fallback is the safe reading here.
+    private val ruleSetValue = dataStore.createValue(
+        key = "rules.set.v1",
+        defaultValue = ChargeRuleSet(),
+        json = json,
+        fallbackToDefault = true,
+    )
+
+    private val runtimeValue = dataStore.createValue(
+        key = stringPreferencesKey("rules.runtime.v1"),
+        reader = { raw -> decodeRuleRuntimeState(raw as? String) },
+        writer = { state -> json.encodeToString(RuleRuntimeState.serializer(), state) },
+    )
+
+    private val btValue = dataStore.createValue(
+        key = "rules.bt.v1",
+        defaultValue = BtConnectionSnapshot(),
+        json = json,
+        fallbackToDefault = true,
+    )
+
+    val rules: Flow<List<ChargeRule>> = ruleSetValue.flow.map { it.rules.deduped() }.distinctUntilChanged()
+
+    val runtime: Flow<RuleRuntimeState> = runtimeValue.flow
+
+    suspend fun rulesNow(): List<ChargeRule> = ruleSetValue.value().rules.deduped()
+
+    suspend fun runtimeNow(): RuleRuntimeState = runtimeValue.value()
+
+    suspend fun btSnapshotNow(): BtConnectionSnapshot = btValue.value()
+
+    internal suspend fun updateRules(block: (List<ChargeRule>) -> List<ChargeRule>) {
+        ruleSetValue.update { current -> ChargeRuleSet(rules = block(current.rules.deduped()).deduped()) }
+    }
+
+    internal suspend fun updateRuntime(block: (RuleRuntimeState) -> RuleRuntimeState) {
+        runtimeValue.update(block)
+    }
+
+    internal suspend fun updateBtSnapshot(block: (BtConnectionSnapshot) -> BtConnectionSnapshot) {
+        btValue.update(block)
+    }
+}
+
+/**
+ * Ids address rules (the runtime points at one, reorder/delete resolve by it), so a duplicate would
+ * make "which rule" ambiguous. Keep the first occurrence — it is the higher-priority one.
+ */
+private fun List<ChargeRule>.deduped(): List<ChargeRule> = distinctBy { it.id }

--- a/app/src/main/java/eu/darken/amply/rules/core/RuleApplier.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/RuleApplier.kt
@@ -45,6 +45,9 @@ class RuleApplier @Inject constructor(
     val rules: Flow<List<ChargeRule>> = store.rules
     val runtime: Flow<RuleRuntimeState> = store.runtime
 
+    /** Point read for a one-shot caller (the editor loading a rule); collection is via [rules]. */
+    suspend fun rulesNow(): List<ChargeRule> = store.rulesNow()
+
     /** False on plug-latched adapters — the editor hides charger-type conditions there. */
     fun chargerTypeSupported(): Boolean = gateway.chargerTypeSupported()
 

--- a/app/src/main/java/eu/darken/amply/rules/core/RuleApplier.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/RuleApplier.kt
@@ -102,6 +102,10 @@ class RuleApplier @Inject constructor(
             ruleList.any { it.enabled && it.policy != null && it.matches(snapshot) }
         val configured = if (relevant) readConfigured() else null
         val lastPersistent = preferences.lastPersistentPolicyNow()
+        // The shared write journal: whatever Amply last wrote, from any component. Read as a pair so
+        // the policy and its timestamp can never be sampled either side of a concurrent write.
+        val lastRequestedPolicy = preferences.lastRequestedNow()
+        val lastRequestedAt = preferences.lastRequestedAtNow()
 
         val inputs = { proSettled: Boolean ->
             RuleEngine.evaluate(
@@ -113,6 +117,9 @@ class RuleApplier @Inject constructor(
                 proSettled = proSettled,
                 lastPersistent = lastPersistent,
                 defaultProtective = gateway.defaultProtectivePolicy(),
+                supportedPolicyIds = gateway.supportedPolicyIds(),
+                lastRequestedPolicy = lastRequestedPolicy,
+                lastRequestedAt = lastRequestedAt,
             )
         }
         // Resolve the entitlement only when the outcome actually depends on it: isProSettled() can
@@ -172,13 +179,17 @@ class RuleApplier @Inject constructor(
     }
 
     /**
-     * The user (or the widget/tile) just wrote a persistent policy: it outranks the rules layer, so
+     * The user (or the widget/tile) is writing a persistent policy: it outranks the rules layer, so
      * drop rule ownership without restoring and suspend **every** rule that currently matches. Only
      * the winner would be too narrow — the second-priority rule would re-apply over the same choice
      * on the very next tick.
      *
-     * Call this only *after* the write succeeded: a refused write leaves the user's intent unrealized,
-     * and suspending rules for it would disable them for nothing.
+     * Called *before* the write, alongside persisting the pending recovery target — not after it
+     * succeeds. Suspending ahead of the write is the safe order because that persisted target owns
+     * convergence to the explicit policy on every failure path (a failed write, a killed process, a
+     * reboot), so the end state is the explicit policy whether or not this particular write lands.
+     * Suspending afterwards would instead leave a window where the policy is already written and
+     * every rule is still armed to overwrite it on the next tick.
      */
     suspend fun suspendMatchingCohort(plugged: Boolean, plugKind: PlugKind?) = mutex.withLock {
         val ruleList = store.rulesNow()
@@ -310,7 +321,11 @@ class RuleApplier @Inject constructor(
             false
         }
         if (written) {
-            store.updateRuntime { onSuccess(it).copy(lastApplyFailed = false) }
+            // Stamped by COPYING the journal entry the repository just wrote, never from an
+            // independent clock read: the engine compares the two, and two separate `now`s could
+            // differ by milliseconds and make the rules layer look overwritten by its own write.
+            val stamp = preferences.lastRequestedAtNow()
+            store.updateRuntime { onSuccess(it).copy(lastApplyFailed = false, lastWriteAt = stamp) }
         } else {
             // Keep the pending phase: the write is still owed, and the 30s monitor tick retries it.
             log(TAG, Logging.Priority.ERROR) { "Rule write for ${policy.stableId} failed" }

--- a/app/src/main/java/eu/darken/amply/rules/core/RuleApplier.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/RuleApplier.kt
@@ -1,0 +1,370 @@
+package eu.darken.amply.rules.core
+
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.ChargingPreferences
+import eu.darken.amply.common.debug.logging.Logging
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import eu.darken.amply.fullcharge.core.BootCountProvider
+import eu.darken.amply.upgrade.core.UpgradeRepo
+import eu.darken.amply.upgrade.core.isProSettled
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The rules layer's single serialization point.
+ *
+ * **Every** rule-store mutation (the editor's CRUD, reorder, toggle; the Bluetooth receiver's
+ * snapshot update) and every evaluation runs under this one mutex. Without that, a rule deleted from
+ * the UI could interleave with an in-flight activation and leave the runtime owning a policy on
+ * behalf of a rule that no longer exists — with nothing left that knows to restore the baseline.
+ *
+ * It deliberately never takes the charge-session service's dispatch lock: the service calls in here,
+ * not the other way round, so there is exactly one lock ordering and no cycle.
+ *
+ * Transitions are **write-ahead**: the intended phase, target and baseline are persisted before the
+ * policy write and only finalized after it succeeds. A process death mid-write therefore leaves a
+ * pending phase that the next evaluation reconciles, rather than a lost baseline.
+ */
+@Singleton
+class RuleApplier @Inject constructor(
+    private val store: ChargeRulesStore,
+    private val gateway: RuleChargeGateway,
+    private val preferences: ChargingPreferences,
+    private val upgradeRepo: UpgradeRepo,
+    private val bluetooth: BluetoothConnectionSource,
+    private val bootCountProvider: BootCountProvider,
+) {
+    private val mutex = Mutex()
+
+    val rules: Flow<List<ChargeRule>> = store.rules
+    val runtime: Flow<RuleRuntimeState> = store.runtime
+
+    /** False on plug-latched adapters — the editor hides charger-type conditions there. */
+    fun chargerTypeSupported(): Boolean = gateway.chargerTypeSupported()
+
+    fun bondedDevices(): List<BondedDevice> = bluetooth.bondedDevices()
+
+    fun hasBluetoothPermission(): Boolean = bluetooth.hasPermission()
+
+    /**
+     * Whether the monitor service must stay alive for the rules layer. Owed work counts as much as
+     * an enabled rule: a pending write still has to be retried, and a suspension cohort still has to
+     * be observed stopping matching before rules may resume.
+     *
+     * Lock-free on purpose — this is polled from the service's keep-alive path and must never queue
+     * behind an in-flight evaluation.
+     */
+    suspend fun isServiceRequired(): Boolean {
+        if (store.rulesNow().any { it.enabled }) return true
+        val runtime = store.runtimeNow()
+        return runtime.phase != RulePhase.IDLE || runtime.suspendedRuleIds.isNotEmpty()
+    }
+
+    /**
+     * One evaluation pass: reconcile owed work, decide, act.
+     *
+     * [reconcileBluetooth] asks for the (bounded, best-effort) profile-proxy sweep instead of
+     * trusting the receiver-maintained snapshot. Only worth it when the process may have missed
+     * broadcasts — i.e. at service start — never on the 30s tick.
+     */
+    suspend fun evaluate(
+        plugged: Boolean,
+        plugKind: PlugKind?,
+        sessionActive: Boolean,
+        reconcileBluetooth: Boolean = false,
+    ) = mutex.withLock {
+        val ruleList = store.rulesNow()
+        val runtimeState = store.runtimeNow()
+        if (ruleList.none { it.enabled } && runtimeState.phase == RulePhase.IDLE &&
+            runtimeState.suspendedRuleIds.isEmpty()
+        ) {
+            return@withLock
+        }
+
+        val snapshot = ConditionSnapshot(
+            btAddresses = resolveBtAddresses(ruleList, reconcileBluetooth),
+            plugged = plugged,
+            plugKind = plugKind,
+            chargerTypeSupported = gateway.chargerTypeSupported(),
+        )
+        // Only pay for a readback when it can change the answer: an activation needs a baseline, and
+        // an active rule needs the divergence check. An idle layer with nothing matching needs neither.
+        val relevant = runtimeState.phase != RulePhase.IDLE ||
+            ruleList.any { it.enabled && it.policy != null && it.matches(snapshot) }
+        val configured = if (relevant) readConfigured() else null
+        val lastPersistent = preferences.lastPersistentPolicyNow()
+
+        val inputs = { proSettled: Boolean ->
+            RuleEngine.evaluate(
+                rules = ruleList,
+                snapshot = snapshot,
+                runtime = runtimeState,
+                configured = configured,
+                sessionActive = sessionActive,
+                proSettled = proSettled,
+                lastPersistent = lastPersistent,
+                defaultProtective = gateway.defaultProtectivePolicy(),
+            )
+        }
+        // Resolve the entitlement only when the outcome actually depends on it: isProSettled() can
+        // wait out a billing round-trip, which has no business running on every battery tick.
+        var decision = inputs(true)
+        if (decision.action is RuleAction.Activate || decision.action is RuleAction.Switch) {
+            if (!upgradeRepo.isProSettled()) {
+                log(TAG) { "Rule activation denied: no entitlement" }
+                decision = inputs(false)
+            }
+        }
+        perform(decision)
+    }
+
+    /** Receiver hook. Returns whether any enabled rule actually cares about Bluetooth. */
+    suspend fun onBluetoothConnectionChanged(address: String, connected: Boolean): Boolean = mutex.withLock {
+        val normalized = normalizeBtAddress(address)
+        val bootCount = bootCountProvider.current()
+        store.updateBtSnapshot { current ->
+            // A snapshot from a previous boot describes connections that cannot still exist.
+            val base = if (current.bootCount == bootCount) current.addresses else emptySet()
+            BtConnectionSnapshot(
+                addresses = if (connected) base + normalized else base - normalized,
+                bootCount = bootCount,
+            )
+        }
+        store.rulesNow().any { it.enabled && it.condition is RuleCondition.BluetoothDevice }
+    }
+
+    suspend fun addRule(rule: ChargeRule) = mutex.withLock {
+        store.updateRules { it + rule }
+    }
+
+    suspend fun updateRule(rule: ChargeRule) = mutex.withLock {
+        store.updateRules { rules -> rules.map { if (it.id == rule.id) rule else it } }
+    }
+
+    suspend fun deleteRule(id: String) = mutex.withLock {
+        store.updateRules { rules -> rules.filterNot { it.id == id } }
+    }
+
+    suspend fun setRuleEnabled(id: String, enabled: Boolean) = mutex.withLock {
+        store.updateRules { rules -> rules.map { if (it.id == id) it.copy(enabled = enabled) else it } }
+    }
+
+    /** Reorder by one position. Priority is the list order, so this is the whole priority editor. */
+    suspend fun moveRule(id: String, up: Boolean) = mutex.withLock {
+        store.updateRules { rules ->
+            val index = rules.indexOfFirst { it.id == id }
+            val target = index + if (up) -1 else 1
+            if (index < 0 || target !in rules.indices) {
+                rules
+            } else {
+                rules.toMutableList().apply { add(target, removeAt(index)) }
+            }
+        }
+    }
+
+    /**
+     * The user (or the widget/tile) just wrote a persistent policy: it outranks the rules layer, so
+     * drop rule ownership without restoring and suspend **every** rule that currently matches. Only
+     * the winner would be too narrow — the second-priority rule would re-apply over the same choice
+     * on the very next tick.
+     *
+     * Call this only *after* the write succeeded: a refused write leaves the user's intent unrealized,
+     * and suspending rules for it would disable them for nothing.
+     */
+    suspend fun suspendMatchingCohort(plugged: Boolean, plugKind: PlugKind?) = mutex.withLock {
+        val ruleList = store.rulesNow()
+        val snapshot = ConditionSnapshot(
+            btAddresses = resolveBtAddresses(ruleList, reconcile = false),
+            plugged = plugged,
+            plugKind = plugKind,
+            chargerTypeSupported = gateway.chargerTypeSupported(),
+        )
+        val cohort = ruleList.filter { it.enabled && it.policy != null && it.matches(snapshot) }
+            .map { it.id }
+            .toSet()
+        log(TAG, Logging.Priority.INFO) { "Explicit persistent write; suspending cohort $cohort" }
+        store.updateRuntime { RuleRuntimeState(suspendedRuleIds = cohort) }
+    }
+
+    /**
+     * The baseline a starting full-charge session must restore to, so the session — which is durable
+     * and survives process death — owns the user's true policy rather than the rules layer's
+     * transient override. Null when no rule owns the policy.
+     */
+    suspend fun readActiveBaseline(): ChargePolicy? = mutex.withLock {
+        store.runtimeNow().takeIf { it.phase != RulePhase.IDLE }?.baselinePolicy
+    }
+
+    /**
+     * Hand ownership to a session that is already persisted. Strictly after the session record
+     * exists: clearing first would open a window where neither the session nor the rules layer owes
+     * the baseline back.
+     */
+    suspend fun clearActiveAfterSessionPersist() = mutex.withLock {
+        store.updateRuntime { RuleRuntimeState(suspendedRuleIds = it.suspendedRuleIds) }
+    }
+
+    private suspend fun perform(decision: RuleDecision) {
+        val suspended = decision.suspendedRuleIds
+        when (val action = decision.action) {
+            is RuleAction.Noop -> store.updateRuntime { it.copy(suspendedRuleIds = suspended) }
+            is RuleAction.ClearActiveBookkeeping -> {
+                log(TAG) { "Dropping rule ownership without a write" }
+                store.updateRuntime { RuleRuntimeState(suspendedRuleIds = suspended) }
+            }
+            is RuleAction.AdoptExternal -> {
+                log(TAG, Logging.Priority.INFO) {
+                    "Configured policy changed outside the rules layer; adopting it and suspending ${action.cohort}"
+                }
+                store.updateRuntime { RuleRuntimeState(suspendedRuleIds = action.cohort) }
+            }
+            is RuleAction.Activate -> {
+                log(TAG, Logging.Priority.INFO) {
+                    "Rule ${action.rule.id} activating ${action.policy.stableId} over ${action.baseline.stableId}"
+                }
+                writeAhead(
+                    intent = RuleRuntimeState(
+                        phase = RulePhase.APPLY_PENDING,
+                        targetPolicyId = action.policy.stableId,
+                        activeRuleId = action.rule.id,
+                        baselinePolicyId = action.baseline.stableId,
+                        suspendedRuleIds = suspended,
+                    ),
+                    policy = action.policy,
+                    onSuccess = { it.copy(phase = RulePhase.ACTIVE) },
+                )
+            }
+            is RuleAction.Switch -> {
+                log(TAG, Logging.Priority.INFO) {
+                    "Rule ${action.rule.id} taking over with ${action.policy.stableId}"
+                }
+                writeAhead(
+                    intent = RuleRuntimeState(
+                        phase = RulePhase.APPLY_PENDING,
+                        targetPolicyId = action.policy.stableId,
+                        activeRuleId = action.rule.id,
+                        baselinePolicyId = action.baseline.stableId,
+                        suspendedRuleIds = suspended,
+                    ),
+                    policy = action.policy,
+                    onSuccess = { it.copy(phase = RulePhase.ACTIVE) },
+                )
+            }
+            is RuleAction.Restore -> {
+                log(TAG, Logging.Priority.INFO) { "No rule matches; restoring ${action.policy.stableId}" }
+                writeAhead(
+                    intent = RuleRuntimeState(
+                        phase = RulePhase.RESTORE_PENDING,
+                        targetPolicyId = action.policy.stableId,
+                        baselinePolicyId = action.policy.stableId,
+                        suspendedRuleIds = suspended,
+                    ),
+                    policy = action.policy,
+                    onSuccess = { RuleRuntimeState(suspendedRuleIds = it.suspendedRuleIds) },
+                )
+            }
+            is RuleAction.ReconcilePending -> {
+                log(TAG) { "Re-issuing the pending rule write for ${action.policy.stableId}" }
+                val pending = store.runtimeNow()
+                writeAhead(
+                    intent = pending.copy(suspendedRuleIds = suspended),
+                    policy = action.policy,
+                    onSuccess = { current ->
+                        if (current.phase == RulePhase.RESTORE_PENDING) {
+                            RuleRuntimeState(suspendedRuleIds = current.suspendedRuleIds)
+                        } else {
+                            current.copy(phase = RulePhase.ACTIVE)
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    /**
+     * Persist the intent, then write, then finalize. The order is the crash-safety property: a death
+     * between the two leaves a pending phase (retried on the next tick), never a policy the layer has
+     * silently forgotten it owes a restore for.
+     */
+    private suspend fun writeAhead(
+        intent: RuleRuntimeState,
+        policy: ChargePolicy,
+        onSuccess: (RuleRuntimeState) -> RuleRuntimeState,
+    ) {
+        store.updateRuntime { intent }
+        val written = try {
+            gateway.applyTemporary(policy)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, Logging.Priority.ERROR) { "Rule write for ${policy.stableId} threw: ${e.message}" }
+            false
+        }
+        if (written) {
+            store.updateRuntime { onSuccess(it).copy(lastApplyFailed = false) }
+        } else {
+            // Keep the pending phase: the write is still owed, and the 30s monitor tick retries it.
+            log(TAG, Logging.Priority.ERROR) { "Rule write for ${policy.stableId} failed" }
+            store.updateRuntime { it.copy(lastApplyFailed = true) }
+        }
+    }
+
+    private suspend fun readConfigured(): ChargeObservation? = try {
+        gateway.readConfigured()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        // Unreadable is a legitimate answer here: the engine falls back to the journal for a
+        // baseline and refuses to claim external divergence without a readback.
+        log(TAG, Logging.Priority.WARN) { "Configured readback failed: ${e.message}" }
+        null
+    }
+
+    /**
+     * The connected-Bluetooth set to evaluate against.
+     *
+     * A missing BLUETOOTH_CONNECT reads as **empty**, not as "unchanged": without it neither the
+     * receiver nor the proxies can observe anything, so keeping a stale set would hold a rule active
+     * for a device that may have been gone for hours. Empty deactivates and restores the baseline,
+     * which is the safe direction.
+     */
+    private suspend fun resolveBtAddresses(rules: List<ChargeRule>, reconcile: Boolean): Set<String> {
+        if (rules.none { it.enabled && it.condition is RuleCondition.BluetoothDevice }) return emptySet()
+        val bootCount = bootCountProvider.current()
+        if (!bluetooth.hasPermission()) {
+            log(TAG, Logging.Priority.WARN) { "Bluetooth permission missing; treating nothing as connected" }
+            store.updateBtSnapshot { BtConnectionSnapshot(bootCount = bootCount) }
+            return emptySet()
+        }
+        if (reconcile) {
+            val live = try {
+                bluetooth.connectedAddresses()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, Logging.Priority.WARN) { "Bluetooth reconciliation failed: ${e.message}" }
+                null
+            }
+            if (live != null) {
+                store.updateBtSnapshot { BtConnectionSnapshot(addresses = live, bootCount = bootCount) }
+                return live
+            }
+        }
+        val snapshot = store.btSnapshotNow()
+        if (snapshot.bootCount != bootCount) {
+            store.updateBtSnapshot { BtConnectionSnapshot(bootCount = bootCount) }
+            return emptySet()
+        }
+        return snapshot.addresses
+    }
+
+    private companion object {
+        val TAG = logTag("Rules", "Applier")
+    }
+}

--- a/app/src/main/java/eu/darken/amply/rules/core/RuleChargeGateway.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/RuleChargeGateway.kt
@@ -1,0 +1,62 @@
+package eu.darken.amply.rules.core
+
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.ChargingRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * The narrow slice of charging control the rules layer needs.
+ *
+ * It exists so `RuleApplier`'s one safety-critical property — the runtime intent is persisted
+ * **before** the policy write, never after — can be asserted on the JVM against a recording fake,
+ * instead of only being visible by reading the code.
+ */
+interface RuleChargeGateway {
+
+    /** Fresh configured readback, or null when this adapter cannot produce one (async-hardware). */
+    suspend fun readConfigured(): ChargeObservation?
+
+    /**
+     * Rule writes are always **temporary**: they must not touch `lastPersistentPolicy`, which is the
+     * user's own choice and the fallback baseline the rules layer restores to.
+     */
+    suspend fun applyTemporary(policy: ChargePolicy): Boolean
+
+    /** False on plug-latched adapters, where a charger-type condition could never take effect. */
+    fun chargerTypeSupported(): Boolean
+
+    /** Last-resort baseline when the current state is unreadable and Amply's journal is empty. */
+    fun defaultProtectivePolicy(): ChargePolicy
+}
+
+@Singleton
+class ChargingRuleGateway @Inject constructor(
+    private val repository: ChargingRepository,
+) : RuleChargeGateway {
+
+    // Adapter selection is immutable device information, but resolving it is not cheap (DeviceInfo
+    // queries activities, providers and UserManager). The session service caches it the same way.
+    private val adapterFacts by lazy {
+        val adapter = repository.currentAdapter()
+        AdapterFacts(
+            chargerTypeSupported = adapter?.policyLatchesAtPlug != true,
+            defaultProtective = adapter?.defaultProtectivePolicy ?: ChargePolicy.FixedLimit(80),
+        )
+    }
+
+    override suspend fun readConfigured(): ChargeObservation? = repository.syncReadback()
+
+    override suspend fun applyTemporary(policy: ChargePolicy): Boolean =
+        repository.applyTemporary(policy).success
+
+    override fun chargerTypeSupported(): Boolean = adapterFacts.chargerTypeSupported
+
+    override fun defaultProtectivePolicy(): ChargePolicy = adapterFacts.defaultProtective
+
+    private data class AdapterFacts(
+        val chargerTypeSupported: Boolean,
+        val defaultProtective: ChargePolicy,
+    )
+}

--- a/app/src/main/java/eu/darken/amply/rules/core/RuleChargeGateway.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/RuleChargeGateway.kt
@@ -29,6 +29,12 @@ interface RuleChargeGateway {
 
     /** Last-resort baseline when the current state is unreadable and Amply's journal is empty. */
     fun defaultProtectivePolicy(): ChargePolicy
+
+    /**
+     * Stable ids the selected adapter can actually apply. Empty when no adapter is selected, which
+     * the engine reads permissively — "not resolved" must not disable every rule.
+     */
+    fun supportedPolicyIds(): Set<String>
 }
 
 @Singleton
@@ -43,6 +49,7 @@ class ChargingRuleGateway @Inject constructor(
         AdapterFacts(
             chargerTypeSupported = adapter?.policyLatchesAtPlug != true,
             defaultProtective = adapter?.defaultProtectivePolicy ?: ChargePolicy.FixedLimit(80),
+            supportedPolicyIds = adapter?.supportedPolicies.orEmpty().map { it.stableId }.toSet(),
         )
     }
 
@@ -55,8 +62,11 @@ class ChargingRuleGateway @Inject constructor(
 
     override fun defaultProtectivePolicy(): ChargePolicy = adapterFacts.defaultProtective
 
+    override fun supportedPolicyIds(): Set<String> = adapterFacts.supportedPolicyIds
+
     private data class AdapterFacts(
         val chargerTypeSupported: Boolean,
         val defaultProtective: ChargePolicy,
+        val supportedPolicyIds: Set<String>,
     )
 }

--- a/app/src/main/java/eu/darken/amply/rules/core/RuleEngine.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/RuleEngine.kt
@@ -73,9 +73,24 @@ object RuleEngine {
         /** Amply's own journal of the user's last persistent choice; fallback baseline only. */
         lastPersistent: ChargePolicy?,
         defaultProtective: ChargePolicy,
+        /**
+         * Stable ids the selected adapter can actually apply. Empty means "not resolved yet", which
+         * is permissive — an unresolved adapter must not silently disable every rule.
+         */
+        supportedPolicyIds: Set<String>,
+        /** The last policy ANY Amply component wrote, and when, from the shared write journal. */
+        lastRequestedPolicy: ChargePolicy?,
+        lastRequestedAt: Long,
     ): RuleDecision {
         val byId = rules.associateBy { it.id }
-        val matching = rules.filter { it.enabled && it.policy != null && it.matches(snapshot) }
+        val matching = rules.filter {
+            it.enabled &&
+                it.policy != null &&
+                // A policy this adapter does not offer would be refused by the write path anyway;
+                // matching on it would park the layer in a permanently failing pending phase.
+                (supportedPolicyIds.isEmpty() || it.policyId in supportedPolicyIds) &&
+                it.matches(snapshot)
+        }
         // A suspended rule that no longer exists, is disabled, or no longer matches has served its
         // purpose: the user has moved on from the situation their manual override belonged to.
         val suspended = runtime.suspendedRuleIds.filter { id ->
@@ -134,22 +149,41 @@ object RuleEngine {
 
         if (ownsPolicy) {
             val baseline = runtime.baselinePolicy
-            // External divergence is only claimable against a real readback: without one, "different"
-            // is indistinguishable from "unreadable", and adopting on a guess would abandon a
-            // perfectly good rule activation. Only from a SETTLED activation, too — while a write is
-            // still pending, "configured != target" is the ordinary look of a write that failed or
-            // hasn't landed, and treating that as the user's choice would suspend every rule.
-            val verified = (configured as? ChargeObservation.Verified)?.policy
-                ?.takeIf { runtime.phase == RulePhase.ACTIVE }
+            // Divergence is claimed only from a SETTLED activation: while a write is still pending,
+            // "configured != target" is the ordinary look of a write that failed or hasn't landed,
+            // and treating that as the user's choice would suspend every rule.
+            val settledActive = runtime.phase == RulePhase.ACTIVE
             val written = runtime.targetPolicy ?: activeRule?.policy
-            if (verified != null && written != null && verified != written) {
-                // Adopt what is actually configured (no restore — the user's newer choice wins) and
-                // suspend every rule that currently matches, not just the winner: otherwise the
-                // second-priority rule would immediately re-apply over the same manual choice.
-                return RuleDecision(
-                    RuleAction.AdoptExternal(matching.map { it.id }.toSet()),
-                    matching.map { it.id }.toSet(),
-                )
+
+            // (1) The configured state itself contradicts what the rules layer wrote. A readable but
+            // UNRECOGNIZED value counts: the rules layer only ever writes values Amply can name, so
+            // an unnameable one is by definition somebody else's — and it must not be overwritten,
+            // which is exactly what carrying on as if the rule still owned the policy would do.
+            // Without any readback nothing is claimed: "different" would be indistinguishable from
+            // "unreadable", and adopting on a guess abandons a perfectly good activation.
+            val readbackDiverged = settledActive && when {
+                configured is ChargeObservation.Verified -> written != null && configured.policy != written
+                configured is ChargeObservation.Unknown -> configured.unrecognizedValue
+                else -> false
+            }
+
+            // (2) Amply's own write journal moved past the rules layer. Every write path — a session
+            // override or its restore, a failed override's rollback, boot-recovery rewrites, an
+            // explicit persistent policy — records into that journal (under NonCancellable, after
+            // the physical write), so an entry that is NEWER than this activation and names a
+            // DIFFERENT policy proves another component overwrote the rule's policy. This is the
+            // only divergence signal available on adapters that cannot read their state back at all.
+            val journalDiverged = settledActive &&
+                lastRequestedAt > runtime.lastWriteAt &&
+                lastRequestedPolicy != null &&
+                lastRequestedPolicy != runtime.targetPolicy
+
+            if (readbackDiverged || journalDiverged) {
+                // Adopt what is actually configured (no restore — the newer choice wins) and suspend
+                // every rule that currently matches, not just the winner: otherwise the
+                // second-priority rule would immediately re-apply over the same choice.
+                val cohort = matching.map { it.id }.toSet()
+                return RuleDecision(RuleAction.AdoptExternal(cohort), cohort)
             }
             if (baseline == null) {
                 // Nothing recorded to restore to: don't invent one, just drop the bookkeeping.
@@ -165,9 +199,8 @@ object RuleEngine {
                 return RuleDecision(action, suspended)
             }
             val targetPolicy = winner.policy!!
-            val settled = runtime.phase == RulePhase.ACTIVE
             // Also covers editing the active rule's policy: same rule, different target.
-            if (activeStillWins && settled && runtime.targetPolicyId == winner.policyId) {
+            if (activeStillWins && settledActive && runtime.targetPolicyId == winner.policyId) {
                 return RuleDecision(RuleAction.Noop, suspended)
             }
             return RuleDecision(RuleAction.Switch(winner, targetPolicy, baseline), suspended)

--- a/app/src/main/java/eu/darken/amply/rules/core/RuleEngine.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/RuleEngine.kt
@@ -74,8 +74,10 @@ object RuleEngine {
         lastPersistent: ChargePolicy?,
         defaultProtective: ChargePolicy,
         /**
-         * Stable ids the selected adapter can actually apply. Empty means "not resolved yet", which
-         * is permissive — an unresolved adapter must not silently disable every rule.
+         * Stable ids the selected adapter can actually apply. **Empty means the device can apply
+         * nothing** — the diagnostics-only lab adapters declare exactly that — so it is read
+         * strictly, never as "not resolved yet". A rule naming a policy outside this set can only
+         * ever produce a refused write.
          */
         supportedPolicyIds: Set<String>,
         /** The last policy ANY Amply component wrote, and when, from the shared write journal. */
@@ -83,20 +85,20 @@ object RuleEngine {
         lastRequestedAt: Long,
     ): RuleDecision {
         val byId = rules.associateBy { it.id }
-        val matching = rules.filter {
-            it.enabled &&
-                it.policy != null &&
-                // A policy this adapter does not offer would be refused by the write path anyway;
-                // matching on it would park the layer in a permanently failing pending phase.
-                (supportedPolicyIds.isEmpty() || it.policyId in supportedPolicyIds) &&
-                it.matches(snapshot)
-        }
-        // A suspended rule that no longer exists, is disabled, or no longer matches has served its
-        // purpose: the user has moved on from the situation their manual override belonged to.
-        val suspended = runtime.suspendedRuleIds.filter { id ->
-            val rule = byId[id]
-            rule != null && rule.enabled && rule.matches(snapshot)
-        }.toSet()
+        // One definition of "this rule is in play right now", used for both the winner selection and
+        // the suspension cohort: a rule that cannot act must neither activate NOR keep the cohort
+        // closed against the rules that can.
+        fun ChargeRule.isEffective() = enabled &&
+            policy != null &&
+            // A policy this adapter does not offer would be refused by the write path anyway;
+            // matching on it would park the layer in a permanently failing pending phase.
+            policyId in supportedPolicyIds &&
+            matches(snapshot)
+
+        val matching = rules.filter { it.isEffective() }
+        // A suspended rule that no longer exists, can no longer act, or no longer matches has served
+        // its purpose: the user has moved on from the situation their manual override belonged to.
+        val suspended = runtime.suspendedRuleIds.filter { id -> byId[id]?.isEffective() == true }.toSet()
         val blocked = suspended.isNotEmpty()
 
         // A live session outranks everything: it owns the policy and — via the baseline handed to

--- a/app/src/main/java/eu/darken/amply/rules/core/RuleEngine.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/RuleEngine.kt
@@ -1,0 +1,217 @@
+package eu.darken.amply.rules.core
+
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+
+/**
+ * Everything the engine is allowed to know about the world right now. Deliberately a value type with
+ * no Android in it: the whole precedence stack is decided here, on the JVM, and unit-tested directly.
+ *
+ * [chargerTypeSupported] is a capability, not a preference: on adapters whose ROM samples the policy
+ * only at plug time (`policyLatchesAtPlug`), a charger-type rule's write always lands *after* the
+ * sample and is restored before the next one, so it could never take effect. Such rules never match.
+ */
+data class ConditionSnapshot(
+    val btAddresses: Set<String> = emptySet(),
+    val plugged: Boolean = false,
+    val plugKind: PlugKind? = null,
+    val chargerTypeSupported: Boolean = true,
+)
+
+/** What the rules layer should do next. Exactly one action per evaluation pass. */
+sealed interface RuleAction {
+    data object Noop : RuleAction
+
+    /** Drop rule ownership without writing anything — a session or an external choice took over. */
+    data object ClearActiveBookkeeping : RuleAction
+
+    data class Activate(val rule: ChargeRule, val policy: ChargePolicy, val baseline: ChargePolicy) : RuleAction
+
+    /** A different (or edited) rule wins while one is already active; the baseline carries over. */
+    data class Switch(val rule: ChargeRule, val policy: ChargePolicy, val baseline: ChargePolicy) : RuleAction
+
+    /** No rule wins any more: write the recorded baseline back. */
+    data class Restore(val policy: ChargePolicy) : RuleAction
+
+    /** The configured policy diverged from what the rules layer wrote: adopt it and suspend. */
+    data class AdoptExternal(val cohort: Set<String>) : RuleAction
+
+    /** A persisted-but-unconfirmed write is still owed; re-issue it. */
+    data class ReconcilePending(val policy: ChargePolicy) : RuleAction
+}
+
+/**
+ * One evaluation's outcome. The suspension cohort rides along rather than needing its own action, so
+ * "these suspended rules stopped matching" and "therefore this rule may now activate" resolve in the
+ * SAME pass — a two-pass design would need a spare evaluation to make progress and could sit idle
+ * until the next 30s tick.
+ */
+data class RuleDecision(
+    val action: RuleAction,
+    val suspendedRuleIds: Set<String>,
+)
+
+/**
+ * The precedence stack, top wins: **active session > explicit user persistent write > external
+ * change > rules > baseline**.
+ *
+ * Pure by construction (no Android, no I/O, no clock): the applier collects the inputs, this decides,
+ * the applier performs. Every safety property worth testing — never overwrite a state Amply cannot
+ * restore, never claim a rule applied when the write failed, never re-activate over the user's own
+ * choice — is a property of this function.
+ */
+object RuleEngine {
+
+    fun evaluate(
+        rules: List<ChargeRule>,
+        snapshot: ConditionSnapshot,
+        runtime: RuleRuntimeState,
+        /** Fresh configured readback, or null when this adapter/device cannot produce one. */
+        configured: ChargeObservation?,
+        sessionActive: Boolean,
+        proSettled: Boolean,
+        /** Amply's own journal of the user's last persistent choice; fallback baseline only. */
+        lastPersistent: ChargePolicy?,
+        defaultProtective: ChargePolicy,
+    ): RuleDecision {
+        val byId = rules.associateBy { it.id }
+        val matching = rules.filter { it.enabled && it.policy != null && it.matches(snapshot) }
+        // A suspended rule that no longer exists, is disabled, or no longer matches has served its
+        // purpose: the user has moved on from the situation their manual override belonged to.
+        val suspended = runtime.suspendedRuleIds.filter { id ->
+            val rule = byId[id]
+            rule != null && rule.enabled && rule.matches(snapshot)
+        }.toSet()
+        val blocked = suspended.isNotEmpty()
+
+        // A live session outranks everything: it owns the policy and — via the baseline handed to
+        // ChargeSessionManager.begin — the restore too. Bookkeeping left ACTIVE here is the crash
+        // window between the session being persisted and the rules layer being cleared.
+        if (sessionActive) {
+            val action = if (runtime.phase != RulePhase.IDLE) {
+                RuleAction.ClearActiveBookkeeping
+            } else {
+                RuleAction.Noop
+            }
+            return RuleDecision(action, suspended)
+        }
+
+        val winner = matching.firstOrNull()
+        val activeRule = runtime.activeRuleId?.let { byId[it] }
+        val activeStillWins = activeRule != null && winner?.id == activeRule.id
+
+        // An unconfirmed write is owed before anything else is decided: the persisted intent says a
+        // policy may or may not have landed, and every other branch below assumes it knows what is
+        // configured.
+        if (runtime.isPending) {
+            val target = runtime.targetPolicy
+            when (runtime.phase) {
+                RulePhase.RESTORE_PENDING -> {
+                    // A rule winning again while a restore is owed makes the restore obsolete: write
+                    // the rule's policy instead, keeping the same baseline still owed underneath.
+                    val baseline = runtime.baselinePolicy ?: target
+                    if (winner != null && !blocked && proSettled && baseline != null) {
+                        return RuleDecision(
+                            RuleAction.Switch(winner, winner.policy!!, baseline),
+                            suspended,
+                        )
+                    }
+                    if (target != null) return RuleDecision(RuleAction.ReconcilePending(target), suspended)
+                }
+                RulePhase.APPLY_PENDING -> {
+                    // Still the winner: finish the write. Otherwise the pending transition is
+                    // obsolete and we fall through, treating the state as ACTIVE — the write may
+                    // have landed, so the baseline is still owed and must be resolved normally.
+                    if (activeStillWins && target != null) {
+                        return RuleDecision(RuleAction.ReconcilePending(target), suspended)
+                    }
+                }
+                else -> Unit
+            }
+        }
+
+        val ownsPolicy = runtime.phase != RulePhase.IDLE
+
+        if (ownsPolicy) {
+            val baseline = runtime.baselinePolicy
+            // External divergence is only claimable against a real readback: without one, "different"
+            // is indistinguishable from "unreadable", and adopting on a guess would abandon a
+            // perfectly good rule activation. Only from a SETTLED activation, too — while a write is
+            // still pending, "configured != target" is the ordinary look of a write that failed or
+            // hasn't landed, and treating that as the user's choice would suspend every rule.
+            val verified = (configured as? ChargeObservation.Verified)?.policy
+                ?.takeIf { runtime.phase == RulePhase.ACTIVE }
+            val written = runtime.targetPolicy ?: activeRule?.policy
+            if (verified != null && written != null && verified != written) {
+                // Adopt what is actually configured (no restore — the user's newer choice wins) and
+                // suspend every rule that currently matches, not just the winner: otherwise the
+                // second-priority rule would immediately re-apply over the same manual choice.
+                return RuleDecision(
+                    RuleAction.AdoptExternal(matching.map { it.id }.toSet()),
+                    matching.map { it.id }.toSet(),
+                )
+            }
+            if (baseline == null) {
+                // Nothing recorded to restore to: don't invent one, just drop the bookkeeping.
+                return RuleDecision(RuleAction.ClearActiveBookkeeping, suspended)
+            }
+            if (winner == null) return RuleDecision(RuleAction.Restore(baseline), suspended)
+            // A lapsed entitlement stops new activations and switches, but never a deactivation: the
+            // user's own baseline must always be restorable. An active rule that still matches keeps
+            // running — ending it would change the charging policy over a billing state.
+            if (!proSettled) {
+                val activeStillMatches = activeRule != null && matching.any { it.id == activeRule.id }
+                val action = if (activeStillMatches) RuleAction.Noop else RuleAction.Restore(baseline)
+                return RuleDecision(action, suspended)
+            }
+            val targetPolicy = winner.policy!!
+            val settled = runtime.phase == RulePhase.ACTIVE
+            // Also covers editing the active rule's policy: same rule, different target.
+            if (activeStillWins && settled && runtime.targetPolicyId == winner.policyId) {
+                return RuleDecision(RuleAction.Noop, suspended)
+            }
+            return RuleDecision(RuleAction.Switch(winner, targetPolicy, baseline), suspended)
+        }
+
+        if (winner == null || blocked || !proSettled) return RuleDecision(RuleAction.Noop, suspended)
+
+        val baseline = resolveBaseline(configured, lastPersistent, defaultProtective)
+            ?: return RuleDecision(RuleAction.Noop, suspended)
+        return RuleDecision(RuleAction.Activate(winner, winner.policy!!, baseline), suspended)
+    }
+
+    /**
+     * What the rules layer owes back once it stops applying.
+     *
+     * Order matters and is not interchangeable: a fresh readback of what is configured *right now*
+     * beats Amply's journal, which can be arbitrarily stale (the user may have changed the policy in
+     * the OEM's own settings since). The journal and the adapter default are used **only** when the
+     * current state is genuinely unreadable.
+     *
+     * Returns null for a readable-but-unrecognized native value: a mode Amply cannot name is a mode
+     * it cannot put back, and replacing it would silently destroy the user's configuration.
+     */
+    private fun resolveBaseline(
+        configured: ChargeObservation?,
+        lastPersistent: ChargePolicy?,
+        defaultProtective: ChargePolicy,
+    ): ChargePolicy? = when {
+        configured is ChargeObservation.Verified -> configured.policy
+        configured is ChargeObservation.Unknown && configured.unrecognizedValue -> null
+        else -> lastPersistent ?: defaultProtective
+    }
+}
+
+/**
+ * Whether this rule's condition holds right now. A rule whose policy this build cannot decode never
+ * matches — the caller filters on that before asking, and the winner selection relies on it.
+ */
+internal fun ChargeRule.matches(snapshot: ConditionSnapshot): Boolean = when (val test = condition) {
+    is RuleCondition.BluetoothDevice ->
+        snapshot.btAddresses.contains(normalizeBtAddress(test.address))
+    is RuleCondition.ChargerType ->
+        snapshot.chargerTypeSupported &&
+            snapshot.plugged &&
+            snapshot.plugKind != null &&
+            test.types.contains(snapshot.plugKind)
+}

--- a/app/src/main/java/eu/darken/amply/rules/core/RulesModule.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/RulesModule.kt
@@ -1,0 +1,23 @@
+package eu.darken.amply.rules.core
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.amply.monitor.core.ChargeMonitorWatcher
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RulesModule {
+
+    @Binds
+    @IntoSet
+    abstract fun bindRulesWatcher(impl: RulesWatcher): ChargeMonitorWatcher
+
+    @Binds
+    abstract fun bindRuleChargeGateway(impl: ChargingRuleGateway): RuleChargeGateway
+
+    @Binds
+    abstract fun bindBluetoothConnectionSource(impl: AndroidBluetoothConnectionSource): BluetoothConnectionSource
+}

--- a/app/src/main/java/eu/darken/amply/rules/core/RulesWatcher.kt
+++ b/app/src/main/java/eu/darken/amply/rules/core/RulesWatcher.kt
@@ -1,0 +1,26 @@
+package eu.darken.amply.rules.core
+
+import eu.darken.amply.monitor.core.ChargeMonitorTick
+import eu.darken.amply.monitor.core.ChargeMonitorWatcher
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Keep-alive only — deliberately **not** where rules are evaluated.
+ *
+ * Watcher ticks are bounded by the service's per-watcher budget and are explicitly optional work
+ * that may be dropped. A rule write is neither: it changes the charging policy and owes a restore.
+ * So the service calls [RuleApplier.evaluate] directly in its evaluation path, and this binding
+ * exists purely so the monitor service stays alive while rules (or owed rule work) exist.
+ */
+@Singleton
+class RulesWatcher @Inject constructor(
+    private val applier: RuleApplier,
+) : ChargeMonitorWatcher {
+
+    override val id = "charge_rules"
+
+    override suspend fun isEnabled(): Boolean = applier.isServiceRequired()
+
+    override suspend fun onBatteryTick(tick: ChargeMonitorTick) = Unit
+}

--- a/app/src/main/java/eu/darken/amply/rules/ui/ChargeRuleEditorScreen.kt
+++ b/app/src/main/java/eu/darken/amply/rules/ui/ChargeRuleEditorScreen.kt
@@ -1,0 +1,354 @@
+package eu.darken.amply.rules.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Button
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import eu.darken.amply.R
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardDefaults
+import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.PreviewWrapper
+import eu.darken.amply.common.compose.asComposable
+import eu.darken.amply.rules.core.BondedDevice
+import eu.darken.amply.rules.core.PlugKind
+
+/**
+ * Create or edit one rule. The charger-type option is **absent**, not disabled, where the adapter
+ * latches its policy at plug time: offering a condition that can never take effect would be a
+ * promise the device cannot keep.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun ChargeRuleEditorScreen(
+    state: RuleEditorState,
+    onBack: () -> Unit,
+    onLabelChange: (String) -> Unit,
+    onConditionKindChange: (ConditionKind) -> Unit,
+    onDeviceSelect: (BondedDevice) -> Unit,
+    onPlugKindToggle: (PlugKind) -> Unit,
+    onPolicySelect: (ChargePolicy) -> Unit,
+    onSave: () -> Unit,
+    onDelete: (String) -> Unit,
+    onRequestBluetoothPermission: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        stringResource(
+                            if (state.isNew) R.string.rules_editor_title_new else R.string.rules_editor_title_edit,
+                        ),
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.TwoTone.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+                actions = {
+                    state.ruleId?.let { id ->
+                        IconButton(onClick = { onDelete(id) }) {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = stringResource(R.string.rules_action_delete),
+                            )
+                        }
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item(key = "editor.when") {
+                AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+                    Text(
+                        stringResource(R.string.rules_editor_when_header),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    ConditionChoice(
+                        text = stringResource(R.string.rules_editor_kind_bluetooth),
+                        selected = state.conditionKind == ConditionKind.BLUETOOTH,
+                        onClick = { onConditionKindChange(ConditionKind.BLUETOOTH) },
+                    )
+                    if (state.chargerTypeSupported) {
+                        ConditionChoice(
+                            text = stringResource(R.string.rules_editor_kind_charger),
+                            selected = state.conditionKind == ConditionKind.CHARGER,
+                            onClick = { onConditionKindChange(ConditionKind.CHARGER) },
+                        )
+                    }
+                }
+            }
+            when (state.conditionKind) {
+                ConditionKind.BLUETOOTH -> item(key = "editor.devices") {
+                    AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+                        Text(
+                            stringResource(R.string.rules_editor_device_header),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        when {
+                            state.bluetoothPermissionMissing -> Row(
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Text(
+                                    stringResource(R.string.rules_editor_bluetooth_permission),
+                                    modifier = Modifier.weight(1f),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                                TextButton(onClick = onRequestBluetoothPermission) {
+                                    Text(stringResource(R.string.rules_editor_bluetooth_permission_action))
+                                }
+                            }
+                            state.bondedDevices.isEmpty() -> Text(
+                                stringResource(R.string.rules_editor_device_empty),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            else -> state.bondedDevices.forEach { device ->
+                                ConditionChoice(
+                                    text = device.name?.takeIf { it.isNotBlank() }
+                                        ?: stringResource(R.string.rules_editor_device_unnamed),
+                                    supporting = device.address,
+                                    selected = state.address == device.address,
+                                    onClick = { onDeviceSelect(device) },
+                                )
+                            }
+                        }
+                    }
+                }
+                ConditionKind.CHARGER -> item(key = "editor.chargers") {
+                    AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+                        Text(
+                            stringResource(R.string.rules_editor_charger_header),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            PlugKind.entries.forEach { kind ->
+                                FilterChip(
+                                    selected = kind in state.plugKinds,
+                                    onClick = { onPlugKindToggle(kind) },
+                                    label = { Text(kind.label()) },
+                                    leadingIcon = if (kind in state.plugKinds) {
+                                        {
+                                            Icon(
+                                                Icons.Default.Check,
+                                                contentDescription = null,
+                                                modifier = Modifier.size(18.dp),
+                                            )
+                                        }
+                                    } else {
+                                        null
+                                    },
+                                )
+                            }
+                        }
+                        if (state.plugKinds.isEmpty()) {
+                            Text(
+                                stringResource(R.string.rules_editor_charger_hint),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+            item(key = "editor.policy") {
+                AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+                    Text(
+                        stringResource(R.string.rules_editor_policy_header),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    // Grouped by the derived kind, so "protect" and "charge fully" read as the two
+                    // things a condition can be for rather than as one flat list of modes.
+                    val (charging, protecting) = state.supportedPolicies.partition { it.allowsFullCharge }
+                    PolicyGroup(
+                        header = stringResource(R.string.rules_kind_protection),
+                        policies = protecting,
+                        selected = state.policy,
+                        onSelect = onPolicySelect,
+                    )
+                    PolicyGroup(
+                        header = stringResource(R.string.rules_kind_charge),
+                        policies = charging,
+                        selected = state.policy,
+                        onSelect = onPolicySelect,
+                    )
+                }
+            }
+            item(key = "editor.label") {
+                AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+                    Text(
+                        stringResource(R.string.rules_editor_label_header),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    OutlinedTextField(
+                        value = state.label,
+                        onValueChange = onLabelChange,
+                        singleLine = true,
+                        placeholder = { Text(stringResource(R.string.rules_editor_label_hint)) },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+            item(key = "editor.save") {
+                Button(
+                    onClick = onSave,
+                    enabled = state.canSave,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(R.string.rules_editor_save))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PolicyGroup(
+    header: String,
+    policies: List<ChargePolicy>,
+    selected: ChargePolicy?,
+    onSelect: (ChargePolicy) -> Unit,
+) {
+    if (policies.isEmpty()) return
+    Text(
+        header,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+    )
+    policies.forEach { policy ->
+        ConditionChoice(
+            text = policy.label.asComposable(),
+            selected = selected == policy,
+            onClick = { onSelect(policy) },
+        )
+    }
+}
+
+/**
+ * A radio row. The **row** carries the selection semantics and the radio button itself is inert, so
+ * the tap target is the whole line and accessibility announces one control, not two.
+ */
+@Composable
+private fun ConditionChoice(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    supporting: String? = null,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(selected = selected, role = Role.RadioButton, onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = selected, onClick = null)
+        Column(Modifier.weight(1f)) {
+            Text(text, style = MaterialTheme.typography.bodyLarge)
+            supporting?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@AmplyPreview
+@Composable
+private fun ChargeRuleEditorScreenPreview() = PreviewWrapper {
+    ChargeRuleEditorScreen(
+        state = RuleEditorState(
+            ruleId = "car",
+            label = "Car",
+            conditionKind = ConditionKind.BLUETOOTH,
+            address = "AA:BB:CC:DD:EE:FF",
+            deviceName = "Car audio",
+            policy = ChargePolicy.Unrestricted,
+            supportedPolicies = listOf(
+                ChargePolicy.FixedLimit(80),
+                ChargePolicy.Adaptive,
+                ChargePolicy.Unrestricted,
+            ),
+            bondedDevices = listOf(
+                BondedDevice("AA:BB:CC:DD:EE:FF", "Car audio"),
+                BondedDevice("11:22:33:44:55:66", "Bedside speaker"),
+            ),
+        ),
+        onBack = {},
+        onLabelChange = {},
+        onConditionKindChange = {},
+        onDeviceSelect = {},
+        onPlugKindToggle = {},
+        onPolicySelect = {},
+        onSave = {},
+        onDelete = {},
+        onRequestBluetoothPermission = {},
+    )
+}
+
+// A charger rule on a device that supports it, mid-edit with nothing picked yet: the save button is
+// off until at least one charger type is selected.
+@AmplyPreview
+@Composable
+private fun ChargeRuleEditorScreenChargerPreview() = PreviewWrapper {
+    ChargeRuleEditorScreen(
+        state = RuleEditorState(
+            conditionKind = ConditionKind.CHARGER,
+            supportedPolicies = listOf(ChargePolicy.FixedLimit(80), ChargePolicy.Unrestricted),
+        ),
+        onBack = {},
+        onLabelChange = {},
+        onConditionKindChange = {},
+        onDeviceSelect = {},
+        onPlugKindToggle = {},
+        onPolicySelect = {},
+        onSave = {},
+        onDelete = {},
+        onRequestBluetoothPermission = {},
+    )
+}

--- a/app/src/main/java/eu/darken/amply/rules/ui/ChargeRulesScreen.kt
+++ b/app/src/main/java/eu/darken/amply/rules/ui/ChargeRulesScreen.kt
@@ -1,0 +1,379 @@
+package eu.darken.amply.rules.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.WarningAmber
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.amply.R
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardDefaults
+import eu.darken.amply.common.compose.AmplyCardTone
+import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.PreviewWrapper
+import eu.darken.amply.common.compose.asComposable
+import eu.darken.amply.rules.core.ChargeRule
+import eu.darken.amply.rules.core.PlugKind
+import eu.darken.amply.rules.core.RuleCondition
+import eu.darken.amply.rules.core.policy
+
+/**
+ * The ordered rule list. Priority is the order itself — the topmost matching rule wins, across both
+ * kinds — so reordering is the whole priority editor and needs no separate concept.
+ */
+@Composable
+fun ChargeRulesScreen(
+    state: ChargeRulesUiState,
+    onBack: () -> Unit,
+    onAdd: () -> Unit,
+    onEdit: (String) -> Unit,
+    onDelete: (String) -> Unit,
+    onEnabledChange: (String, Boolean) -> Unit,
+    onMove: (String, Boolean) -> Unit,
+    onFixBluetoothPermission: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.rules_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.TwoTone.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                onClick = onAdd,
+                icon = { Icon(Icons.Default.Add, contentDescription = null) },
+                text = { Text(stringResource(R.string.rules_add_action)) },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
+            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 96.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            if (state.applyFailed) {
+                item(key = "rules.failure") {
+                    NoticeCard(
+                        text = stringResource(R.string.rules_failure_warning),
+                        tone = AmplyCardTone.SurfaceContainer,
+                        error = true,
+                    )
+                }
+            }
+            if (state.bluetoothPermissionMissing) {
+                item(key = "rules.btpermission") {
+                    NoticeCard(
+                        text = stringResource(R.string.rules_bluetooth_permission_warning),
+                        tone = AmplyCardTone.SurfaceContainer,
+                        error = true,
+                        action = {
+                            TextButton(onClick = onFixBluetoothPermission) {
+                                Text(stringResource(R.string.rules_editor_bluetooth_permission_action))
+                            }
+                        },
+                    )
+                }
+            }
+            if (state.rows.isEmpty()) {
+                item(key = "rules.empty") {
+                    AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+                        Text(
+                            stringResource(R.string.rules_empty_title),
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                        Text(
+                            stringResource(R.string.rules_empty_body),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Button(onClick = onAdd, modifier = Modifier.fillMaxWidth()) {
+                            Text(stringResource(R.string.rules_add_action))
+                        }
+                    }
+                }
+            } else {
+                if (state.rows.size > 1) {
+                    item(key = "rules.priority") {
+                        Text(
+                            stringResource(R.string.rules_priority_note),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+                for (row in state.rows) {
+                    item(key = "rules.row.${row.rule.id}") {
+                        ChargeRuleCard(
+                            row = row,
+                            onEdit = { onEdit(row.rule.id) },
+                            onDelete = { onDelete(row.rule.id) },
+                            onEnabledChange = { onEnabledChange(row.rule.id, it) },
+                            onMove = { up -> onMove(row.rule.id, up) },
+                        )
+                    }
+                }
+                item(key = "rules.footnote") {
+                    Text(
+                        stringResource(R.string.rules_notification_footnote),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChargeRuleCard(
+    row: ChargeRuleRow,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    onEnabledChange: (Boolean) -> Unit,
+    onMove: (Boolean) -> Unit,
+) {
+    val rule = row.rule
+    AmplyCard(
+        // The winner is the one rule actually doing something; everything below it is standing by.
+        tone = if (row.active) AmplyCardTone.SecondaryContainer else AmplyCardTone.Default,
+        verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                rule.kindIcon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Column(Modifier.weight(1f)) {
+                Text(rule.displayTitle(), style = MaterialTheme.typography.titleMedium)
+                Text(
+                    rule.conditionSummary(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(checked = rule.enabled, onCheckedChange = onEnabledChange)
+        }
+        Text(
+            listOfNotNull(
+                row.policy?.label?.asComposable(),
+                rule.kindLabel(),
+            ).joinToString(stringResource(R.string.rules_condition_separator)),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        if (row.active) {
+            Text(
+                stringResource(R.string.rules_active_marker),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        // Stated on the row rather than hidden: a condition that cannot act here would otherwise
+        // look switched on and simply never do anything.
+        if (row.unsupportedCondition) {
+            WarningLine(stringResource(R.string.rules_condition_unsupported))
+        }
+        if (row.unsupportedPolicy) {
+            WarningLine(stringResource(R.string.rules_policy_unavailable))
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = { onMove(true) }, enabled = row.canMoveUp) {
+                Icon(
+                    Icons.Default.KeyboardArrowUp,
+                    contentDescription = stringResource(R.string.rules_action_move_up),
+                )
+            }
+            IconButton(onClick = { onMove(false) }, enabled = row.canMoveDown) {
+                Icon(
+                    Icons.Default.KeyboardArrowDown,
+                    contentDescription = stringResource(R.string.rules_action_move_down),
+                )
+            }
+            Spacer(Modifier.weight(1f))
+            TextButton(onClick = onEdit) {
+                Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(18.dp))
+                Text(stringResource(R.string.rules_action_edit), Modifier.padding(start = 4.dp))
+            }
+            TextButton(onClick = onDelete) {
+                Icon(Icons.Default.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                Text(stringResource(R.string.rules_action_delete), Modifier.padding(start = 4.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun WarningLine(text: String) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            Icons.Default.WarningAmber,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = MaterialTheme.colorScheme.error,
+        )
+        Text(
+            text,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+        )
+    }
+}
+
+@Composable
+private fun NoticeCard(
+    text: String,
+    tone: AmplyCardTone,
+    error: Boolean,
+    action: (@Composable () -> Unit)? = null,
+) {
+    AmplyCard(tone = tone) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Default.WarningAmber,
+                contentDescription = null,
+                tint = if (error) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.tertiary,
+            )
+            Text(
+                text,
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodySmall,
+                color = if (error) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface,
+            )
+            action?.invoke()
+        }
+    }
+}
+
+private fun previewRow(
+    id: String,
+    label: String,
+    condition: RuleCondition,
+    policy: ChargePolicy,
+    enabled: Boolean = true,
+    active: Boolean = false,
+    unsupportedCondition: Boolean = false,
+    canMoveUp: Boolean = true,
+    canMoveDown: Boolean = true,
+): ChargeRuleRow {
+    val rule = ChargeRule(
+        id = id,
+        enabled = enabled,
+        label = label,
+        condition = condition,
+        policyId = policy.stableId,
+    )
+    return ChargeRuleRow(
+        rule = rule,
+        policy = rule.policy,
+        active = active,
+        unsupportedCondition = unsupportedCondition,
+        unsupportedPolicy = false,
+        canMoveUp = canMoveUp,
+        canMoveDown = canMoveDown,
+    )
+}
+
+@AmplyPreview
+@Composable
+private fun ChargeRulesScreenPreview() = PreviewWrapper {
+    ChargeRulesScreen(
+        state = ChargeRulesUiState(
+            rows = listOf(
+                previewRow(
+                    id = "car",
+                    label = "Car",
+                    condition = RuleCondition.BluetoothDevice("AA:BB:CC:DD:EE:FF", "Car audio"),
+                    policy = ChargePolicy.Unrestricted,
+                    active = true,
+                    canMoveUp = false,
+                ),
+                previewRow(
+                    id = "desk",
+                    label = "Desk dock",
+                    condition = RuleCondition.ChargerType(setOf(PlugKind.DOCK, PlugKind.WIRELESS)),
+                    policy = ChargePolicy.FixedLimit(80),
+                    unsupportedCondition = true,
+                ),
+                previewRow(
+                    id = "night",
+                    label = "",
+                    condition = RuleCondition.BluetoothDevice("11:22:33:44:55:66", "Bedside speaker"),
+                    policy = ChargePolicy.Adaptive,
+                    enabled = false,
+                    canMoveDown = false,
+                ),
+            ),
+            applyFailed = true,
+        ),
+        onBack = {},
+        onAdd = {},
+        onEdit = {},
+        onDelete = {},
+        onEnabledChange = { _, _ -> },
+        onMove = { _, _ -> },
+        onFixBluetoothPermission = {},
+    )
+}
+
+@AmplyPreview
+@Composable
+private fun ChargeRulesScreenEmptyPreview() = PreviewWrapper {
+    ChargeRulesScreen(
+        state = ChargeRulesUiState(bluetoothPermissionMissing = true),
+        onBack = {},
+        onAdd = {},
+        onEdit = {},
+        onDelete = {},
+        onEnabledChange = { _, _ -> },
+        onMove = { _, _ -> },
+        onFixBluetoothPermission = {},
+    )
+}

--- a/app/src/main/java/eu/darken/amply/rules/ui/ChargeRulesViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/rules/ui/ChargeRulesViewModel.kt
@@ -1,0 +1,357 @@
+package eu.darken.amply.rules.ui
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.ChargingRepository
+import eu.darken.amply.common.debug.logging.Logging
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import eu.darken.amply.common.flow.SingleEventFlow
+import eu.darken.amply.fullcharge.core.ChargeSessionService
+import eu.darken.amply.rules.core.BondedDevice
+import eu.darken.amply.rules.core.ChargeRule
+import eu.darken.amply.rules.core.PlugKind
+import eu.darken.amply.rules.core.RuleApplier
+import eu.darken.amply.rules.core.RuleCondition
+import eu.darken.amply.rules.core.RulePhase
+import eu.darken.amply.rules.core.RuleRuntimeState
+import eu.darken.amply.rules.core.normalizeBtAddress
+import eu.darken.amply.rules.core.policy
+import eu.darken.amply.upgrade.core.UpgradeRepo
+import eu.darken.amply.upgrade.core.isProForUi
+import eu.darken.amply.upgrade.core.isProSettled
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.UUID
+import javax.inject.Inject
+
+/** One row of the ordered rule list, with everything the screen needs already derived. */
+data class ChargeRuleRow(
+    val rule: ChargeRule,
+    val policy: ChargePolicy?,
+    val active: Boolean,
+    /** The condition or the policy cannot do anything on this device; the row says so. */
+    val unsupportedCondition: Boolean,
+    val unsupportedPolicy: Boolean,
+    val canMoveUp: Boolean,
+    val canMoveDown: Boolean,
+)
+
+data class ChargeRulesUiState(
+    val rows: List<ChargeRuleRow> = emptyList(),
+    val applyFailed: Boolean = false,
+    val bluetoothPermissionMissing: Boolean = false,
+    val showProBadge: Boolean = false,
+)
+
+enum class ConditionKind {
+    BLUETOOTH,
+    CHARGER,
+}
+
+/**
+ * The editor's working copy. Held here rather than in the screen so a rotation mid-edit doesn't lose
+ * it and so the pure screen stays a function of state.
+ */
+data class RuleEditorState(
+    val ruleId: String? = null,
+    val label: String = "",
+    val conditionKind: ConditionKind = ConditionKind.BLUETOOTH,
+    val address: String? = null,
+    val deviceName: String? = null,
+    val plugKinds: Set<PlugKind> = emptySet(),
+    val policy: ChargePolicy? = null,
+    val supportedPolicies: List<ChargePolicy> = emptyList(),
+    val bondedDevices: List<BondedDevice> = emptyList(),
+    val chargerTypeSupported: Boolean = true,
+    val bluetoothPermissionMissing: Boolean = false,
+) {
+    val isNew: Boolean get() = ruleId == null
+
+    /** A charger rule with no type selected would be a wildcard; the engine treats it as matching nothing. */
+    val canSave: Boolean
+        get() = policy != null && when (conditionKind) {
+            ConditionKind.BLUETOOTH -> !address.isNullOrBlank()
+            ConditionKind.CHARGER -> plugKinds.isNotEmpty()
+        }
+}
+
+@HiltViewModel
+class ChargeRulesViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val applier: RuleApplier,
+    private val repository: ChargingRepository,
+    private val upgradeRepo: UpgradeRepo,
+) : ViewModel() {
+
+    /** A gated affordance was used without the entitlement; the root navigates to the upgrade screen. */
+    val upgradeRequiredEvents = SingleEventFlow<Unit>()
+
+    /**
+     * The entitlement check passed and this rule may be switched on. The notification prompt is
+     * deliberately downstream: asking for notification access and only then refusing the feature
+     * would be the wrong order to put a user through.
+     */
+    val proceedWithEnableEvents = SingleEventFlow<String>()
+
+    /** The editor is ready (its state is already set); the root navigates to it. */
+    val openEditorEvents = SingleEventFlow<Unit>()
+
+    private val bluetoothPermissionMissing = MutableStateFlow(!applier.hasBluetoothPermission())
+    private val editorState = MutableStateFlow<RuleEditorState?>(null)
+
+    /**
+     * Resolved once, off the main thread: the answer comes from adapter selection, which reads
+     * providers, activities and system settings. Permissive until it lands — the rows only *add* a
+     * warning when it turns out false, so an optimistic first frame understates nothing.
+     */
+    private val chargerTypeSupported = MutableStateFlow(true)
+
+    val editor: StateFlow<RuleEditorState?> = editorState.asStateFlow()
+
+    init {
+        viewModelScope.launch(Dispatchers.Default) {
+            chargerTypeSupported.value = applier.chargerTypeSupported()
+        }
+    }
+
+    val state: StateFlow<ChargeRulesUiState> = combine(
+        applier.rules,
+        applier.runtime,
+        bluetoothPermissionMissing,
+        chargerTypeSupported,
+        upgradeRepo.upgradeInfo
+            .map { it.isSettled && !it.isPro }
+            .catch { e ->
+                if (e is CancellationException) throw e
+                log(TAG, Logging.Priority.WARN) { "Upgrade info read failed: ${e.message}" }
+                emit(false)
+            }
+            .onStart { emit(false) }
+            .distinctUntilChanged(),
+    ) { rules, runtime, permissionMissing, chargerSupported, showProBadge ->
+        ChargeRulesUiState(
+            rows = rules.toRows(runtime, chargerSupported),
+            applyFailed = runtime.lastApplyFailed,
+            bluetoothPermissionMissing = permissionMissing && rules.any {
+                it.enabled && it.condition is RuleCondition.BluetoothDevice
+            },
+            showProBadge = showProBadge,
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS), ChargeRulesUiState())
+
+    private fun List<ChargeRule>.toRows(
+        runtime: RuleRuntimeState,
+        chargerTypeSupported: Boolean,
+    ): List<ChargeRuleRow> {
+        val supported = repository.state.value.supportedPolicies
+        return mapIndexed { index, rule ->
+            val policy = rule.policy
+            ChargeRuleRow(
+                rule = rule,
+                policy = policy,
+                active = runtime.phase != RulePhase.IDLE && runtime.activeRuleId == rule.id,
+                unsupportedCondition = rule.condition is RuleCondition.ChargerType && !chargerTypeSupported,
+                // Only claimable once the adapter has actually offered a policy list; an empty one
+                // means "not resolved yet", not "this device supports nothing".
+                unsupportedPolicy = policy == null || (supported.isNotEmpty() && policy !in supported),
+                canMoveUp = index > 0,
+                canMoveDown = index < lastIndex,
+            )
+        }
+    }
+
+    /** Re-read after returning from the system permission prompt. */
+    fun refreshBluetoothPermission() {
+        bluetoothPermissionMissing.value = !applier.hasBluetoothPermission()
+    }
+
+    /**
+     * The one entry point for adding: gated *before* the editor opens, so nobody fills in a condition
+     * only to be told at the end that it needs an upgrade.
+     */
+    fun requestAddRule() {
+        viewModelScope.launch {
+            if (!upgradeRepo.isProForUi()) {
+                log(TAG) { "Rule creation denied, routing to the upgrade screen" }
+                upgradeRequiredEvents.tryEmit(Unit)
+                return@launch
+            }
+            editorState.value = editorDefaults()
+            openEditorEvents.tryEmit(Unit)
+        }
+    }
+
+    /** Editing an existing rule is never gated: a lapsed entitlement must not trap a rule switched on. */
+    fun editRule(id: String) {
+        viewModelScope.launch {
+            val rule = applier.rulesNow().firstOrNull { it.id == id } ?: return@launch
+            val condition = rule.condition
+            editorState.value = editorDefaults().copy(
+                ruleId = rule.id,
+                label = rule.label,
+                conditionKind = when (condition) {
+                    is RuleCondition.BluetoothDevice -> ConditionKind.BLUETOOTH
+                    is RuleCondition.ChargerType -> ConditionKind.CHARGER
+                },
+                address = (condition as? RuleCondition.BluetoothDevice)?.address,
+                deviceName = (condition as? RuleCondition.BluetoothDevice)?.name,
+                plugKinds = (condition as? RuleCondition.ChargerType)?.types.orEmpty(),
+                policy = rule.policy,
+            )
+            openEditorEvents.tryEmit(Unit)
+        }
+    }
+
+    fun closeEditor() {
+        editorState.value = null
+    }
+
+    fun setEditorLabel(label: String) = editorState.update { it.copy(label = label) }
+
+    fun setEditorConditionKind(kind: ConditionKind) = editorState.update { it.copy(conditionKind = kind) }
+
+    fun setEditorDevice(device: BondedDevice) = editorState.update {
+        it.copy(address = device.address, deviceName = device.name)
+    }
+
+    fun toggleEditorPlugKind(kind: PlugKind) = editorState.update {
+        it.copy(plugKinds = if (kind in it.plugKinds) it.plugKinds - kind else it.plugKinds + kind)
+    }
+
+    fun setEditorPolicy(policy: ChargePolicy) = editorState.update { it.copy(policy = policy) }
+
+    /**
+     * Persist the working copy. A brand-new rule is switched on, which is an activation — so it
+     * passes the backend entitlement gate here (not just the navigation gate at [requestAddRule])
+     * and then routes through the notification prompt like any other enable.
+     */
+    fun saveEditor() {
+        val draft = editorState.value ?: return
+        val policy = draft.policy ?: return
+        if (!draft.canSave) return
+        viewModelScope.launch {
+            if (draft.isNew && !upgradeRepo.isProSettled()) {
+                log(TAG) { "Rule creation denied at the write, routing to the upgrade screen" }
+                upgradeRequiredEvents.tryEmit(Unit)
+                return@launch
+            }
+            val condition = when (draft.conditionKind) {
+                ConditionKind.BLUETOOTH -> RuleCondition.BluetoothDevice(
+                    address = normalizeBtAddress(draft.address.orEmpty()),
+                    name = draft.deviceName,
+                )
+                ConditionKind.CHARGER -> RuleCondition.ChargerType(draft.plugKinds)
+            }
+            val id = draft.ruleId ?: UUID.randomUUID().toString()
+            val rule = ChargeRule(
+                id = id,
+                enabled = true,
+                label = draft.label.trim(),
+                condition = condition,
+                policyId = policy.stableId,
+            )
+            if (draft.isNew) applier.addRule(rule) else applier.updateRule(rule)
+            editorState.value = null
+            nudgeService()
+            // A new rule is on from the moment it is saved, so it needs the monitor notification.
+            if (draft.isNew) proceedWithEnableEvents.tryEmit(id)
+        }
+    }
+
+    fun deleteRule(id: String) {
+        viewModelScope.launch {
+            applier.deleteRule(id)
+            editorState.value = null
+            nudgeService()
+        }
+    }
+
+    /** Switching a rule ON is gated; switching it off never is. */
+    fun requestEnableRule(id: String) {
+        viewModelScope.launch {
+            if (upgradeRepo.isProForUi()) {
+                proceedWithEnableEvents.tryEmit(id)
+            } else {
+                log(TAG) { "Rule enable denied, routing to the upgrade screen" }
+                upgradeRequiredEvents.tryEmit(Unit)
+            }
+        }
+    }
+
+    fun setRuleEnabled(id: String, enabled: Boolean) {
+        viewModelScope.launch {
+            // Defence in depth, as with the stats capture switch: this is the only path that writes
+            // the flag, and it is reachable from more than one affordance.
+            if (enabled && !upgradeRepo.isProSettled()) {
+                log(TAG) { "Rule enable denied at the write, routing to the upgrade screen" }
+                upgradeRequiredEvents.tryEmit(Unit)
+                return@launch
+            }
+            applier.setRuleEnabled(id, enabled)
+            nudgeService()
+        }
+    }
+
+    fun moveRule(id: String, up: Boolean) {
+        viewModelScope.launch {
+            applier.moveRule(id, up)
+            nudgeService()
+        }
+    }
+
+    /**
+     * Off the main thread: listing bonded devices is a Binder round-trip to the Bluetooth stack, and
+     * the charger-type answer can still be resolving adapter selection on first use.
+     */
+    private suspend fun editorDefaults(): RuleEditorState = withContext(Dispatchers.Default) {
+        RuleEditorState(
+            supportedPolicies = repository.state.value.supportedPolicies,
+            bondedDevices = applier.bondedDevices(),
+            chargerTypeSupported = applier.chargerTypeSupported(),
+            bluetoothPermissionMissing = !applier.hasBluetoothPermission(),
+        )
+    }
+
+    /**
+     * Every mutation re-evaluates: a rule the user just switched on has to take effect now, not on
+     * the next 30s tick. Mirrors the alarm's enable path — a foreground start from a foreground
+     * activity — and tolerates a refusal, since the next service start reconciles anyway.
+     */
+    private fun nudgeService() {
+        val intent = Intent(context, ChargeSessionService::class.java)
+            .setAction(ChargeSessionService.ACTION_EVALUATE_RULES)
+        try {
+            ContextCompat.startForegroundService(context, intent)
+        } catch (e: Exception) {
+            log(TAG, Logging.Priority.WARN) { "Rule evaluation nudge failed: ${e.message}" }
+        }
+    }
+
+    private fun MutableStateFlow<RuleEditorState?>.update(block: (RuleEditorState) -> RuleEditorState) {
+        value = value?.let(block)
+    }
+
+    private companion object {
+        val TAG = logTag("Rules", "ViewModel")
+        const val STOP_TIMEOUT_MILLIS = 5_000L
+    }
+}

--- a/app/src/main/java/eu/darken/amply/rules/ui/ChargeRulesViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/rules/ui/ChargeRulesViewModel.kt
@@ -73,6 +73,12 @@ enum class ConditionKind {
  */
 data class RuleEditorState(
     val ruleId: String? = null,
+    /**
+     * The edited rule's switch, carried through untouched: saving an edit must never turn a rule on
+     * or off behind the user's back. A new rule starts **off** and is switched on only once the
+     * entitlement gate and the notification prompt have both passed.
+     */
+    val enabled: Boolean = false,
     val label: String = "",
     val conditionKind: ConditionKind = ConditionKind.BLUETOOTH,
     val address: String? = null,
@@ -179,9 +185,19 @@ class ChargeRulesViewModel @Inject constructor(
         }
     }
 
-    /** Re-read after returning from the system permission prompt. */
+    /**
+     * Re-read after returning from the system permission prompt. An open editor is updated in place
+     * — a grant made *from* the editor's own "Allow" button must fill its device list right there,
+     * not only after backing out and re-entering.
+     */
     fun refreshBluetoothPermission() {
-        bluetoothPermissionMissing.value = !applier.hasBluetoothPermission()
+        viewModelScope.launch {
+            val missing = withContext(Dispatchers.Default) { !applier.hasBluetoothPermission() }
+            bluetoothPermissionMissing.value = missing
+            if (editorState.value == null) return@launch
+            val devices = withContext(Dispatchers.Default) { applier.bondedDevices() }
+            editorState.update { it.copy(bluetoothPermissionMissing = missing, bondedDevices = devices) }
+        }
     }
 
     /**
@@ -207,6 +223,7 @@ class ChargeRulesViewModel @Inject constructor(
             val condition = rule.condition
             editorState.value = editorDefaults().copy(
                 ruleId = rule.id,
+                enabled = rule.enabled,
                 label = rule.label,
                 conditionKind = when (condition) {
                     is RuleCondition.BluetoothDevice -> ConditionKind.BLUETOOTH
@@ -240,20 +257,21 @@ class ChargeRulesViewModel @Inject constructor(
     fun setEditorPolicy(policy: ChargePolicy) = editorState.update { it.copy(policy = policy) }
 
     /**
-     * Persist the working copy. A brand-new rule is switched on, which is an activation — so it
-     * passes the backend entitlement gate here (not just the navigation gate at [requestAddRule])
-     * and then routes through the notification prompt like any other enable.
+     * Persist the working copy.
+     *
+     * A brand-new rule is saved **switched off** and then routed through the normal enable flow
+     * (entitlement gate, then the notification prompt, then the write that turns it on). Saving it
+     * on and switching it off again if a gate refuses would mean a rule that briefly owns the
+     * charging policy before anything has agreed it may; saving it off costs one extra step and can
+     * only ever leave the user with a visible, inert rule they can switch on later.
+     *
+     * An edit carries the existing switch through untouched — saving must not turn a rule on or off.
      */
     fun saveEditor() {
         val draft = editorState.value ?: return
         val policy = draft.policy ?: return
         if (!draft.canSave) return
         viewModelScope.launch {
-            if (draft.isNew && !upgradeRepo.isProSettled()) {
-                log(TAG) { "Rule creation denied at the write, routing to the upgrade screen" }
-                upgradeRequiredEvents.tryEmit(Unit)
-                return@launch
-            }
             val condition = when (draft.conditionKind) {
                 ConditionKind.BLUETOOTH -> RuleCondition.BluetoothDevice(
                     address = normalizeBtAddress(draft.address.orEmpty()),
@@ -264,7 +282,7 @@ class ChargeRulesViewModel @Inject constructor(
             val id = draft.ruleId ?: UUID.randomUUID().toString()
             val rule = ChargeRule(
                 id = id,
-                enabled = true,
+                enabled = draft.enabled,
                 label = draft.label.trim(),
                 condition = condition,
                 policyId = policy.stableId,
@@ -272,8 +290,9 @@ class ChargeRulesViewModel @Inject constructor(
             if (draft.isNew) applier.addRule(rule) else applier.updateRule(rule)
             editorState.value = null
             nudgeService()
-            // A new rule is on from the moment it is saved, so it needs the monitor notification.
-            if (draft.isNew) proceedWithEnableEvents.tryEmit(id)
+            // Now ask for the rule to be switched on, through the same gate every other enable uses.
+            // A refusal leaves the rule saved and off rather than active-then-revoked.
+            if (draft.isNew) requestEnableRule(id)
         }
     }
 

--- a/app/src/main/java/eu/darken/amply/rules/ui/RulePresentation.kt
+++ b/app/src/main/java/eu/darken/amply/rules/ui/RulePresentation.kt
@@ -1,0 +1,83 @@
+package eu.darken.amply.rules.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bluetooth
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.PowerSettingsNew
+import androidx.compose.material.icons.filled.Security
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import eu.darken.amply.R
+import eu.darken.amply.rules.core.ChargeRule
+import eu.darken.amply.rules.core.PlugKind
+import eu.darken.amply.rules.core.RuleCondition
+import eu.darken.amply.rules.core.RuleKind
+import eu.darken.amply.rules.core.kind
+
+/**
+ * How a rule reads. Shared by the rules screen and the dashboard card so the two can never describe
+ * the same rule differently.
+ */
+@Composable
+fun ChargeRule.conditionSummary(): String = when (val condition = this.condition) {
+    is RuleCondition.BluetoothDevice -> {
+        val name = condition.name?.takeIf { it.isNotBlank() } ?: condition.address.takeIf { it.isNotBlank() }
+        if (name != null) {
+            stringResource(R.string.rules_condition_bluetooth, name)
+        } else {
+            stringResource(R.string.rules_condition_bluetooth_unnamed)
+        }
+    }
+    is RuleCondition.ChargerType -> if (condition.types.isEmpty()) {
+        stringResource(R.string.rules_condition_charger_none)
+    } else {
+        stringResource(R.string.rules_condition_charger, condition.types.joinLabels())
+    }
+}
+
+/** The user's name for a rule, falling back to what it actually does. */
+@Composable
+fun ChargeRule.displayTitle(): String = label.takeIf { it.isNotBlank() } ?: conditionSummary()
+
+@Composable
+fun Set<PlugKind>.joinLabels(): String {
+    val separator = stringResource(R.string.rules_condition_separator)
+    // Ordered by the enum, not by insertion, so the same selection always reads the same way. The
+    // labels are resolved before joining — joinToString is not inline, so its transform cannot make
+    // composable calls.
+    val labels = PlugKind.entries.filter { it in this }.map { it.label() }
+    return labels.joinToString(separator)
+}
+
+@Composable
+fun PlugKind.label(): String = stringResource(
+    when (this) {
+        PlugKind.AC -> R.string.rules_plug_ac
+        PlugKind.USB -> R.string.rules_plug_usb
+        PlugKind.WIRELESS -> R.string.rules_plug_wireless
+        PlugKind.DOCK -> R.string.rules_plug_dock
+    },
+)
+
+/** The kind is derived from the policy, so the icon and the effect can never disagree. */
+val ChargeRule.kindIcon: ImageVector
+    get() = when (kind) {
+        RuleKind.CHARGE -> Icons.Default.Bolt
+        RuleKind.PROTECTION -> Icons.Default.Security
+        // Undecodable policy: the row is marked unsupported and does nothing.
+        null -> Icons.Default.PowerSettingsNew
+    }
+
+val ChargeRule.conditionIcon: ImageVector
+    get() = when (condition) {
+        is RuleCondition.BluetoothDevice -> Icons.Default.Bluetooth
+        is RuleCondition.ChargerType -> Icons.Default.Bolt
+    }
+
+@Composable
+fun ChargeRule.kindLabel(): String? = when (kind) {
+    RuleKind.CHARGE -> stringResource(R.string.rules_kind_charge)
+    RuleKind.PROTECTION -> stringResource(R.string.rules_kind_protection)
+    null -> null
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -636,4 +636,62 @@
     <!-- Tile + widget locked states -->
     <string name="tile_upgrade_required">Tap to unlock with %1$s</string>
     <string name="widget_locked_body">Tap to unlock the widget</string>
+
+    <!-- Charge conditions — the rules list, its editor, and the dashboard card -->
+    <string name="rules_title">Charge conditions</string>
+    <string name="rules_priority_note">The topmost matching condition wins.</string>
+    <string name="rules_empty_title">No conditions yet</string>
+    <string name="rules_empty_body">Let a charge policy follow your situation: while a Bluetooth device is connected, or while you\'re on a certain charger.</string>
+    <string name="rules_add_action">Add condition</string>
+    <string name="rules_active_marker">Active now</string>
+    <string name="rules_kind_protection">Protects the battery</string>
+    <string name="rules_kind_charge">Charges fully</string>
+    <string name="rules_condition_bluetooth">While %1$s is connected</string>
+    <string name="rules_condition_bluetooth_unnamed">While a paired device is connected</string>
+    <string name="rules_condition_charger">While charging via %1$s</string>
+    <string name="rules_condition_charger_none">No charger type selected</string>
+    <string name="rules_condition_separator">, </string>
+    <string name="rules_condition_unsupported">This device can\'t act on charger conditions.</string>
+    <string name="rules_policy_unavailable">This charge mode isn\'t available on this device.</string>
+    <string name="rules_failure_warning">The last change couldn\'t be applied. Amply keeps retrying.</string>
+    <string name="rules_bluetooth_permission_warning">Bluetooth access is off, so device conditions can\'t be detected.</string>
+    <string name="rules_notification_footnote">While a condition is on, Amply keeps a quiet notification so it can watch for it.</string>
+    <string name="rules_action_edit">Edit</string>
+    <string name="rules_action_delete">Delete</string>
+    <string name="rules_action_move_up">Move up</string>
+    <string name="rules_action_move_down">Move down</string>
+
+    <string name="rules_editor_title_new">New condition</string>
+    <string name="rules_editor_title_edit">Edit condition</string>
+    <string name="rules_editor_when_header">When</string>
+    <string name="rules_editor_kind_bluetooth">A Bluetooth device is connected</string>
+    <string name="rules_editor_kind_charger">Charging on a certain charger</string>
+    <string name="rules_editor_device_header">Paired device</string>
+    <string name="rules_editor_device_empty">No paired Bluetooth devices found.</string>
+    <string name="rules_editor_device_unnamed">Unnamed device</string>
+    <string name="rules_editor_charger_header">Charger types</string>
+    <string name="rules_editor_charger_hint">Pick at least one.</string>
+    <string name="rules_editor_policy_header">Then charge like this</string>
+    <string name="rules_editor_label_header">Name (optional)</string>
+    <string name="rules_editor_label_hint">Car</string>
+    <string name="rules_editor_bluetooth_permission">Allow Bluetooth access to pick a paired device.</string>
+    <string name="rules_editor_bluetooth_permission_action">Allow</string>
+    <string name="rules_editor_save">Save</string>
+
+    <string name="rules_plug_ac">AC charger</string>
+    <string name="rules_plug_usb">USB</string>
+    <string name="rules_plug_wireless">Wireless</string>
+    <string name="rules_plug_dock">Dock</string>
+
+    <string name="dashboard_conditions_title">Charge conditions</string>
+    <string name="dashboard_conditions_open">Open charge conditions</string>
+    <string name="dashboard_conditions_empty_body">Let a charge policy follow your situation, like connecting to your car.</string>
+    <string name="dashboard_conditions_empty_action">Set one up</string>
+    <string name="dashboard_conditions_waiting">Waiting for a match</string>
+    <string name="dashboard_conditions_active">Active</string>
+    <string name="dashboard_hero_condition">Set by condition: %1$s</string>
+
+    <string name="settings_rules_title">Charge conditions</string>
+    <string name="settings_rules_subtitle_on">%1$d switched on</string>
+    <string name="settings_rules_subtitle_off">Let a policy follow your situation</string>
 </resources>

--- a/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
+++ b/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
@@ -227,14 +227,16 @@ class StoredRecordFormatTest {
             activeRuleId = "car",
             baselinePolicyId = "fixed:80",
             suspendedRuleIds = setOf("desk"),
+            lastWriteAt = 1_700L,
         )
 
         json.encodeToString(RuleRuntimeState.serializer(), runtime) shouldBe
             """{"phase":"ACTIVE","targetPolicyId":"unrestricted","activeRuleId":"car",""" +
-            """"baselinePolicyId":"fixed:80","suspendedRuleIds":["desk"],"lastApplyFailed":false}"""
+            """"baselinePolicyId":"fixed:80","suspendedRuleIds":["desk"],"lastApplyFailed":false,""" +
+            """"lastWriteAt":1700}"""
 
         json.encodeToString(RuleRuntimeState.serializer(), RuleRuntimeState()) shouldBe
-            """{"phase":"IDLE","suspendedRuleIds":[],"lastApplyFailed":false}"""
+            """{"phase":"IDLE","suspendedRuleIds":[],"lastApplyFailed":false,"lastWriteAt":0}"""
     }
 
     @Test
@@ -266,13 +268,20 @@ class StoredRecordFormatTest {
         // Wrong types for the auxiliary fields; the transition itself survives intact.
         decodeRuleRuntimeState(
             """{"phase":"RESTORE_PENDING","targetPolicyId":"adaptive",""" +
-                """"suspendedRuleIds":"nope","lastApplyFailed":"yes"}""",
+                """"suspendedRuleIds":"nope","lastApplyFailed":"yes","lastWriteAt":"soon"}""",
         ).let {
             it.phase shouldBe RulePhase.RESTORE_PENDING
             it.targetPolicyId shouldBe "adaptive"
             it.suspendedRuleIds shouldBe emptySet()
             it.lastApplyFailed shouldBe false
+            // 0 reads as "never written by the rules layer", which only ever makes the divergence
+            // check more conservative — it cannot claim a write it has no timestamp for.
+            it.lastWriteAt shouldBe 0L
         }
+
+        decodeRuleRuntimeState(
+            """{"phase":"ACTIVE","activeRuleId":"car","lastWriteAt":1700}""",
+        ).lastWriteAt shouldBe 1_700L
 
         // Only unparseable JSON loses the whole record.
         decodeRuleRuntimeState("not json at all") shouldBe RuleRuntimeState()

--- a/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
+++ b/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
@@ -14,6 +14,14 @@ import eu.darken.amply.fullcharge.core.InterruptionReason
 import eu.darken.amply.fullcharge.core.RecoveryRecord
 import eu.darken.amply.fullcharge.core.WorkProvenance
 import eu.darken.amply.main.core.QuickAccessState
+import eu.darken.amply.rules.core.BtConnectionSnapshot
+import eu.darken.amply.rules.core.ChargeRule
+import eu.darken.amply.rules.core.ChargeRuleSet
+import eu.darken.amply.rules.core.PlugKind
+import eu.darken.amply.rules.core.RuleCondition
+import eu.darken.amply.rules.core.RulePhase
+import eu.darken.amply.rules.core.RuleRuntimeState
+import eu.darken.amply.rules.core.decodeRuleRuntimeState
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
@@ -180,6 +188,97 @@ class StoredRecordFormatTest {
         json.decodeFromString(ThemeState.serializer(), "{}") shouldBe ThemeState()
         json.decodeFromString(QuickAccessState.serializer(), "{}") shouldBe QuickAccessState()
         json.decodeFromString(ChargeAlarmConfig.serializer(), "{}") shouldBe ChargeAlarmConfig()
+    }
+
+    @Test
+    fun `charge rules encode to the pinned shape, with an explicit condition discriminator`() {
+        val set = ChargeRuleSet(
+            rules = listOf(
+                ChargeRule(
+                    id = "car",
+                    label = "Car dock",
+                    condition = RuleCondition.BluetoothDevice("AA:BB:CC:DD:EE:FF", "Car"),
+                    policyId = ChargePolicy.Unrestricted.stableId,
+                ),
+                ChargeRule(
+                    id = "desk",
+                    enabled = false,
+                    condition = RuleCondition.ChargerType(setOf(PlugKind.AC, PlugKind.DOCK)),
+                    policyId = ChargePolicy.FixedLimit(80).stableId,
+                ),
+            ),
+        )
+
+        json.encodeToString(ChargeRuleSet.serializer(), set) shouldBe
+            """{"rules":[""" +
+            """{"id":"car","enabled":true,"label":"Car dock",""" +
+            """"condition":{"type":"bluetooth","address":"AA:BB:CC:DD:EE:FF","name":"Car"},""" +
+            """"policyId":"unrestricted"},""" +
+            """{"id":"desk","enabled":false,"label":"",""" +
+            """"condition":{"type":"charger","types":["AC","DOCK"]},""" +
+            """"policyId":"fixed:80"}]}"""
+    }
+
+    @Test
+    fun `the rules runtime encodes to the pinned shape`() {
+        val runtime = RuleRuntimeState(
+            phase = RulePhase.ACTIVE,
+            targetPolicyId = "unrestricted",
+            activeRuleId = "car",
+            baselinePolicyId = "fixed:80",
+            suspendedRuleIds = setOf("desk"),
+        )
+
+        json.encodeToString(RuleRuntimeState.serializer(), runtime) shouldBe
+            """{"phase":"ACTIVE","targetPolicyId":"unrestricted","activeRuleId":"car",""" +
+            """"baselinePolicyId":"fixed:80","suspendedRuleIds":["desk"],"lastApplyFailed":false}"""
+
+        json.encodeToString(RuleRuntimeState.serializer(), RuleRuntimeState()) shouldBe
+            """{"phase":"IDLE","suspendedRuleIds":[],"lastApplyFailed":false}"""
+    }
+
+    @Test
+    fun `the bluetooth snapshot encodes to the pinned shape`() {
+        json.encodeToString(
+            BtConnectionSnapshot.serializer(),
+            BtConnectionSnapshot(addresses = setOf("AA:BB:CC:DD:EE:FF"), bootCount = 7),
+        ) shouldBe """{"addresses":["AA:BB:CC:DD:EE:FF"],"bootCount":7}"""
+
+        json.encodeToString(BtConnectionSnapshot.serializer(), BtConnectionSnapshot()) shouldBe
+            """{"addresses":[]}"""
+    }
+
+    /**
+     * The runtime carries **owed restore work** — the user's own policy a rule replaced. One
+     * unreadable field must never take the baseline with it, or the battery stays on the rule's
+     * policy with nothing left that knows to put it back.
+     */
+    @Test
+    fun `the rules runtime decodes field by field`() {
+        // A phase name from a future build, alongside a perfectly good baseline.
+        decodeRuleRuntimeState("""{"phase":"SOMETHING_NEW","activeRuleId":"car","baselinePolicyId":"fixed:90"}""")
+            .let {
+                // Conservative: still owning the policy is the only reading that cannot lose work.
+                it.phase shouldBe RulePhase.ACTIVE
+                it.baselinePolicyId shouldBe "fixed:90"
+            }
+
+        // Wrong types for the auxiliary fields; the transition itself survives intact.
+        decodeRuleRuntimeState(
+            """{"phase":"RESTORE_PENDING","targetPolicyId":"adaptive",""" +
+                """"suspendedRuleIds":"nope","lastApplyFailed":"yes"}""",
+        ).let {
+            it.phase shouldBe RulePhase.RESTORE_PENDING
+            it.targetPolicyId shouldBe "adaptive"
+            it.suspendedRuleIds shouldBe emptySet()
+            it.lastApplyFailed shouldBe false
+        }
+
+        // Only unparseable JSON loses the whole record.
+        decodeRuleRuntimeState("not json at all") shouldBe RuleRuntimeState()
+        decodeRuleRuntimeState(null) shouldBe RuleRuntimeState()
+        // Nothing recorded at all reads as idle, not as a phantom activation.
+        decodeRuleRuntimeState("{}") shouldBe RuleRuntimeState()
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardInterruptionCardTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardInterruptionCardTest.kt
@@ -64,6 +64,7 @@ class DashboardInterruptionCardTest {
                 onAlarmEnabledChange = {},
                 onAlarmTargetChange = {},
                 onFixNotifications = {},
+                onOpenConditions = {},
                 onOpenBatteryHub = {},
                 onRetryCapture = {},
                 onPinWidget = {},

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenGestureTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenGestureTest.kt
@@ -377,6 +377,7 @@ private fun DashboardScreenForTest(state: DashboardUiState) {
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenUnderTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenUnderTest.kt
@@ -25,6 +25,7 @@ internal fun DashboardScreenUnderTest(
         onAlarmEnabledChange = {},
         onAlarmTargetChange = {},
         onFixNotifications = {},
+        onOpenConditions = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
         onPinWidget = {},

--- a/app/src/test/java/eu/darken/amply/main/ui/settings/SettingsScreenTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/settings/SettingsScreenTest.kt
@@ -48,6 +48,8 @@ class SettingsScreenTest {
                 onGeneral = {},
                 gestureEnabled = true,
                 onCharging = {},
+                activeRuleCount = 0,
+                onChargeRules = {},
                 captureEnabled = true,
                 onChargingHistory = {},
                 showDiagnostics = true,

--- a/app/src/test/java/eu/darken/amply/monitor/core/ChargeMonitorWatcherGraphTest.kt
+++ b/app/src/test/java/eu/darken/amply/monitor/core/ChargeMonitorWatcherGraphTest.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import dagger.hilt.components.SingletonComponent
 import eu.darken.amply.alarm.core.ChargeAlarmWatcher
+import eu.darken.amply.rules.core.RulesWatcher
 import eu.darken.amply.stats.core.ChargeStatsWatcher
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
@@ -60,5 +61,19 @@ class ChargeMonitorWatcherGraphTest {
 
         watchers.map { it.id } shouldContain "battery_stats"
         watchers.any { it is ChargeStatsWatcher } shouldBe true
+    }
+
+    @Test
+    fun `the charge rules watcher is bound into the monitor watcher set`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val watchers = EntryPointAccessors.fromApplication(
+            context,
+            WatcherEntryPoint::class.java,
+        ).watchers()
+
+        // Keep-alive only (rules are evaluated by the service directly), so an absent binding would
+        // not break a tick — it would let the service stop while rules still need it.
+        watchers.map { it.id } shouldContain "charge_rules"
+        watchers.any { it is RulesWatcher } shouldBe true
     }
 }

--- a/app/src/test/java/eu/darken/amply/rules/core/BluetoothRuleReceiverTest.kt
+++ b/app/src/test/java/eu/darken/amply/rules/core/BluetoothRuleReceiverTest.kt
@@ -1,0 +1,97 @@
+package eu.darken.amply.rules.core
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * The receiver is the only live "is it connected" signal, so what it persists is what every later
+ * evaluation believes. Robolectric because a real [BluetoothDevice] extra is what the parsing has to
+ * survive — the interesting failure is an intent shape, not a decision.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class BluetoothRuleReceiverTest {
+
+    private val address = "AA:BB:CC:DD:EE:FF"
+    private lateinit var scope: CoroutineScope
+    private lateinit var tempDir: File
+    private lateinit var store: ChargeRulesStore
+    private lateinit var receiver: BluetoothRuleReceiver
+
+    @Before
+    fun setup() {
+        scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        tempDir = Files.createTempDirectory("rules-receiver").toFile()
+        val dataStore = testDataStore(scope, tempDir)
+        store = testRulesStore(dataStore)
+        receiver = BluetoothRuleReceiver().apply {
+            applier = RuleApplier(
+                store = store,
+                gateway = FakeChargeGateway(),
+                preferences = testPreferences(dataStore),
+                upgradeRepo = FakeUpgradeRepo(),
+                bluetooth = FakeBluetoothSource(),
+                bootCountProvider = bootCount(3),
+            )
+        }
+    }
+
+    @After
+    fun teardown() {
+        scope.cancel()
+        tempDir.deleteRecursively()
+    }
+
+    private fun aclIntent(action: String): Intent = Intent(action).putExtra(
+        BluetoothDevice.EXTRA_DEVICE,
+        BluetoothAdapter.getDefaultAdapter().getRemoteDevice(address),
+    )
+
+    private fun deliver(action: String) = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val update = BluetoothRuleReceiver.parse(aclIntent(action))!!
+        receiver.handleUpdate(context, update)
+    }
+
+    @Test
+    fun `an ACL connect adds the device to the snapshot`() {
+        deliver(BluetoothDevice.ACTION_ACL_CONNECTED)
+
+        runBlocking { store.btSnapshotNow() }.let {
+            it.addresses shouldBe setOf(address)
+            it.bootCount shouldBe 3
+        }
+    }
+
+    @Test
+    fun `an ACL disconnect removes the device again`() {
+        deliver(BluetoothDevice.ACTION_ACL_CONNECTED)
+        deliver(BluetoothDevice.ACTION_ACL_DISCONNECTED)
+
+        runBlocking { store.btSnapshotNow() }.addresses.shouldBeEmpty()
+    }
+
+    @Test
+    fun `unrelated broadcasts are ignored`() {
+        BluetoothRuleReceiver.parse(aclIntent(BluetoothDevice.ACTION_FOUND)) shouldBe null
+        BluetoothRuleReceiver.parse(Intent(BluetoothDevice.ACTION_ACL_CONNECTED)) shouldBe null
+    }
+}

--- a/app/src/test/java/eu/darken/amply/rules/core/RuleApplierTest.kt
+++ b/app/src/test/java/eu/darken/amply/rules/core/RuleApplierTest.kt
@@ -3,8 +3,10 @@ package eu.darken.amply.rules.core
 import eu.darken.amply.charging.core.BackendKind
 import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.ChargingPreferences
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -36,6 +38,7 @@ class RuleApplierTest {
         val gateway: FakeChargeGateway,
         val bluetooth: FakeBluetoothSource,
         val upgrade: FakeUpgradeRepo,
+        val preferences: ChargingPreferences,
         val scope: CoroutineScope,
     )
 
@@ -46,19 +49,20 @@ class RuleApplierTest {
         val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
         val dataStore = testDataStore(scope, tempDir)
         val store = testRulesStore(dataStore)
+        val preferences = testPreferences(dataStore)
         val gateway = FakeChargeGateway()
         val bluetooth = FakeBluetoothSource()
         val upgrade = FakeUpgradeRepo()
         val applier = RuleApplier(
             store = store,
             gateway = gateway,
-            preferences = testPreferences(dataStore),
+            preferences = preferences,
             upgradeRepo = upgrade,
             bluetooth = bluetooth,
             bootCountProvider = bootCount(bootCountValue),
         )
         try {
-            Fixture(applier, store, gateway, bluetooth, upgrade, scope).block()
+            Fixture(applier, store, gateway, bluetooth, upgrade, preferences, scope).block()
         } finally {
             scope.cancel()
         }
@@ -117,6 +121,27 @@ class RuleApplierTest {
         store.runtimeNow().phase shouldBe RulePhase.ACTIVE
         store.runtimeNow().lastApplyFailed shouldBe false
         gateway.writes shouldContainExactly listOf(adaptive, adaptive)
+    }
+
+    @Test
+    fun `a successful write stamps the journal's own timestamp, not a fresh clock read`() = fixture {
+        // The engine compares these two to spot another component writing past the rules layer, so
+        // the stamp must be a COPY. Two independent `now`s could differ by milliseconds and make the
+        // layer look overwritten by its own write.
+        gateway.journal = preferences
+        applier.addRule(btRule())
+        connect()
+
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false)
+
+        val journalAt = preferences.lastRequestedAtNow()
+        journalAt shouldBeGreaterThan 0L
+        store.runtimeNow().lastWriteAt shouldBe journalAt
+
+        // And the layer must not then read its own write as divergence on the following tick.
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false)
+        store.runtimeNow().phase shouldBe RulePhase.ACTIVE
+        store.runtimeNow().suspendedRuleIds.shouldBeEmpty()
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/rules/core/RuleApplierTest.kt
+++ b/app/src/test/java/eu/darken/amply/rules/core/RuleApplierTest.kt
@@ -1,0 +1,266 @@
+package eu.darken.amply.rules.core
+
+import eu.darken.amply.charging.core.BackendKind
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * The applier's own responsibilities: crash-safe write ordering, what a failed write leaves behind,
+ * when the Bluetooth snapshot is trustworthy, and the session handoff. What to *decide* is
+ * `RuleEngineTest`'s job.
+ */
+class RuleApplierTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val limit80 = ChargePolicy.FixedLimit(80)
+    private val limit90 = ChargePolicy.FixedLimit(90)
+    private val adaptive = ChargePolicy.Adaptive
+    private val carAddress = "AA:BB:CC:DD:EE:FF"
+
+    private class Fixture(
+        val applier: RuleApplier,
+        val store: ChargeRulesStore,
+        val gateway: FakeChargeGateway,
+        val bluetooth: FakeBluetoothSource,
+        val upgrade: FakeUpgradeRepo,
+        val scope: CoroutineScope,
+    )
+
+    private fun fixture(
+        bootCountValue: Int? = 7,
+        block: suspend Fixture.() -> Unit,
+    ) = runBlocking {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        val dataStore = testDataStore(scope, tempDir)
+        val store = testRulesStore(dataStore)
+        val gateway = FakeChargeGateway()
+        val bluetooth = FakeBluetoothSource()
+        val upgrade = FakeUpgradeRepo()
+        val applier = RuleApplier(
+            store = store,
+            gateway = gateway,
+            preferences = testPreferences(dataStore),
+            upgradeRepo = upgrade,
+            bluetooth = bluetooth,
+            bootCountProvider = bootCount(bootCountValue),
+        )
+        try {
+            Fixture(applier, store, gateway, bluetooth, upgrade, scope).block()
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    private fun btRule(id: String = "car", policy: ChargePolicy = adaptive) = ChargeRule(
+        id = id,
+        label = id,
+        condition = RuleCondition.BluetoothDevice(carAddress),
+        policyId = policy.stableId,
+    )
+
+    private suspend fun Fixture.connect(address: String = carAddress) {
+        applier.onBluetoothConnectionChanged(address, connected = true)
+    }
+
+    @Test
+    fun `the runtime intent is persisted before the policy write`() = fixture {
+        applier.addRule(btRule())
+        connect()
+        // Sampled from inside the write, which is the only way to prove the ordering: a crash here
+        // must leave a pending phase and the baseline, not an unrecorded policy change.
+        var atWrite: RuleRuntimeState? = null
+        gateway.onWrite = { atWrite = store.runtimeNow() }
+        gateway.configured = ChargeObservation.Verified(limit90, BackendKind.SHIZUKU)
+
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false)
+
+        atWrite!!.phase shouldBe RulePhase.APPLY_PENDING
+        atWrite!!.targetPolicyId shouldBe adaptive.stableId
+        atWrite!!.baselinePolicyId shouldBe limit90.stableId
+        atWrite!!.activeRuleId shouldBe "car"
+        // Finalized only after the write came back successful.
+        store.runtimeNow().phase shouldBe RulePhase.ACTIVE
+        store.runtimeNow().lastApplyFailed shouldBe false
+        gateway.writes shouldContainExactly listOf(adaptive)
+    }
+
+    @Test
+    fun `a failed write keeps the pending phase and flags the failure`() = fixture {
+        applier.addRule(btRule())
+        connect()
+        gateway.writeSucceeds = false
+
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false)
+
+        val runtime = store.runtimeNow()
+        runtime.phase shouldBe RulePhase.APPLY_PENDING
+        runtime.lastApplyFailed shouldBe true
+        runtime.baselinePolicyId shouldBe limit80.stableId
+
+        // The next tick retries; a success clears both the phase and the flag.
+        gateway.writeSucceeds = true
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false)
+
+        store.runtimeNow().phase shouldBe RulePhase.ACTIVE
+        store.runtimeNow().lastApplyFailed shouldBe false
+        gateway.writes shouldContainExactly listOf(adaptive, adaptive)
+    }
+
+    @Test
+    fun `a connection snapshot from another boot is not evidence`() = fixture(bootCountValue = 8) {
+        applier.addRule(btRule())
+        // Written during boot 7; this process is in boot 8, so those connections cannot still exist.
+        store.updateBtSnapshot { BtConnectionSnapshot(addresses = setOf(carAddress), bootCount = 7) }
+
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false)
+
+        gateway.writes.shouldBeEmpty()
+        store.btSnapshotNow().addresses.shouldBeEmpty()
+    }
+
+    @Test
+    fun `a missing bluetooth permission reads as nothing connected`() = fixture {
+        applier.addRule(btRule())
+        connect()
+        gateway.configured = ChargeObservation.Verified(limit90, BackendKind.SHIZUKU)
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false)
+        store.runtimeNow().phase shouldBe RulePhase.ACTIVE
+
+        // Permission revoked: nothing can observe the device any more, so the rule must let go of
+        // the policy rather than hold it on stale evidence.
+        bluetooth.permission = false
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false)
+
+        gateway.writes shouldContainExactly listOf(adaptive, limit90)
+        store.runtimeNow().phase shouldBe RulePhase.IDLE
+    }
+
+    @Test
+    fun `reconciliation replaces the snapshot with what the profiles report`() = fixture {
+        applier.addRule(btRule())
+        connect()
+        // The device disconnected while Amply was not running, so the receiver never saw it go.
+        bluetooth.live = emptySet()
+
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false, reconcileBluetooth = true)
+
+        store.btSnapshotNow().addresses.shouldBeEmpty()
+        gateway.writes.shouldBeEmpty()
+    }
+
+    @Test
+    fun `a lapsed entitlement blocks the write entirely`() = fixture {
+        applier.addRule(btRule())
+        connect()
+        upgrade.pro = false
+
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false)
+
+        gateway.writes.shouldBeEmpty()
+        store.runtimeNow().phase shouldBe RulePhase.IDLE
+    }
+
+    @Test
+    fun `suspending the cohort drops rule ownership without a write`() = fixture {
+        applier.addRule(btRule("car"))
+        applier.addRule(btRule("car2"))
+        applier.addRule(
+            ChargeRule(
+                id = "desk",
+                label = "desk",
+                condition = RuleCondition.BluetoothDevice("11:22:33:44:55:66"),
+                policyId = limit90.stableId,
+            ),
+        )
+        connect()
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false)
+        store.runtimeNow().phase shouldBe RulePhase.ACTIVE
+        gateway.writes.clear()
+
+        applier.suspendMatchingCohort(plugged = false, plugKind = null)
+
+        val runtime = store.runtimeNow()
+        // Every matching rule, not just the winner — the runner-up would otherwise re-apply at once.
+        runtime.suspendedRuleIds shouldBe setOf("car", "car2")
+        runtime.phase shouldBe RulePhase.IDLE
+        // Adopting the user's write means NOT restoring: their choice is the intended end state.
+        gateway.writes.shouldBeEmpty()
+
+        // And no rule may take the policy back while a suspended one still matches.
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false)
+        gateway.writes.shouldBeEmpty()
+    }
+
+    @Test
+    fun `the session handoff reads the baseline and only then drops ownership`() = fixture {
+        applier.addRule(btRule())
+        connect()
+        gateway.configured = ChargeObservation.Verified(limit90, BackendKind.SHIZUKU)
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = false)
+
+        // The session is handed the user's real baseline, not the rule's override.
+        applier.readActiveBaseline() shouldBe limit90
+
+        applier.clearActiveAfterSessionPersist()
+
+        applier.readActiveBaseline() shouldBe null
+        store.runtimeNow().phase shouldBe RulePhase.IDLE
+        // No write: the session owns the policy now.
+        gateway.writes shouldContainExactly listOf(adaptive)
+    }
+
+    @Test
+    fun `an active session leaves the rules layer alone`() = fixture {
+        applier.addRule(btRule())
+        connect()
+
+        applier.evaluate(plugged = false, plugKind = null, sessionActive = true)
+
+        gateway.writes.shouldBeEmpty()
+        store.runtimeNow().phase shouldBe RulePhase.IDLE
+    }
+
+    @Test
+    fun `the service is required while a rule is enabled or work is owed`() = fixture {
+        applier.isServiceRequired() shouldBe false
+
+        applier.addRule(btRule())
+        applier.isServiceRequired() shouldBe true
+
+        applier.setRuleEnabled("car", false)
+        applier.isServiceRequired() shouldBe false
+
+        // A suspension cohort still has to be watched for its rules to stop matching.
+        store.updateRuntime { it.copy(suspendedRuleIds = setOf("car")) }
+        applier.isServiceRequired() shouldBe true
+    }
+
+    @Test
+    fun `reordering moves a rule one position and clamps at the ends`() = fixture {
+        applier.addRule(btRule("a"))
+        applier.addRule(btRule("b"))
+        applier.addRule(btRule("c"))
+
+        applier.moveRule("c", up = true)
+        store.rulesNow().map { it.id } shouldContainExactly listOf("a", "c", "b")
+
+        applier.moveRule("a", up = true)
+        store.rulesNow().map { it.id } shouldContainExactly listOf("a", "c", "b")
+
+        applier.moveRule("a", up = false)
+        store.rulesNow().map { it.id } shouldContainExactly listOf("c", "a", "b")
+    }
+}

--- a/app/src/test/java/eu/darken/amply/rules/core/RuleEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/rules/core/RuleEngineTest.kt
@@ -57,6 +57,9 @@ class RuleEngineTest {
         chargerTypeSupported = chargerTypeSupported,
     )
 
+    /** What a control-capable adapter offers; the fixtures below all draw their policies from it. */
+    private val adapterPolicies = setOf(limit80, limit90, adaptive, full).map { it.stableId }.toSet()
+
     private fun evaluate(
         rules: List<ChargeRule>,
         snapshot: ConditionSnapshot = ConditionSnapshot(),
@@ -66,7 +69,7 @@ class RuleEngineTest {
         proSettled: Boolean = true,
         lastPersistent: ChargePolicy? = null,
         defaultProtective: ChargePolicy = limit80,
-        supportedPolicyIds: Set<String> = emptySet(),
+        supportedPolicyIds: Set<String> = adapterPolicies,
         lastRequestedPolicy: ChargePolicy? = null,
         lastRequestedAt: Long = 0L,
     ) = RuleEngine.evaluate(
@@ -348,10 +351,34 @@ class RuleEngineTest {
 
         evaluate(listOf(unsupported, usable), connected(carAddress), supportedPolicyIds = supported)
             .action.shouldBeInstanceOf<RuleAction.Activate>().rule.id shouldBe "usable"
+    }
 
-        // An empty set means adapter selection has not resolved yet, which must not disable rules.
-        evaluate(listOf(unsupported), connected(carAddress), supportedPolicyIds = emptySet())
-            .action.shouldBeInstanceOf<RuleAction.Activate>()
+    @Test
+    fun `an adapter that can apply nothing matches nothing`() {
+        // An empty set is a real answer, not a missing one: the diagnostics-only lab adapters declare
+        // exactly that. Reading it permissively would let every rule activate on a device where no
+        // write can ever land.
+        evaluate(listOf(btRule("a")), connected(carAddress), supportedPolicyIds = emptySet())
+            .action shouldBe RuleAction.Noop
+    }
+
+    @Test
+    fun `a suspended rule that can no longer act stops holding the cohort closed`() {
+        // `blocker` is suspended and still connected, but its policy is not one this adapter offers,
+        // so it can never re-apply — keeping the cohort closed on it would strand `usable` forever.
+        val blocker = btRule("blocker", policy = ChargePolicy.PauseAtFull)
+        val usable = btRule("usable", policy = adaptive)
+        val runtime = RuleRuntimeState(suspendedRuleIds = setOf("blocker"))
+
+        val decision = evaluate(
+            rules = listOf(blocker, usable),
+            snapshot = connected(carAddress),
+            runtime = runtime,
+            supportedPolicyIds = setOf(adaptive.stableId),
+        )
+
+        decision.suspendedRuleIds.shouldBeEmpty()
+        decision.action.shouldBeInstanceOf<RuleAction.Activate>().rule.id shouldBe "usable"
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/rules/core/RuleEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/rules/core/RuleEngineTest.kt
@@ -66,6 +66,9 @@ class RuleEngineTest {
         proSettled: Boolean = true,
         lastPersistent: ChargePolicy? = null,
         defaultProtective: ChargePolicy = limit80,
+        supportedPolicyIds: Set<String> = emptySet(),
+        lastRequestedPolicy: ChargePolicy? = null,
+        lastRequestedAt: Long = 0L,
     ) = RuleEngine.evaluate(
         rules = rules,
         snapshot = snapshot,
@@ -75,6 +78,9 @@ class RuleEngineTest {
         proSettled = proSettled,
         lastPersistent = lastPersistent,
         defaultProtective = defaultProtective,
+        supportedPolicyIds = supportedPolicyIds,
+        lastRequestedPolicy = lastRequestedPolicy,
+        lastRequestedAt = lastRequestedAt,
     )
 
     private fun activeOn(rule: ChargeRule, baseline: ChargePolicy = limit80) = RuleRuntimeState(
@@ -251,6 +257,101 @@ class RuleEngineTest {
         // user's fresh choice on the very next tick.
         decision.action shouldBe RuleAction.AdoptExternal(setOf("top", "other"))
         decision.suspendedRuleIds shouldBe setOf("top", "other")
+    }
+
+    @Test
+    fun `an unrecognized configured value is external divergence, not a rule's own state`() {
+        // The rules layer only ever writes values Amply can name, so an unnameable one is by
+        // definition somebody else's — and carrying on as if the rule owned the policy would end in
+        // overwriting a mode Amply cannot reproduce.
+        val top = btRule("top", policy = adaptive)
+        val other = btRule("other", policy = limit90)
+
+        val decision = evaluate(
+            rules = listOf(top, other),
+            snapshot = connected(carAddress),
+            runtime = activeOn(top),
+            configured = ChargeObservation.Unknown("vendor mode 7".toCaString(), unrecognizedValue = true),
+        )
+
+        decision.action shouldBe RuleAction.AdoptExternal(setOf("top", "other"))
+        decision.suspendedRuleIds shouldBe setOf("top", "other")
+    }
+
+    @Test
+    fun `a merely unreadable state is not divergence`() {
+        val rule = btRule("a", policy = adaptive)
+
+        evaluate(
+            rules = listOf(rule),
+            snapshot = connected(carAddress),
+            runtime = activeOn(rule),
+            configured = ChargeObservation.Unknown("no backend".toCaString()),
+        ).action shouldBe RuleAction.Noop
+    }
+
+    @Test
+    fun `a newer journal entry naming another policy is external divergence`() {
+        // Every Amply write path records into the shared journal after the physical write, so an
+        // entry newer than this activation naming a different policy proves something else wrote
+        // past the rules layer. This is the only divergence signal on adapters with no readback.
+        val top = btRule("top", policy = adaptive)
+        val other = btRule("other", policy = limit90)
+        val runtime = activeOn(top).copy(lastWriteAt = 1_000L)
+
+        val decision = evaluate(
+            rules = listOf(top, other),
+            snapshot = connected(carAddress),
+            runtime = runtime,
+            lastRequestedPolicy = full,
+            lastRequestedAt = 2_000L,
+        )
+
+        decision.action shouldBe RuleAction.AdoptExternal(setOf("top", "other"))
+    }
+
+    @Test
+    fun `the rules layer's own write is not divergence`() {
+        val rule = btRule("a", policy = adaptive)
+        val runtime = activeOn(rule).copy(lastWriteAt = 1_000L)
+
+        // Same policy, newer stamp: this is exactly what the rules layer's own write looks like once
+        // the repository's journal entry lands (the stamp is copied from it, so equality is normal).
+        evaluate(
+            rules = listOf(rule),
+            snapshot = connected(carAddress),
+            runtime = runtime,
+            lastRequestedPolicy = adaptive,
+            lastRequestedAt = 2_000L,
+        ).action shouldBe RuleAction.Noop
+
+        // A journal entry OLDER than the activation is history, not an overwrite.
+        evaluate(
+            rules = listOf(rule),
+            snapshot = connected(carAddress),
+            runtime = runtime,
+            lastRequestedPolicy = full,
+            lastRequestedAt = 500L,
+        ).action shouldBe RuleAction.Noop
+    }
+
+    @Test
+    fun `a policy this adapter cannot apply never matches`() {
+        // Decodable, but not in the adapter's list: matching on it would park the layer in a
+        // permanently failing pending phase, since the write path refuses it.
+        val unsupported = btRule("unsupported", policy = ChargePolicy.PauseAtFull)
+        val usable = btRule("usable", policy = adaptive)
+        val supported = setOf(adaptive.stableId, limit80.stableId)
+
+        evaluate(listOf(unsupported), connected(carAddress), supportedPolicyIds = supported)
+            .action shouldBe RuleAction.Noop
+
+        evaluate(listOf(unsupported, usable), connected(carAddress), supportedPolicyIds = supported)
+            .action.shouldBeInstanceOf<RuleAction.Activate>().rule.id shouldBe "usable"
+
+        // An empty set means adapter selection has not resolved yet, which must not disable rules.
+        evaluate(listOf(unsupported), connected(carAddress), supportedPolicyIds = emptySet())
+            .action.shouldBeInstanceOf<RuleAction.Activate>()
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/rules/core/RuleEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/rules/core/RuleEngineTest.kt
@@ -1,0 +1,419 @@
+package eu.darken.amply.rules.core
+
+import eu.darken.amply.charging.core.BackendKind
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.common.ca.toCaString
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+/**
+ * The whole precedence stack lives in [RuleEngine], so this is where the safety properties are
+ * pinned: never overwrite a state Amply cannot restore, never lose the user's baseline, never
+ * re-apply over a choice the user just made by hand.
+ */
+class RuleEngineTest {
+
+    private val limit80 = ChargePolicy.FixedLimit(80)
+    private val limit90 = ChargePolicy.FixedLimit(90)
+    private val adaptive = ChargePolicy.Adaptive
+    private val full = ChargePolicy.Unrestricted
+
+    private val carAddress = "AA:BB:CC:DD:EE:FF"
+
+    private fun btRule(
+        id: String,
+        address: String = carAddress,
+        policy: ChargePolicy = limit80,
+        enabled: Boolean = true,
+    ) = ChargeRule(
+        id = id,
+        enabled = enabled,
+        label = id,
+        condition = RuleCondition.BluetoothDevice(address),
+        policyId = policy.stableId,
+    )
+
+    private fun chargerRule(
+        id: String,
+        types: Set<PlugKind> = setOf(PlugKind.AC),
+        policy: ChargePolicy = full,
+        enabled: Boolean = true,
+    ) = ChargeRule(
+        id = id,
+        enabled = enabled,
+        label = id,
+        condition = RuleCondition.ChargerType(types),
+        policyId = policy.stableId,
+    )
+
+    private fun connected(vararg addresses: String) = ConditionSnapshot(btAddresses = addresses.toSet())
+
+    private fun pluggedInto(kind: PlugKind, chargerTypeSupported: Boolean = true) = ConditionSnapshot(
+        plugged = true,
+        plugKind = kind,
+        chargerTypeSupported = chargerTypeSupported,
+    )
+
+    private fun evaluate(
+        rules: List<ChargeRule>,
+        snapshot: ConditionSnapshot = ConditionSnapshot(),
+        runtime: RuleRuntimeState = RuleRuntimeState(),
+        configured: ChargeObservation? = null,
+        sessionActive: Boolean = false,
+        proSettled: Boolean = true,
+        lastPersistent: ChargePolicy? = null,
+        defaultProtective: ChargePolicy = limit80,
+    ) = RuleEngine.evaluate(
+        rules = rules,
+        snapshot = snapshot,
+        runtime = runtime,
+        configured = configured,
+        sessionActive = sessionActive,
+        proSettled = proSettled,
+        lastPersistent = lastPersistent,
+        defaultProtective = defaultProtective,
+    )
+
+    private fun activeOn(rule: ChargeRule, baseline: ChargePolicy = limit80) = RuleRuntimeState(
+        phase = RulePhase.ACTIVE,
+        targetPolicyId = rule.policyId,
+        activeRuleId = rule.id,
+        baselinePolicyId = baseline.stableId,
+    )
+
+    @Test
+    fun `the first matching enabled rule wins regardless of kind`() {
+        val charge = btRule("charge", policy = full)
+        val protect = btRule("protect", policy = adaptive)
+
+        val decision = evaluate(listOf(charge, protect), connected(carAddress))
+
+        decision.action.shouldBeInstanceOf<RuleAction.Activate>().rule.id shouldBe "charge"
+
+        // Order alone decides — flipping it flips the winner, across the kind boundary.
+        evaluate(listOf(protect, charge), connected(carAddress))
+            .action.shouldBeInstanceOf<RuleAction.Activate>().rule.id shouldBe "protect"
+    }
+
+    @Test
+    fun `a bluetooth rule matches while unplugged`() {
+        val decision = evaluate(listOf(btRule("a")), connected(carAddress))
+
+        decision.action.shouldBeInstanceOf<RuleAction.Activate>()
+    }
+
+    @Test
+    fun `bluetooth addresses match case-insensitively`() {
+        val rule = btRule("a", address = carAddress.lowercase())
+
+        evaluate(listOf(rule), connected(carAddress)).action.shouldBeInstanceOf<RuleAction.Activate>()
+    }
+
+    @Test
+    fun `a bluetooth rule stops matching once the device is gone`() {
+        val rule = btRule("a")
+
+        evaluate(listOf(rule), connected("11:22:33:44:55:66"), runtime = activeOn(rule)).action shouldBe
+            RuleAction.Restore(limit80)
+    }
+
+    @Test
+    fun `a charger rule needs both power and a listed plug kind`() {
+        val rule = chargerRule("a", types = setOf(PlugKind.AC))
+
+        evaluate(listOf(rule), pluggedInto(PlugKind.AC)).action.shouldBeInstanceOf<RuleAction.Activate>()
+        evaluate(listOf(rule), pluggedInto(PlugKind.USB)).action shouldBe RuleAction.Noop
+        // Unplugged: a charger-type condition is about being on that charger, nothing else.
+        evaluate(listOf(rule), ConditionSnapshot(plugged = false, plugKind = null)).action shouldBe RuleAction.Noop
+    }
+
+    @Test
+    fun `a charger rule with no selected type matches nothing`() {
+        val rule = chargerRule("a", types = emptySet())
+
+        evaluate(listOf(rule), pluggedInto(PlugKind.AC)).action shouldBe RuleAction.Noop
+    }
+
+    @Test
+    fun `charger rules never match on a plug-latched adapter`() {
+        // The ROM samples the policy at plug time, so a write triggered BY the plug always lands too
+        // late to have any effect. Such a rule must never claim to be doing something.
+        val rule = chargerRule("a")
+
+        evaluate(listOf(rule), pluggedInto(PlugKind.AC, chargerTypeSupported = false)).action shouldBe
+            RuleAction.Noop
+    }
+
+    @Test
+    fun `disabled rules and rules with an unreadable policy never win`() {
+        val disabled = btRule("disabled", enabled = false)
+        val unreadable = ChargeRule(
+            id = "future",
+            condition = RuleCondition.BluetoothDevice(carAddress),
+            policyId = "vendor-mode-7",
+        )
+        val usable = btRule("usable", policy = adaptive)
+
+        evaluate(listOf(disabled, unreadable, usable), connected(carAddress))
+            .action.shouldBeInstanceOf<RuleAction.Activate>().rule.id shouldBe "usable"
+    }
+
+    @Test
+    fun `activation adopts the freshly read policy as the baseline, over a stale journal`() {
+        val decision = evaluate(
+            rules = listOf(btRule("a", policy = full)),
+            snapshot = connected(carAddress),
+            configured = ChargeObservation.Verified(limit90, BackendKind.SHIZUKU),
+            // The journal is what Amply last wrote; the user may have changed it natively since.
+            lastPersistent = limit80,
+        )
+
+        decision.action.shouldBeInstanceOf<RuleAction.Activate>().baseline shouldBe limit90
+    }
+
+    @Test
+    fun `an unreadable state falls back to the journal, then to the adapter default`() {
+        val rules = listOf(btRule("a", policy = full))
+
+        evaluate(rules, connected(carAddress), configured = null, lastPersistent = adaptive)
+            .action.shouldBeInstanceOf<RuleAction.Activate>().baseline shouldBe adaptive
+
+        evaluate(rules, connected(carAddress), configured = null, lastPersistent = null, defaultProtective = limit90)
+            .action.shouldBeInstanceOf<RuleAction.Activate>().baseline shouldBe limit90
+    }
+
+    @Test
+    fun `a readable but unrecognized native value refuses activation`() {
+        // Amply cannot name this mode, so it cannot put it back — overwriting it would destroy the
+        // user's configuration with no way to reproduce it.
+        val decision = evaluate(
+            rules = listOf(btRule("a", policy = full)),
+            snapshot = connected(carAddress),
+            configured = ChargeObservation.Unknown("odd".toCaString(), unrecognizedValue = true),
+        )
+
+        decision.action shouldBe RuleAction.Noop
+    }
+
+    @Test
+    fun `a higher-priority rule takes over while keeping the original baseline`() {
+        val top = btRule("top", policy = full)
+        val low = btRule("low", policy = adaptive)
+
+        val decision = evaluate(
+            rules = listOf(top, low),
+            snapshot = connected(carAddress),
+            runtime = activeOn(low, baseline = limit90),
+            // What is configured now is the ACTIVE RULE's override, never a baseline candidate.
+            configured = ChargeObservation.Verified(adaptive, BackendKind.SHIZUKU),
+        )
+
+        val switch = decision.action.shouldBeInstanceOf<RuleAction.Switch>()
+        switch.rule.id shouldBe "top"
+        switch.baseline shouldBe limit90
+    }
+
+    @Test
+    fun `editing the active rule's policy re-applies it`() {
+        val rule = btRule("a", policy = adaptive)
+        val runtime = activeOn(rule).copy(targetPolicyId = full.stableId)
+
+        val decision = evaluate(listOf(rule), connected(carAddress), runtime = runtime)
+
+        decision.action.shouldBeInstanceOf<RuleAction.Switch>().policy shouldBe adaptive
+    }
+
+    @Test
+    fun `a settled activation that still wins does nothing`() {
+        val rule = btRule("a")
+
+        evaluate(listOf(rule), connected(carAddress), runtime = activeOn(rule)).action shouldBe RuleAction.Noop
+    }
+
+    @Test
+    fun `an external change is adopted and suspends every matching rule`() {
+        val top = btRule("top", policy = adaptive)
+        val other = btRule("other", policy = limit90)
+        val unmatched = chargerRule("charger")
+
+        val decision = evaluate(
+            rules = listOf(top, other, unmatched),
+            snapshot = connected(carAddress),
+            runtime = activeOn(top),
+            // Neither the rule's policy nor the baseline: somebody else wrote this.
+            configured = ChargeObservation.Verified(full, BackendKind.SHIZUKU),
+        )
+
+        // The whole matching cohort, not just the winner: otherwise `other` would re-apply over the
+        // user's fresh choice on the very next tick.
+        decision.action shouldBe RuleAction.AdoptExternal(setOf("top", "other"))
+        decision.suspendedRuleIds shouldBe setOf("top", "other")
+    }
+
+    @Test
+    fun `divergence is never claimed without a readback`() {
+        val rule = btRule("a", policy = adaptive)
+
+        evaluate(
+            rules = listOf(rule),
+            snapshot = connected(carAddress),
+            runtime = activeOn(rule),
+            configured = ChargeObservation.LastRequested(full),
+        ).action shouldBe RuleAction.Noop
+    }
+
+    @Test
+    fun `a suspended rule blocks activation while it still matches`() {
+        val rule = btRule("a")
+        val runtime = RuleRuntimeState(suspendedRuleIds = setOf("a"))
+
+        val decision = evaluate(listOf(rule), connected(carAddress), runtime = runtime)
+
+        decision.action shouldBe RuleAction.Noop
+        decision.suspendedRuleIds shouldBe setOf("a")
+    }
+
+    @Test
+    fun `a suspended cohort clears once none of its rules match`() {
+        val rule = btRule("a")
+        val runtime = RuleRuntimeState(suspendedRuleIds = setOf("a"))
+
+        val decision = evaluate(listOf(rule), ConditionSnapshot(), runtime = runtime)
+
+        decision.suspendedRuleIds.shouldBeEmpty()
+    }
+
+    @Test
+    fun `a suspended rule that is deleted or disabled stops holding the cohort`() {
+        val runtime = RuleRuntimeState(suspendedRuleIds = setOf("a"))
+
+        evaluate(emptyList(), connected(carAddress), runtime = runtime).suspendedRuleIds.shouldBeEmpty()
+        evaluate(listOf(btRule("a", enabled = false)), connected(carAddress), runtime = runtime)
+            .suspendedRuleIds.shouldBeEmpty()
+    }
+
+    @Test
+    fun `clearing the cohort and acting on the new winner happen in one pass`() {
+        // `car` is suspended and no longer matches; `desk` matches now. A two-pass design would idle
+        // here until the next tick.
+        val car = btRule("car")
+        val desk = btRule("desk", address = "11:22:33:44:55:66", policy = adaptive)
+        val runtime = RuleRuntimeState(suspendedRuleIds = setOf("car"))
+
+        val decision = evaluate(listOf(car, desk), connected("11:22:33:44:55:66"), runtime = runtime)
+
+        decision.suspendedRuleIds.shouldBeEmpty()
+        decision.action.shouldBeInstanceOf<RuleAction.Activate>().rule.id shouldBe "desk"
+    }
+
+    @Test
+    fun `an unconfirmed apply is re-issued while its rule still wins`() {
+        val rule = btRule("a", policy = adaptive)
+        val runtime = RuleRuntimeState(
+            phase = RulePhase.APPLY_PENDING,
+            targetPolicyId = adaptive.stableId,
+            activeRuleId = "a",
+            baselinePolicyId = limit80.stableId,
+        )
+
+        evaluate(listOf(rule), connected(carAddress), runtime = runtime).action shouldBe
+            RuleAction.ReconcilePending(adaptive)
+    }
+
+    @Test
+    fun `an unconfirmed apply whose rule stopped matching resolves to the baseline`() {
+        // The write may or may not have landed, so the baseline is still owed either way.
+        val rule = btRule("a", policy = adaptive)
+        val runtime = RuleRuntimeState(
+            phase = RulePhase.APPLY_PENDING,
+            targetPolicyId = adaptive.stableId,
+            activeRuleId = "a",
+            baselinePolicyId = limit90.stableId,
+        )
+
+        evaluate(listOf(rule), ConditionSnapshot(), runtime = runtime).action shouldBe
+            RuleAction.Restore(limit90)
+    }
+
+    @Test
+    fun `an unconfirmed restore is re-issued`() {
+        val runtime = RuleRuntimeState(
+            phase = RulePhase.RESTORE_PENDING,
+            targetPolicyId = limit90.stableId,
+            baselinePolicyId = limit90.stableId,
+        )
+
+        evaluate(emptyList(), ConditionSnapshot(), runtime = runtime).action shouldBe
+            RuleAction.ReconcilePending(limit90)
+    }
+
+    @Test
+    fun `an unconfirmed restore yields to a rule that matches again`() {
+        val rule = btRule("a", policy = adaptive)
+        val runtime = RuleRuntimeState(
+            phase = RulePhase.RESTORE_PENDING,
+            targetPolicyId = limit90.stableId,
+            baselinePolicyId = limit90.stableId,
+        )
+
+        val switch = evaluate(listOf(rule), connected(carAddress), runtime = runtime)
+            .action.shouldBeInstanceOf<RuleAction.Switch>()
+        switch.policy shouldBe adaptive
+        // Still owed underneath, unchanged.
+        switch.baseline shouldBe limit90
+    }
+
+    @Test
+    fun `an active session clears rule bookkeeping without writing`() {
+        // The session was handed the baseline and owns the restore now; this covers the crash window
+        // between the session being persisted and the rules layer being cleared.
+        val rule = btRule("a")
+
+        evaluate(
+            rules = listOf(rule),
+            snapshot = connected(carAddress),
+            runtime = activeOn(rule),
+            sessionActive = true,
+        ).action shouldBe RuleAction.ClearActiveBookkeeping
+
+        evaluate(listOf(rule), connected(carAddress), sessionActive = true).action shouldBe RuleAction.Noop
+    }
+
+    @Test
+    fun `a lapsed entitlement blocks new activations and switches`() {
+        val top = btRule("top", policy = full)
+        val low = btRule("low", policy = adaptive)
+
+        evaluate(listOf(top), connected(carAddress), proSettled = false).action shouldBe RuleAction.Noop
+        evaluate(
+            rules = listOf(top, low),
+            snapshot = connected(carAddress),
+            runtime = activeOn(low),
+            proSettled = false,
+        ).action shouldBe RuleAction.Noop
+    }
+
+    @Test
+    fun `a lapsed entitlement still restores the baseline`() {
+        val rule = btRule("a", policy = adaptive)
+
+        evaluate(
+            rules = listOf(rule),
+            snapshot = ConditionSnapshot(),
+            runtime = activeOn(rule, baseline = limit90),
+            proSettled = false,
+        ).action shouldBe RuleAction.Restore(limit90)
+    }
+
+    @Test
+    fun `an activation with no recorded baseline is dropped rather than guessed at`() {
+        val rule = btRule("a")
+        val runtime = RuleRuntimeState(phase = RulePhase.ACTIVE, activeRuleId = "a")
+
+        evaluate(listOf(rule), ConditionSnapshot(), runtime = runtime).action shouldBe
+            RuleAction.ClearActiveBookkeeping
+    }
+}

--- a/app/src/test/java/eu/darken/amply/rules/core/RuleTestFakes.kt
+++ b/app/src/test/java/eu/darken/amply/rules/core/RuleTestFakes.kt
@@ -39,7 +39,17 @@ internal class FakeChargeGateway(
     var writeSucceeds: Boolean = true,
     var chargerTypeSupport: Boolean = true,
     var defaultProtective: ChargePolicy = ChargePolicy.FixedLimit(80),
-    var supportedIds: Set<String> = emptySet(),
+    /**
+     * What a control-capable adapter offers. Defaulted rather than empty because the engine reads an
+     * empty set strictly — that is the diagnostics-only lab adapters' answer, and it means no rule
+     * can act at all.
+     */
+    var supportedIds: Set<String> = setOf(
+        ChargePolicy.FixedLimit(80),
+        ChargePolicy.FixedLimit(90),
+        ChargePolicy.Adaptive,
+        ChargePolicy.Unrestricted,
+    ).map { it.stableId }.toSet(),
     /** Set to model the repository's own journal write, which every real write performs. */
     var journal: ChargingPreferences? = null,
 ) : RuleChargeGateway {

--- a/app/src/test/java/eu/darken/amply/rules/core/RuleTestFakes.kt
+++ b/app/src/test/java/eu/darken/amply/rules/core/RuleTestFakes.kt
@@ -39,6 +39,9 @@ internal class FakeChargeGateway(
     var writeSucceeds: Boolean = true,
     var chargerTypeSupport: Boolean = true,
     var defaultProtective: ChargePolicy = ChargePolicy.FixedLimit(80),
+    var supportedIds: Set<String> = emptySet(),
+    /** Set to model the repository's own journal write, which every real write performs. */
+    var journal: ChargingPreferences? = null,
 ) : RuleChargeGateway {
 
     val writes = mutableListOf<ChargePolicy>()
@@ -49,6 +52,9 @@ internal class FakeChargeGateway(
     override suspend fun applyTemporary(policy: ChargePolicy): Boolean {
         writes += policy
         onWrite?.invoke(policy)
+        // The real repository records every successful write to the shared journal, under
+        // NonCancellable, before returning — the rules layer's lastWriteAt stamp copies from it.
+        if (writeSucceeds) journal?.recordRequested(policy, persistent = false)
         // Model a sync-readback adapter: what was successfully written becomes what reads back, so a
         // test only sees "external divergence" when it deliberately sets [configured] behind our
         // back. A fake with no readback at all (null) stays that way — that is the async-hardware case.
@@ -61,6 +67,8 @@ internal class FakeChargeGateway(
     override fun chargerTypeSupported(): Boolean = chargerTypeSupport
 
     override fun defaultProtectivePolicy(): ChargePolicy = defaultProtective
+
+    override fun supportedPolicyIds(): Set<String> = supportedIds
 }
 
 internal class FakeBluetoothSource(

--- a/app/src/test/java/eu/darken/amply/rules/core/RuleTestFakes.kt
+++ b/app/src/test/java/eu/darken/amply/rules/core/RuleTestFakes.kt
@@ -1,0 +1,106 @@
+package eu.darken.amply.rules.core
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import eu.darken.amply.charging.core.BackendKind
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.ChargingPreferences
+import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.serialization.SerializationModule
+import eu.darken.amply.fullcharge.core.BootCountProvider
+import eu.darken.amply.upgrade.core.UpgradeRepo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import java.io.File
+import java.time.Instant
+
+/**
+ * Shared fakes for the rules layer. The stores are real (a temp-file DataStore), because their
+ * tolerant decoding is part of what is under test; only the outward-facing collaborators — the
+ * charging write path, Bluetooth, billing, the boot counter — are stand-ins.
+ */
+internal fun testDataStore(scope: CoroutineScope, dir: File) = AppDataStore(
+    PreferenceDataStoreFactory.create(scope = scope) {
+        File(dir, "rules-${System.nanoTime()}.preferences_pb")
+    },
+)
+
+internal fun testPreferences(store: AppDataStore) = ChargingPreferences(store, SerializationModule.json())
+
+internal fun testRulesStore(store: AppDataStore) = ChargeRulesStore(store, SerializationModule.json())
+
+/**
+ * Records every write in order and lets a test observe the persisted runtime *at the moment of the
+ * write* — which is how the write-ahead ordering is asserted rather than assumed.
+ */
+internal class FakeChargeGateway(
+    var configured: ChargeObservation? = null,
+    var writeSucceeds: Boolean = true,
+    var chargerTypeSupport: Boolean = true,
+    var defaultProtective: ChargePolicy = ChargePolicy.FixedLimit(80),
+) : RuleChargeGateway {
+
+    val writes = mutableListOf<ChargePolicy>()
+    var onWrite: (suspend (ChargePolicy) -> Unit)? = null
+
+    override suspend fun readConfigured(): ChargeObservation? = configured
+
+    override suspend fun applyTemporary(policy: ChargePolicy): Boolean {
+        writes += policy
+        onWrite?.invoke(policy)
+        // Model a sync-readback adapter: what was successfully written becomes what reads back, so a
+        // test only sees "external divergence" when it deliberately sets [configured] behind our
+        // back. A fake with no readback at all (null) stays that way — that is the async-hardware case.
+        if (writeSucceeds && configured != null) {
+            configured = ChargeObservation.Verified(policy, BackendKind.SHIZUKU)
+        }
+        return writeSucceeds
+    }
+
+    override fun chargerTypeSupported(): Boolean = chargerTypeSupport
+
+    override fun defaultProtectivePolicy(): ChargePolicy = defaultProtective
+}
+
+internal class FakeBluetoothSource(
+    var permission: Boolean = true,
+    var live: Set<String>? = null,
+    var bonded: List<BondedDevice> = emptyList(),
+) : BluetoothConnectionSource {
+    override fun hasPermission(): Boolean = permission
+    override suspend fun connectedAddresses(): Set<String>? = live
+    override fun bondedDevices(): List<BondedDevice> = bonded
+}
+
+/**
+ * Backed by a [MutableStateFlow] rather than a finite flow on purpose: `isProSettled` waits for a
+ * Pro emission, and a flow that *completes* without one makes that wait throw — which the gate
+ * catches and fails open on, silently turning a non-Pro fake into a Pro one.
+ */
+internal class FakeUpgradeRepo(pro: Boolean = true) : UpgradeRepo {
+    override val storeSite = ""
+    override val upgradeSite = ""
+    override val betaSite = ""
+
+    private val infoFlow = MutableStateFlow<UpgradeRepo.Info>(FakeInfo(pro))
+
+    var pro: Boolean
+        get() = infoFlow.value.isPro
+        set(value) {
+            infoFlow.value = FakeInfo(value)
+        }
+
+    override val upgradeInfo: Flow<UpgradeRepo.Info> = infoFlow
+
+    override suspend fun refresh() = Unit
+
+    private data class FakeInfo(override val isPro: Boolean) : UpgradeRepo.Info {
+        override val type = UpgradeRepo.Type.FOSS
+        override val isSettled = true
+        override val upgradedAt: Instant? = null
+        override val error: Throwable? = null
+    }
+}
+
+internal fun bootCount(value: Int?) = BootCountProvider { value }


### PR DESCRIPTION
## What changed

Amply can now switch the charging policy automatically based on conditions. A rule pairs a condition — a specific Bluetooth device being connected, or the charger type (AC/USB/wireless/dock) — with a charging policy: for example "in the car (hands-free connected), hold 80%", or "on the bedside dock, allow a full charge". Rules live in one priority-ordered list; the highest matching rule wins, and its policy is applied temporarily and taken back off when the condition ends.

The dashboard gains a conditions card showing the rules in order with the currently winning one highlighted, and the status card names the rule that set the current policy. Rules are managed on a dedicated screen (reorder, enable, edit; Bluetooth device picker from paired devices), reachable from the card and from Settings. Manual choices stay in charge: picking a policy yourself or via the widget pauses the matching rules until their condition next re-occurs, and a one-time full charge runs to completion before rules resume. Changes made in the OEM's own settings are adopted, never fought. Conditional rules are a Pro feature; on GrapheneOS, charger-type conditions are unavailable because that system only samples the charging policy when a charger is plugged in.

## Technical Context

- Rule writes are temporary-class policy writes: the user's persistent baseline journal is never touched by automation, and it is what deactivation restores (freshest readback first, journal as fallback). A readable-but-unrecognized OEM state refuses activation outright — the layer never replaces a state it cannot put back.
- Crash-safety is write-ahead: every transition persists its intent (phase, target, baseline) before the settings write and finalizes after. Overwrites by other components are detected two ways: configured readback where the adapter supports it, and the shared write journal everywhere else — every internal write path records there, so a newer journal entry naming a different policy proves the rules layer was overwritten even on adapters with no readback.
- Precedence is ownership handoff, not polling: a starting one-time session takes the rule's saved baseline as its restore target inside the session-start transaction, and an explicit persistent write durably suspends the whole matching rule cohort before the write happens.
- The evaluation runs as a serialized step of the charge-session service (never inside the budget-bounded watcher ticks); the Bluetooth ACL receiver only persists the connected-set and nudges the service. `RuleEngine` (pure, JVM-tested) plus the `RuleApplier`/`ChargeSessionService` integration points are where review attention pays off most.
- Draft until the physical device matrix has been run on hardware (Bluetooth connect/disconnect transitions, reboot with an active rule, process kill, Shizuku loss, permission revocation, GrapheneOS plug-latch, session-during-rule handoff) — emulators can exercise none of this.
