### PR TITLE
Fix: Open the right battery screen on unsupported devices

### DIFF
--- a/.claude/skills/device-qualification/SKILL.md
+++ b/.claude/skills/device-qualification/SKILL.md
@@ -367,6 +367,24 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
       are compile-time constants, the AIDL has no property op
       (`IChargingControlService.aidl`), and `SystemPropertyReader` structurally cannot distinguish denial from
       absence — so probing a candidate MagicOS property needs a code change, not a contributor run.
+    - **Blocker 2, IDENTITY MECHANISM RESOLVED (support mail, 2026-08-17); version scoping still open.** The
+      contributor supplied both lists from `HNBKQ`. App-readable signals now known to exist on MagicOS 10:
+        - **System features** (`hasSystemFeature`, no permission, no `<queries>` entry — the LineageOS pattern):
+          `com.hihonor.software.features.honor`, `com.hihonor.system.feature`,
+          `com.hihonor.software.features.full`, `com.hihonor.software.features.handset`,
+          `com.hihonor.software.features.oversea`, `com.hihonor.magic.api.23`.
+        - **Core system packages** (PackageManager + `FLAG_SYSTEM` — the GrapheneOS pattern):
+          `com.hihonor.systemserver`, `com.hihonor.systemmanager`, `com.hihonor.powergenie`,
+          `com.hihonor.controlcenter`, `com.hihonor.android.launcher`.
+        - Properties exist too (`ro.build.version.magic=MagicOS_10.0.0`, `ro.build.magic_api_level=42`,
+          `ro.magic.cversion=C636`) but stay the **wrong** route for the SELinux reason above; they are recorded
+          only as corroboration. `ro.product.device=HNBKQ` confirms the fingerprint-derived codename.
+      **What is still missing is ROM-generation scoping.** `com.hihonor.magic.api.23` does not line up with
+      `ro.build.magic_api_level=42`, so that feature reads as a fixed namespace marker rather than a version
+      discriminator — i.e. the features answer "is this MagicOS", not "is this MagicOS 10". Every existing OEM
+      gate is version-scoped (One UI range, `ro.mi.os.version.code`, `oplusrom == 15`); a features-only HONOR gate
+      would be the first that is not, which is exactly the weakness called out above for `Build.MANUFACTURER`.
+      Resolve that before any gate is written, not after.
     - **Level-reporting hazard to test at qualification.** The reporter states Smart battery capacity "still
       displays 100% when fully charged" while capping. A ROM reporting a synthetic 100% at a real ~80% would
       trip `full = status == BATTERY_STATUS_FULL || percent >= 100` in `ChargeSessionService`, ending a session
@@ -393,6 +411,34 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
       `dumpsys battery`, then switch the feature OFF with the cable in and re-record. Voltage and charge counter
       climbing afterwards proves the cap is real and the 100% cosmetic; unchanged means the cell was already full
       and the mode caps nothing. Same evidence shape that settled `tanzanite`.
+      **RESULT (2026-08-17), and it reframes the feature.** Contributor-run, `HNBKQ`:
+
+      | State | Charge counter | status | level | voltage |
+      | --- | --- | --- | --- | --- |
+      | Smart battery capacity ON, plugged, HONOR showing 100% (stable ≥1 min) | 6978 | 2 | 100 | 4551 |
+      | Feature OFF, cable never removed | 6978 (unchanged) | — | — | — |
+      | Feature OFF, after unplug→replug | 7256 | 5 | 100 | 4421 → 4472 |
+
+        - **The synthetic 100% is CONFIRMED in the broadcast, not just the status bar.** `level: 100` with 278 mAh
+          of real headroom, so the sharpenings above are now evidenced rather than inferred. The dumpsys `status: 2`
+          alongside a flat counter also means the ROM reports "charging" while holding.
+        - **But the cap is only ~4%, so Smart battery capacity is NOT an 80%-cap equivalent.** The C636/Singapore
+          variant is the 7100 mAh model (China 7200, Europe 6270; the contributor's own AIDA64 reading of ~7121 mAh
+          corroborates), so 278 mAh ≈ 3.8%. An 80% cap would have plateaued near 5800 mAh. This is a
+          top-of-charge voltage trim, a different class of feature from every currently supported adapter.
+          Consequence: **neither HONOR key is a hard cap** — Smart charge is adaptive (reaches 100% overnight),
+          Smart battery capacity trims ~4% — so an adapter here could offer Adaptive on/off and no percentage at
+          all, with the `allowsFullCharge` honesty gap applying. Weigh that against the build cost before
+          committing to a MagicOS adapter; the mapping being correct is no longer the deciding question.
+        - **`policyLatchesAtPlug` behaviour OBSERVED.** Disabling the feature with the cable in moved nothing; the
+          278 mAh only went in after unplug→replug. Same latch-at-plug-session-start family as GrapheneOS, so an
+          adapter would need `policyLatchesAtPlug = true`, the pending-until-replug state, and the replug grace
+          window rather than anything new. The reconnect gesture would be unsupported for the same timing reason.
+        - Caveats: single run, one sample per state, and the voltage column is not interpretable across rows
+          (4551 was measured under charge, 4421 at `status: 5` resting). The charge counter is the load-bearing
+          number. Note the ~4% figure is a **ratio** (6978/7256), so it survives the charge-counter unit question
+          raised by the telemetry defect below — a uniform 1000× scaling cancels. Only the absolute
+          "278 mAh" framing depends on the unit, and the nominal-capacity cross-check independently supports mAh.
     - **Third key, out of scope: `secure/charge_separation_all_scenarios_switch`** (bypass charging, `1`/`0`,
       reported 2026-08-16). Contributor observation: bypass engages while the screen is on and normal charging
       resumes with the screen off. Recorded as context only — Amply has **no bypass concept at all** (the sole
@@ -405,7 +451,42 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
       "Just send device info" action on the unsupported-device card (`DeviceSupportReporter` emits `device=`
       from `Build.DEVICE`, plus `brand`/`product` and the tri-state key probes; no Shizuku needed) rather than
       another wizard pass, which would omit the codename again.
-    - **Status after the 2026-08-16 follow-up: still NOT qualified, and the gate is unchanged.** One of Blocker
-      1's two halves is closed (keys drive the OEM UI both ways, mirror class excluded); the hardware half and
-      all of Blocker 2 are open. Nothing here justifies an adapter, a lab adapter, or a manufacturer read.
+    - **Three app defects this device exposed (2026-08-17), two of them not HONOR-specific.**
+        - **`FIXED`: "Open battery settings" landed on Battery Saver on every unmapped device.**
+          `ChargingRepository.nativeSettingsIntent()` returned null for `adapter == null` and its only caller
+          substituted `ACTION_BATTERY_SAVER_SETTINGS` outright, so `ACTION_POWER_USAGE_SUMMARY` was never tried —
+          despite every lab adapter preferring it, and despite the manifest already declaring its `<queries>`
+          visibility. Same user-visible symptom as the LineageOS case above, reached by a different path (that one
+          fell through to the Pixel component intent; this one had no adapter object to ask). Affected HONOR,
+          Motorola, Nothing, Sony, Fairphone, Vivo, Tecno — anything without an adapter. Fixed by making the
+          repository fall back to `OemChargingShortcuts.genericBatterySettings`, with the chain extracted so the
+          lab adapters and the null path share one implementation. **Not confirmed to change what this contributor
+          sees**: whether `POWER_USAGE_SUMMARY` resolves on MagicOS 10 is still unverified.
+        - **OPEN (deferred, deliberate): "Just send device info" cannot appear on an unrecognized ROM.**
+          `UnsupportedDeviceCard.kt` gates it on `hasSupportLead` (`ChargingRepository.kt`), a ten-way disjunction
+          of known-ROM markers, every one of which is structurally false for HONOR. Shipped in `v0.3.2-beta0`
+          (`bc55ceb`, PR #44) with a pinning test, so this contributor's build could never have shown it. The gate
+          is defensible (it exists to avoid dead-end reports) but perverse here: the less Amply recognizes a
+          device, the less it lets the user report it — and the report being withheld is the only one carrying
+          `Build.DEVICE`, which is exactly what an allowlist entry needs. This contributor hand-dumped properties
+          because of it. Held rather than changed: reversing a deliberate decision on one data point is thin, and
+          the Shizuku wizard path was still open to them. Revisit if another unknown-ROM contributor hits it.
+        - **OPEN (needs one device reading): charge power renders `0.0 W` / `4 mA` while charging.** Both figures
+          come from one field, `BATTERY_PROPERTY_CURRENT_NOW`. A ROM reporting mA where Android documents µA turns
+          a real 4 A into the integer `4000`, which formats as "4 mA" and computes to
+          `4551 mV × 4000 µA / 1e6 = 18 mW`, printing as "0.0 W" — reproduced exactly in
+          `StatsPowerCalculatorTest`. `Charge counter: 6978` points the same way (documented µAh; 6978 µAh would be
+          6.98 mAh). **But an end-of-charge trickle at level 100 produces the identical value**, so the number
+          alone cannot decide, and a low-side clamp would break correct readings on healthy devices — the
+          `MAX_PLAUSIBLE_MILLIWATTS` guard only ever caught the *over*-reporting direction, and its test comment
+          asserted the wrong direction outright (both corrected). Deciding reading requested: Amply's own
+          "Charge counter" row should render **~7 mAh** if the ROM scales that property, independent of charging
+          state. No per-device telemetry seam exists (`ChargingAdapter` carries no unit capability and
+          `BatteryReader` never sees a `DeviceInfo`), so a fix is new work — and it is adapter-independent, since
+          this device has no adapter to hang it on.
+    - **Status after the 2026-08-17 follow-up: still NOT qualified.** Blocker 1's hardware half is now ANSWERED
+      but the answer is unfavourable — the cap is real yet only ~4%, and neither key is a hard limit, so the open
+      question is no longer "does it work" but "is an Adaptive-only MagicOS adapter worth building". Blocker 2's
+      identity mechanism is resolved; its version scoping is not. Nothing here justifies an adapter, a lab
+      adapter, or a manufacturer read yet.
     - Tracking: GitHub issue #66.

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -1,6 +1,7 @@
 package eu.darken.amply.charging.core
 
 import android.content.Context
+import android.content.Intent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import android.os.BatteryManager
 import eu.darken.amply.R
@@ -13,6 +14,7 @@ import eu.darken.amply.charging.core.access.shizuku.ShizukuController
 import eu.darken.amply.charging.core.adapter.AdapterRegistry
 import eu.darken.amply.charging.core.adapter.AdapterSelection
 import eu.darken.amply.charging.core.adapter.ChargingAdapter
+import eu.darken.amply.charging.core.adapter.OemChargingShortcuts
 import eu.darken.amply.charging.core.adapter.VerificationStrategy
 import eu.darken.amply.charging.core.ChargingPreferences
 import eu.darken.amply.common.ca.CaString
@@ -258,7 +260,13 @@ class ChargingRepository @Inject constructor(
         }
     }
 
-    fun nativeSettingsIntent() = registry.select().adapter?.nativeSettingsIntent(context)
+    /**
+     * Never null: a device with no adapter still gets the generic battery-settings chain. Returning null here made
+     * every unmapped device (any brand Amply carries no adapter for) land on Battery Saver, because the only caller
+     * substituted that directly — while every lab adapter deliberately prefers the battery-usage screen.
+     */
+    fun nativeSettingsIntent(): Intent = registry.select().adapter?.nativeSettingsIntent(context)
+        ?: OemChargingShortcuts.genericBatterySettings(context)
 
     fun currentAdapter(): ChargingAdapter? = registry.select().adapter
 

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/LabChargingAdapters.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/LabChargingAdapters.kt
@@ -2,7 +2,6 @@ package eu.darken.amply.charging.core.adapter
 
 import android.content.Context
 import android.content.Intent
-import android.provider.Settings
 import eu.darken.amply.R
 import eu.darken.amply.charging.core.access.AccessBackend
 import eu.darken.amply.charging.core.ChargeObservation
@@ -33,17 +32,8 @@ abstract class DisabledLabAdapter : ChargingAdapter {
 
     override suspend fun apply(policy: ChargePolicy, backend: AccessBackend) = false
 
-    override fun nativeSettingsIntent(context: Context): Intent {
-        // Prefer the system battery-usage screen, which on most OEM skins is the entry point that
-        // also holds the built-in charge-protection toggle; fall back to Battery Saver settings
-        // where it isn't resolvable. Both are generic AOSP actions — no brittle OEM ComponentNames.
-        val powerUsage = Intent(Intent.ACTION_POWER_USAGE_SUMMARY).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        return if (powerUsage.resolveActivity(context.packageManager) != null) {
-            powerUsage
-        } else {
-            Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-    }
+    override fun nativeSettingsIntent(context: Context): Intent =
+        OemChargingShortcuts.genericBatterySettings(context)
 }
 
 @Singleton

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/OemChargingShortcuts.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/OemChargingShortcuts.kt
@@ -2,6 +2,7 @@ package eu.darken.amply.charging.core.adapter
 
 import android.content.Context
 import android.content.Intent
+import android.provider.Settings
 import eu.darken.amply.charging.core.DeviceInfo
 
 /**
@@ -24,5 +25,24 @@ object OemChargingShortcuts {
         } ?: return null
         candidate.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         return candidate.takeIf { it.resolveActivity(context.packageManager) != null }
+    }
+
+    /**
+     * The generic chain every adapter falls back to: the system battery-usage screen, which on most OEM skins is
+     * the entry point that also holds the built-in charge-protection toggle, then Battery Saver where it isn't
+     * resolvable. Both are AOSP actions — no brittle OEM ComponentNames. `POWER_USAGE_SUMMARY` visibility is
+     * declared in the manifest's `<queries>`, so it resolves on any ROM that ships the screen.
+     *
+     * A device Amply has **no adapter at all** for resolves through here too, which is the point: an unmapped
+     * device is the one most likely to need the OEM's own screen, and it used to land straight on Battery Saver
+     * because there was no adapter object to ask (`ChargingRepository.nativeSettingsIntent`).
+     */
+    fun genericBatterySettings(context: Context): Intent {
+        val powerUsage = Intent(Intent.ACTION_POWER_USAGE_SUMMARY).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        return if (powerUsage.resolveActivity(context.packageManager) != null) {
+            powerUsage
+        } else {
+            Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
     }
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
@@ -625,14 +625,22 @@ class DashboardViewModel @Inject constructor(
     }
 
     fun openNativeSettings() {
-        val intent = repository.nativeSettingsIntent() ?: Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS)
-        runCatching { context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)) }
-            .onFailure {
-                context.startActivity(
-                    Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS)
-                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                )
-            }
+        // Resolution (including the unmapped-device fallback) lives in the repository; this only handles a
+        // launch that throws despite having resolved — resolveActivity is advisory, so an activity can be
+        // disabled or reject the launch between the check and the start.
+        val intent = repository.nativeSettingsIntent()
+        val failure = runCatching { context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)) }
+            .exceptionOrNull() ?: return
+        log(TAG, Logging.Priority.WARN) { "Native settings ${intent.action} failed: ${failure.asLog()}" }
+        // Battery Saver is the repository's own last resort, so retrying it here would just throw again —
+        // and unguarded, that second throw escaped and took the action down with it.
+        if (intent.action == Settings.ACTION_BATTERY_SAVER_SETTINGS) return
+        runCatching {
+            context.startActivity(
+                Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+            )
+        }.onFailure { log(TAG, Logging.Priority.WARN) { "Battery-saver fallback failed: ${it.asLog()}" } }
     }
 
     fun openShizuku() = viewModelScope.launch {

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsPowerCalculator.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsPowerCalculator.kt
@@ -10,9 +10,19 @@ import kotlin.math.abs
  * not encode direction (charge vs discharge) — the caller derives direction from plug/charging state.
  *
  * `mV × µA = 10⁻⁹ W = 10⁻⁶ mW`, so `mW = mV × |µA| / 1_000_000`, computed in [Long] to avoid the
- * `Int` overflow that `4300 mV × 3_000_000 µA` would hit. Values outside a plausible phone/tablet
- * range are rejected as `null` because some OEM firmwares report current in the wrong unit (mA, or
- * deci-units) and would otherwise poison the session average.
+ * `Int` overflow that `4300 mV × 3_000_000 µA` would hit. Results above [MAX_PLAUSIBLE_MILLIWATTS] are
+ * rejected as `null`, which catches a grossly over-reporting firmware before it poisons the session
+ * average. It is a backstop, not a unit check: a 10× over-report of a real 4 A at 4.551 V lands at
+ * ~182 W and is accepted, as the 20 A case in the tests shows.
+ *
+ * **The opposite error is not detectable here, and deliberately is not guarded.** A firmware that
+ * reports `CURRENT_NOW` in mA where Android documents µA makes every reading 1000× too *small*: a real
+ * 4 A arrives as the integer `4000`, renders as "4 mA", and computes to 18 mW — which formats as
+ * "0.0 W". No lower bound can separate that from a legitimate end-of-charge trickle, because a phone
+ * genuinely drawing single-digit mA at 100% produces the identical value. Distinguishing them needs
+ * context this function does not have (charge level, or a second property known to be misscaled), so
+ * the fix belongs wherever that context lives, not in a magnitude clamp here. Observed on HONOR
+ * MagicOS 10 (unconfirmed) — see the HONOR entry in the device-qualification skill.
  */
 object StatsPowerCalculator {
 

--- a/app/src/test/java/eu/darken/amply/charging/core/UnmappedDeviceSettingsIntentTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/UnmappedDeviceSettingsIntentTest.kt
@@ -1,0 +1,140 @@
+package eu.darken.amply.charging.core
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.pm.ResolveInfo
+import android.os.Build
+import android.provider.Settings
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.battery.core.BatteryReader
+import eu.darken.amply.charging.core.access.AccessResolver
+import eu.darken.amply.charging.core.access.DirectSettingsBackend
+import eu.darken.amply.charging.core.access.LineageSettingsClient
+import eu.darken.amply.charging.core.access.ShizukuSettingsBackend
+import eu.darken.amply.charging.core.access.shizuku.ShizukuController
+import eu.darken.amply.charging.core.access.shizuku.ShizukuInstallationDetector
+import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.adapter.GrapheneOsChargingAdapter
+import eu.darken.amply.charging.core.adapter.LineageChargingAdapter
+import eu.darken.amply.charging.core.adapter.LineageLabAdapter
+import eu.darken.amply.charging.core.adapter.OnePlusChargingAdapter
+import eu.darken.amply.charging.core.adapter.OnePlusLabAdapter
+import eu.darken.amply.charging.core.adapter.PixelChargingAdapter
+import eu.darken.amply.charging.core.adapter.SamsungLabAdapter
+import eu.darken.amply.charging.core.adapter.SamsungLegacyChargingAdapter
+import eu.darken.amply.charging.core.adapter.SamsungModernChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiHyperOs3ChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiLabAdapter
+import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.serialization.SerializationModule
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import java.io.File
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.util.ReflectionHelpers
+
+/**
+ * A device Amply carries no adapter for (HONOR/MagicOS here, but equally Motorola, Nothing, Sony, Fairphone,
+ * Vivo, Tecno) must still be pointed at the OEM's battery screen. It used to land on Battery Saver: the
+ * repository returned null for a null adapter and the only caller substituted Battery Saver outright, so
+ * `POWER_USAGE_SUMMARY` was never tried even though every lab adapter prefers it.
+ */
+@RunWith(RobolectricTestRunner::class)
+class UnmappedDeviceSettingsIntentTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val storeScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+    private lateinit var repository: ChargingRepository
+
+    @Before
+    fun setup() {
+        // An unmapped OEM: no adapter's probe matches, so AdapterRegistry.select() yields adapter = null.
+        ReflectionHelpers.setStaticField(Build::class.java, "MANUFACTURER", "HONOR")
+        ReflectionHelpers.setStaticField(Build::class.java, "MODEL", "BKQ-N49")
+        ReflectionHelpers.setStaticField(Build::class.java, "DEVICE", "HNBKQ")
+
+        val appDataStore = AppDataStore(
+            PreferenceDataStoreFactory.create(scope = storeScope) {
+                File(tempFolder.root, "test.preferences_pb")
+            },
+        )
+        val shizukuController = ShizukuController(context, ShizukuInstallationDetector(context))
+        repository = ChargingRepository(
+            context = context,
+            registry = AdapterRegistry(
+                context = context,
+                lineage = LineageChargingAdapter(LineageSettingsClient(context)),
+                lineageLab = LineageLabAdapter(),
+                grapheneOs = GrapheneOsChargingAdapter(),
+                pixel = PixelChargingAdapter(),
+                samsungModern = SamsungModernChargingAdapter(),
+                samsungLegacy = SamsungLegacyChargingAdapter(),
+                samsungLab = SamsungLabAdapter(),
+                xiaomi = XiaomiChargingAdapter(),
+                xiaomiHyperOs3 = XiaomiHyperOs3ChargingAdapter(),
+                xiaomiLab = XiaomiLabAdapter(),
+                onePlus = OnePlusChargingAdapter(),
+                onePlusLab = OnePlusLabAdapter(),
+            ),
+            accessResolver = AccessResolver(
+                direct = DirectSettingsBackend(context),
+                shizuku = ShizukuSettingsBackend(shizukuController),
+            ),
+            preferences = ChargingPreferences(appDataStore, SerializationModule.json()),
+            shizukuController = shizukuController,
+            settleScheduler = object : SettleScheduler {
+                override fun schedule(requestedAtMillis: Long) = Unit
+            },
+            batteryReader = BatteryReader(context),
+        )
+    }
+
+    @After
+    fun teardown() {
+        storeScope.cancel()
+    }
+
+    @Test
+    fun `an unmapped device really has no adapter`() {
+        repository.currentAdapter() shouldBe null
+    }
+
+    @Test
+    fun `an unmapped device is pointed at the battery-usage screen, not battery saver`() {
+        registerActivityFor(Intent.ACTION_POWER_USAGE_SUMMARY)
+
+        repository.nativeSettingsIntent().action shouldBe Intent.ACTION_POWER_USAGE_SUMMARY
+    }
+
+    @Test
+    fun `battery saver stays the fallback when the battery-usage screen is absent`() {
+        // Nothing registered for POWER_USAGE_SUMMARY, e.g. a ROM that ships no battery-usage activity.
+        repository.nativeSettingsIntent().action shouldBe Settings.ACTION_BATTERY_SAVER_SETTINGS
+    }
+
+    private fun registerActivityFor(action: String) {
+        val resolveInfo = ResolveInfo().apply {
+            activityInfo = ActivityInfo().apply {
+                packageName = "com.example.settings"
+                name = "BatteryActivity"
+            }
+        }
+        shadowOf(context.packageManager).addResolveInfoForIntent(Intent(action), resolveInfo)
+    }
+}

--- a/app/src/test/java/eu/darken/amply/stats/core/StatsPowerCalculatorTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/StatsPowerCalculatorTest.kt
@@ -31,13 +31,25 @@ class StatsPowerCalculatorTest {
 
     @Test
     fun `implausible OEM current is rejected rather than poisoning the average`() {
-        // A device reporting current in mA instead of uA would look like ~1000x too much power.
+        // Only the upper bound is guarded: a firmware over-reporting by ~10x lands past the 250 W cap.
         StatsPowerCalculator.milliwatts(4000, 2_000_000_0 /* 20 A in uA-ish scale */).let {
             // 4000mV * 20_000_000uA = 80W = 80000mW, still under cap
             it shouldBe 80000
         }
         // 4000 mV * 100_000_000 (bad units) = 400 W > cap → null
         StatsPowerCalculator.milliwatts(4000, 100_000_000) shouldBe null
+    }
+
+    @Test
+    fun `mA-where-uA-expected is silently under-reported, not clamped`() {
+        // The inverse error: a firmware reporting mA where Android documents uA makes readings 1000x too
+        // SMALL, so no clamp fires. A real 4 A at 4551 mV (HONOR MagicOS 10 shape) arrives as `4000` and
+        // computes to 18 mW, which the UI formats as "0.0 W". Pinned so nobody "fixes" this with a lower
+        // bound: the same 18 mW is what a genuine end-of-charge trickle produces, so the value alone
+        // cannot tell the two apart.
+        StatsPowerCalculator.milliwatts(4551, 4_000) shouldBe 18
+        // The reading it should have produced, had the unit been what the API documents.
+        StatsPowerCalculator.milliwatts(4551, 4_000_000) shouldBe 18204
     }
 
     @Test


### PR DESCRIPTION
## What changed

On a phone Amply has no charge-protection support for, the "Open battery settings" button opened the system Battery saver screen. That screen has no charge-protection toggle in it, so the button led nowhere useful on exactly the devices that needed it most. It now opens the battery-usage screen, which on most manufacturer skins is where the built-in charging-protection option actually lives, and only falls back to Battery saver when a phone has no battery-usage screen at all.

This was reported on a HONOR phone but applied to every brand Amply carries no support for, including Motorola, Nothing, Sony, Fairphone, Vivo and Tecno. The same button in the "Help add support" wizard is fixed by the same change.

Also fixes a crash: if opening the battery screen failed, the retry could throw and take the action down with it.

The remaining two commits change no behavior. One corrects a wrong explanation in the code about how charging-power readings can be misreported, and pins the current behavior in a test. The other records a contributor's hardware measurements in the device-qualification ledger.

## Technical Context

- Root cause: `ChargingRepository.nativeSettingsIntent()` returned null when `AdapterRegistry` matched no adapter, and its single caller substituted `ACTION_BATTERY_SAVER_SETTINGS` outright. `ACTION_POWER_USAGE_SUMMARY` was therefore never attempted, despite all four lab adapters preferring it and the manifest already declaring its `<queries>` visibility. Same user-visible symptom the ledger records for LineageOS, reached by a different path (that one fell through to the Pixel component intent; this one had no adapter object to ask at all).
- The chain moved to `OemChargingShortcuts.genericBatterySettings` so the null path and `DisabledLabAdapter` share one implementation instead of a sixth copy, and the repository's return type is now non-null so no caller can reintroduce its own fallback. The four OEM adapters keep their private copies deliberately: converting them would couple qualified per-device navigation to whatever "generic" comes to mean later.
- The crash was pre-existing for unmapped devices: on a launch failure the handler retried the *same* Battery Saver intent outside `runCatching`, so when that intent was the one that failed, the second throw escaped. It now skips a fallback that would repeat the failed action, and guards and logs both attempts. Worth a close look, since it is the one place this PR changes control flow rather than intent selection.
- `POWER_USAGE_SUMMARY` is verified to resolve only under Robolectric here. Whether it resolves on MagicOS 10 specifically is unconfirmed, so this is not proven to change what the original reporter sees. The change is correct for unmapped devices generally either way.
- The `StatsPowerCalculator` commit deliberately does **not** fix the underlying defect. A firmware reporting `CURRENT_NOW` in mA where Android documents µA makes readings 1000× too small, which the plausibility cap cannot catch, but no lower bound can separate that from a genuine end-of-charge trickle either. The test states why not to add one; the real fix needs charge-level context this function does not have.

Refs #66
