### PR TITLE
Charging: Enable charge control on LineageOS devices

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,9 +19,12 @@ allowlist** (mode `2` is not HyperOS-3-wide and cannot be probed at runtime).
 = FixedLimit(80)/Adaptive) is gated to ColorOS 15 (`ro.build.version.oplusrom == 15`) across the Oplus family
 (OnePlus/Oppo/Realme) — **writes require Shizuku** (system namespace). **LineageOS charging control** (the private
 `lineagesettings` provider, keys `charging_control_enabled`/`_mode`/`_charging_limit`) is manufacturer-agnostic —
-gated to a **physically-qualified device-codename allowlist** (HAL enforcement is per-device) plus the provider and
-system user; **reads are unprivileged (ContentResolver), writes require Shizuku** (the shell UID holds
-`lineageos.permission.WRITE_SETTINGS`, which `WRITE_SECURE_SETTINGS` does not cover). **GrapheneOS charge limit**
+it matches every LineageOS build that ships the provider (plus the system user), but control is gated on
+**enforcement observed on the device itself** (HAL enforcement is per-build, and a read-back proves only that the
+ROM stored the value): a device stays a candidate with controls off until the user runs a verification and the cap
+is seen holding, and loses them for good if the battery is seen charging past it. **Reads are unprivileged
+(ContentResolver), writes require Shizuku** (the shell UID holds `lineageos.permission.WRITE_SETTINGS`, which
+`WRITE_SECURE_SETTINGS` does not cover). **GrapheneOS charge limit**
 (`global battery_charge_limit`, binary FixedLimit(80)/Unrestricted) is gated to GrapheneOS identity (its
 `app.grapheneos.*` core packages; no property/feature/fingerprint marker exists) plus the system user —
 **reads AND writes require Shizuku**: GrapheneOS marks the key `@Protected`, denying it to all third-party
@@ -29,7 +32,8 @@ packages including WSS holders, with only the shell UID exempt. The ROM **latche
 (`policyLatchesAtPlug`), so external writes take effect at the next unplug→replug — handled by a
 pending-until-replug verification state and a 30s session grace window; the reconnect gesture is unsupported
 there. Other Pixels, Samsung on unverified One UI versions (6/7, 9+), unqualified Xiaomi devices,
-non-ColorOS-15 Oplus devices, and unqualified LineageOS builds remain diagnostics-only. See the qualification
+non-ColorOS-15 Oplus devices, and LineageOS builds without the settings provider remain diagnostics-only. See the
+qualification
 ledger (`.claude/skills/device-qualification/`) for the verified devices and mappings.
 
 Package: `eu.darken.amply`. License: GPL-3.0-or-later. Status: pre-launch (current version in `VERSION`).
@@ -49,6 +53,7 @@ constraints:
 Under `app/src/main/java/eu/darken/amply/`:
 
 - `charging/core` — policies, device capability checks, OEM adapters, WSS, Shizuku access (`access/shizuku`, `adapter`)
+- `charging/core/enforcement` — the observed-enforcement gate: verdict engine, durable evidence, monitor watcher
 - `fullcharge/core` — temporary sessions, boot recovery, reconnect gesture
 - `main/ui` — activity, onboarding, dashboard, settings, setup guide, `tile`, `widget`
 - `diagnostics/core` + `diagnostics/ui` — "Help add support" contribution wizard: read-only multi-mode setting

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,9 +20,11 @@ allowlist** (mode `2` is not HyperOS-3-wide and cannot be probed at runtime).
 (OnePlus/Oppo/Realme) — **writes require Shizuku** (system namespace). **LineageOS charging control** (the private
 `lineagesettings` provider, keys `charging_control_enabled`/`_mode`/`_charging_limit`) is manufacturer-agnostic —
 it matches every LineageOS build that ships the provider (plus the system user), but control is gated on
-**enforcement observed on the device itself** (HAL enforcement is per-build, and a read-back proves only that the
-ROM stored the value): a device stays a candidate with controls off until the user runs a verification and the cap
-is seen holding, and loses them for good if the battery is seen charging past it. **Reads are unprivileged
+**enforcement evidence for that build** (HAL enforcement is per-build, and a read-back proves only that the ROM
+stored the value): a device stays a candidate with controls off until a maintainer qualified its codename or the
+user explicitly enables control on an unconfirmed build, and loses them for good if the battery is seen charging
+past the cap. Observation can only ever **refute** a cap, never confirm one — no passively observable signal tells
+a cap hold from a thermal or weak-supply pause. **Reads are unprivileged
 (ContentResolver), writes require Shizuku** (the shell UID holds `lineageos.permission.WRITE_SETTINGS`, which
 `WRITE_SECURE_SETTINGS` does not cover). **GrapheneOS charge limit**
 (`global battery_charge_limit`, binary FixedLimit(80)/Unrestricted) is gated to GrapheneOS identity (its

--- a/.claude/rules/privileged-access.md
+++ b/.claude/rules/privileged-access.md
@@ -143,9 +143,10 @@ the qualification ledger (`device-qualification` skill).
 ### LineageOS
 
 LineageOS control requires **all** of: LineageOS (`DeviceInfo.isLineageOs`), the `lineagesettings` provider
-present, the system user, and **observed enforcement evidence** for this exact build (see "Enforcement evidence
-gate" below). The adapter *matches* every provider-carrying LineageOS build; what it may *do* there is decided by
-the evidence, not by a codename.
+present, the system user, and clearing the **enforcement evidence gate** for this exact build (a maintainer
+codename, or the user's explicit opt-in on an unconfirmed build, and no refutation — see "Enforcement evidence gate"
+below). The adapter *matches* every provider-carrying LineageOS build; what it may *do* there is decided by the
+gate, not by a codename.
 
 **Detect LineageOS with the `org.lineageos.android` system feature, never `ro.lineage.build.version`.** All five
 `ro.lineage.*` properties are labelled `u:object_r:custom_version_prop:s0`, which SELinux denies to
@@ -155,8 +156,9 @@ adapter (verified on oriole / LineageOS 23.2 / Android 16). `hasSystemFeature` n
 permission. `lineageOsVersion` remains a **secondary identity signal** — `isLineageOs` ORs it in so derivatives that
 relabel the property still match — and is normally null on real hardware; it is not "diagnostics only".
 
-`QUALIFIED_CODENAMES` survives as the **maintainer fast path** only (still empty): a codename there skips
-verification entirely. It is deliberately no longer what makes the adapter reachable, because HAL capability is
+`QUALIFIED_CODENAMES` survives as the **maintainer fast path** only (still empty): a codename there is the ONLY
+route to the confirmed tier, since nothing Amply can observe confirms a cap (see below). It is deliberately no
+longer what makes the adapter reachable, because HAL capability is
 *build*-scoped — oriole exposed the LIMIT mode bit on LineageOS 20 and dropped it on 23.2 on identical hardware —
 so a bare codename entry claims more than any single qualification run proves. Add one only with a qualified device
 plus a ledger row, and only when you mean every build on that device.
@@ -177,8 +179,8 @@ Writable keys/domains (`LineageSettingWritePolicy`, independent of the adapter):
 
 **Crucial gate rationale:** the setting can be written while the `vendor.lineage.health.IChargingControl` HAL never
 actually limits (the `mIsLimitSet:false` class of bug) — setting readback does **not** prove hardware enforcement.
-That is why control is never granted on "any LineageOS device": the hardware must be proven, either by the
-maintainer (a ledger row) or by the user's own device under the enforcement evidence gate. The adapter also
+That is why control is never granted on "any LineageOS device": either the maintainer proved the hardware (a ledger
+row), or the user accepted an explicitly unconfirmed build that Amply keeps watching for a refutation. The adapter also
 **refuses** (reads
 `Unknown(unrecognizedValue=true)`) any native state it cannot restore exactly — AUTO/CUSTOM schedule modes, off-tick
 limits, or an absent/malformed `enabled` — so a temporary session never clobbers the user's own choice.
@@ -190,11 +192,11 @@ For adapters that set `ChargingAdapter.enforcementEvidenceRequired` (LineageOS t
 `AdapterRegistry.select()` therefore takes an explicit `EnforcementEvidenceState` — **no default**, so "the caller
 forgot", "not read yet" and "genuinely nothing stored" cannot collapse into control-enabled — and resolves a tier in
 this order: **REFUTED** (or a corrupt record, which may be one) → control off, contribution wanted; **CONFIRMED**
-(maintainer codename or a local confirmation) → control as probed; **UNDER_TEST** (the user started verification) →
-control as probed, but no surface may claim the cap is proven; otherwise **CANDIDATE** → control off. Callers that
-only need adapter *capabilities* pass `EnforcementEvidenceState.Loading`, which can never enable control. A probe
-that **already** refused control (secondary user, missing provider) short-circuits the whole resolution: enforcement
-stays null and no surface offers a verification the recorder could never observe.
+(a maintainer codename, and nothing else) → control as probed; **UNVERIFIED** (the user accepted the unconfirmed
+build) → control as probed, but no surface may claim the cap is proven; otherwise **CANDIDATE** → control off.
+Callers that only need adapter *capabilities* pass `EnforcementEvidenceState.Loading`, which can never enable
+control. A probe that **already** refused control (secondary user, missing provider) short-circuits the whole
+resolution: enforcement stays null and no surface offers an opt-in that could not change anything.
 
 The gate governs **new control only**. A restore the user is already owed — the session restore, its rollback, boot
 recovery — goes through `ChargingRepository.restorePersistent()`, which applies every adapter precondition but not
@@ -204,12 +206,17 @@ strand the device in the session's Unrestricted state.
 Evidence is produced by `charging/core/enforcement/`: a pure `EnforcementVerdictEngine` over the monitor's battery
 ticks, persisted by `EnforcementEvidenceStore`. Three properties are load-bearing and must not be relaxed:
 
-- **CONFIRM requires a hardware hold signal** (`ChargingAdapter.hardwareHoldSignal`, on LineageOS the AOSP
-  charge-policy state 4) on top of a sustained, level-pinned plateau. A plateau alone cannot distinguish a cap hold
-  from a thermal pause or a weak charger — `StatsLimitHitDetector.heldNow` fires on all of them — so an adapter
-  without the signal can never be confirmed, only refuted. **REFUTE keys on an upward level trend** through the cap
-  from any starting level, needs no hardware signal, and deliberately ignores the reported battery status, which a
-  ROM can misreport while charging past the limit.
+- **Observation can only refute, never confirm — `EnforcementVerdict` has exactly one value.** No passively
+  observable signal distinguishes a cap hold from a thermal or weak-supply pause. `EXTRA_CHARGING_STATUS` == 4
+  looked like one, but it is *session-scoped*: measured on a Pixel 6 / LineageOS 23.2, the extra read 4 while the
+  device was actively charging at level 70 under an 80% cap — it means "limit mode is enabled for this plug
+  session", exactly as `StatsLimitHitDetector`'s KDoc documents for Pixel. The only field that differs between a
+  cap hold and a thermal pause is `EXTRA_STATUS`, which both produce. So Amply never claims a cap is verified from
+  observation; the confirmed tier comes solely from physical qualification. Earning a real confirmation would take
+  a **guided two-cap challenge** (write a cap below the current level and watch charging cut, raise it and watch it
+  resume, cut again) — known, and deliberately not implemented. **REFUTE keys on an upward level trend** through
+  the cap from any starting level, needs no hardware signal, and deliberately ignores the reported battery status,
+  which a ROM can misreport while charging past the limit.
 - Evidence is scoped to a **composite build identity** (fingerprint + incremental + build time + provider version
   code, hashed). `Build.FINGERPRINT` alone is useless here: LineageOS spoofs it to stock.
 - A refutation is **terminal** for its scope, and a corrupt record is treated as a refutation. Both are fail-closed

--- a/.claude/rules/privileged-access.md
+++ b/.claude/rules/privileged-access.md
@@ -142,9 +142,10 @@ the qualification ledger (`device-qualification` skill).
 
 ### LineageOS
 
-LineageOS control requires **all** of: LineageOS (`DeviceInfo.isLineageOs`), a **physically-qualified
-device codename** (`Build.DEVICE` ∈ `LineageChargingAdapter.QUALIFIED_CODENAMES`), the `lineagesettings` provider
-present, and the system user.
+LineageOS control requires **all** of: LineageOS (`DeviceInfo.isLineageOs`), the `lineagesettings` provider
+present, the system user, and **observed enforcement evidence** for this exact build (see "Enforcement evidence
+gate" below). The adapter *matches* every provider-carrying LineageOS build; what it may *do* there is decided by
+the evidence, not by a codename.
 
 **Detect LineageOS with the `org.lineageos.android` system feature, never `ro.lineage.build.version`.** All five
 `ro.lineage.*` properties are labelled `u:object_r:custom_version_prop:s0`, which SELinux denies to
@@ -154,14 +155,16 @@ adapter (verified on oriole / LineageOS 23.2 / Android 16). `hasSystemFeature` n
 permission. `lineageOsVersion` remains a **secondary identity signal** — `isLineageOs` ORs it in so derivatives that
 relabel the property still match — and is normally null on real hardware; it is not "diagnostics only".
 
-**Blocker before the first codename is added to `QUALIFIED_CODENAMES`:** the live gate is codename-scoped, but HAL
-capability is *build*-scoped — oriole exposed the LIMIT mode bit on LineageOS 20 and dropped it on 23.2 on identical
-hardware. A bare codename entry would therefore claim more than any single qualification run proves. Scope the entry
-by codename **plus** the qualified Lineage generation / API level (and treat a property-only or derivative match as
-insufficient for the live gate), or qualify every build you intend to cover. It is **manufacturer-agnostic** (LineageOS runs on many OEMs), so the Lineage
-live/lab adapters are ordered **before all OEM adapters** in `AdapterRegistry` — a LineageOS build on Samsung/
-Xiaomi/OnePlus hardware must never be swallowed by a manufacturer-based lab adapter. Unqualified LineageOS builds
-fall to `LineageLabAdapter` (diagnostics/contribution).
+`QUALIFIED_CODENAMES` survives as the **maintainer fast path** only (still empty): a codename there skips
+verification entirely. It is deliberately no longer what makes the adapter reachable, because HAL capability is
+*build*-scoped — oriole exposed the LIMIT mode bit on LineageOS 20 and dropped it on 23.2 on identical hardware —
+so a bare codename entry claims more than any single qualification run proves. Add one only with a qualified device
+plus a ledger row, and only when you mean every build on that device.
+
+LineageOS is **manufacturer-agnostic** (it runs on many OEMs), so the Lineage live/lab adapters are ordered
+**before all OEM adapters** in `AdapterRegistry` — a LineageOS build on Samsung/Xiaomi/OnePlus hardware must never
+be swallowed by a manufacturer-based lab adapter. A build **without** the settings provider does not match the live
+adapter at all and falls to `LineageLabAdapter` (diagnostics/contribution), which keeps that ordering for it.
 
 The three keys live in the private `content://lineagesettings/system` provider — **NOT** any AOSP `settings`
 namespace. Modeled as `SettingNamespace.LINEAGE_SYSTEM`: **reads are unprivileged** (`LineageSettingsClient`,
@@ -174,10 +177,33 @@ Writable keys/domains (`LineageSettingWritePolicy`, independent of the adapter):
 
 **Crucial gate rationale:** the setting can be written while the `vendor.lineage.health.IChargingControl` HAL never
 actually limits (the `mIsLimitSet:false` class of bug) — setting readback does **not** prove hardware enforcement.
-That is why the gate is a qualified-codename allowlist, not "any LineageOS device": a device must be physically
-proven (see the qualification protocol) before its codename is added. The adapter also **refuses** (reads
+That is why control is never granted on "any LineageOS device": the hardware must be proven, either by the
+maintainer (a ledger row) or by the user's own device under the enforcement evidence gate. The adapter also
+**refuses** (reads
 `Unknown(unrecognizedValue=true)`) any native state it cannot restore exactly — AUTO/CUSTOM schedule modes, off-tick
 limits, or an absent/malformed `enabled` — so a temporary session never clobbers the user's own choice.
+
+## Enforcement Evidence Gate
+
+For adapters that set `ChargingAdapter.enforcementEvidenceRequired` (LineageOS today), a settings read-back is
+**not** a licence to offer control: it proves the ROM stored the value, not that the charging hardware acts on it.
+`AdapterRegistry.select()` therefore takes an explicit `EnforcementEvidenceState` — **no default**, so "the caller
+forgot", "not read yet" and "genuinely nothing stored" cannot collapse into control-enabled — and resolves a tier in
+this order: **REFUTED** (or a corrupt record, which may be one) → control off, contribution wanted; **CONFIRMED**
+(maintainer codename or a local confirmation) → control as probed; **UNDER_TEST** (the user started verification) →
+control as probed, but no surface may claim the cap is proven; otherwise **CANDIDATE** → control off. Callers that
+only need adapter *capabilities* pass `EnforcementEvidenceState.Loading`, which can never enable control.
+
+Evidence is produced by `charging/core/enforcement/`: a pure `EnforcementVerdictEngine` over the monitor's battery
+ticks, persisted by `EnforcementEvidenceStore`. Three properties are load-bearing and must not be relaxed:
+
+- **CONFIRM needs a sustained plateau**, not one `StatsLimitHitDetector.heldNow` tick (which also fires on thermal
+  suspension and weak chargers), while **REFUTE keys on an upward level trend** through the cap and deliberately
+  ignores the reported battery status, which a ROM can misreport while charging past the limit.
+- Evidence is scoped to a **composite build identity** (fingerprint + incremental + build time + provider version
+  code, hashed). `Build.FINGERPRINT` alone is useless here: LineageOS spoofs it to stock.
+- A refutation is **terminal** for its scope, and a corrupt record is treated as a refutation. Both are fail-closed
+  on purpose — the one error this gate exists to prevent is claiming protection that isn't there.
 
 ## Foreground Service Requirement
 

--- a/.claude/rules/privileged-access.md
+++ b/.claude/rules/privileged-access.md
@@ -192,14 +192,24 @@ forgot", "not read yet" and "genuinely nothing stored" cannot collapse into cont
 this order: **REFUTED** (or a corrupt record, which may be one) → control off, contribution wanted; **CONFIRMED**
 (maintainer codename or a local confirmation) → control as probed; **UNDER_TEST** (the user started verification) →
 control as probed, but no surface may claim the cap is proven; otherwise **CANDIDATE** → control off. Callers that
-only need adapter *capabilities* pass `EnforcementEvidenceState.Loading`, which can never enable control.
+only need adapter *capabilities* pass `EnforcementEvidenceState.Loading`, which can never enable control. A probe
+that **already** refused control (secondary user, missing provider) short-circuits the whole resolution: enforcement
+stays null and no surface offers a verification the recorder could never observe.
+
+The gate governs **new control only**. A restore the user is already owed — the session restore, its rollback, boot
+recovery — goes through `ChargingRepository.restorePersistent()`, which applies every adapter precondition but not
+the evidence tier: an OTA mid-session changes the build identity, and refusing the owed protective write would
+strand the device in the session's Unrestricted state.
 
 Evidence is produced by `charging/core/enforcement/`: a pure `EnforcementVerdictEngine` over the monitor's battery
 ticks, persisted by `EnforcementEvidenceStore`. Three properties are load-bearing and must not be relaxed:
 
-- **CONFIRM needs a sustained plateau**, not one `StatsLimitHitDetector.heldNow` tick (which also fires on thermal
-  suspension and weak chargers), while **REFUTE keys on an upward level trend** through the cap and deliberately
-  ignores the reported battery status, which a ROM can misreport while charging past the limit.
+- **CONFIRM requires a hardware hold signal** (`ChargingAdapter.hardwareHoldSignal`, on LineageOS the AOSP
+  charge-policy state 4) on top of a sustained, level-pinned plateau. A plateau alone cannot distinguish a cap hold
+  from a thermal pause or a weak charger — `StatsLimitHitDetector.heldNow` fires on all of them — so an adapter
+  without the signal can never be confirmed, only refuted. **REFUTE keys on an upward level trend** through the cap
+  from any starting level, needs no hardware signal, and deliberately ignores the reported battery status, which a
+  ROM can misreport while charging past the limit.
 - Evidence is scoped to a **composite build identity** (fingerprint + incremental + build time + provider version
   code, hashed). `Build.FINGERPRINT` alone is useless here: LineageOS spoofs it to stock.
 - A refutation is **terminal** for its scope, and a corrupt record is treated as a refutation. Both are fail-closed

--- a/.claude/rules/privileged-access.md
+++ b/.claude/rules/privileged-access.md
@@ -199,9 +199,16 @@ control. A probe that **already** refused control (secondary user, missing provi
 resolution: enforcement stays null and no surface offers an opt-in that could not change anything.
 
 The gate governs **new control only**. A restore the user is already owed — the session restore, its rollback, boot
-recovery — goes through `ChargingRepository.restorePersistent()`, which applies every adapter precondition but not
-the evidence tier: an OTA mid-session changes the build identity, and refusing the owed protective write would
-strand the device in the session's Unrestricted state.
+recovery of one — goes through `ChargingRepository.restorePersistent()`, which applies every adapter precondition
+but not the evidence tier: an OTA mid-session changes the build identity, and refusing the owed protective write
+would strand the device in the session's Unrestricted state.
+
+Pending recovery work is **not** automatically an owed restore, so every recovery target carries a persisted
+`RecoveryOrigin` and `writeRecoveryTarget()` dispatches on it: `SESSION_RESTORE` takes the ungated path,
+`USER_REQUEST` (a widget/tile persistent choice, which `setPersistentPolicy` persists *before* its write) stays on
+the gated `reapplyPersistent()`. A fresh user write — `Unrestricted` included — must not reach a build the gate
+refuses just because a process death turned it into recovery work. The field's default is the gated
+`USER_REQUEST`, so a record from a build without it cannot bypass the gate either.
 
 Evidence is produced by `charging/core/enforcement/`: a pure `EnforcementVerdictEngine` over the monitor's battery
 ticks, persisted by `EnforcementEvidenceStore`. Three properties are load-bearing and must not be relaxed:

--- a/.claude/skills/device-qualification/SKILL.md
+++ b/.claude/skills/device-qualification/SKILL.md
@@ -81,6 +81,15 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
     **This is NOT a GO and oriole is NOT in `QUALIFIED_CODENAMES`**: only part of step 2 was run — wired only, no
     wireless, no below/at/above sweep, no hold observed at the raised cap, and none of steps 3-5 (access tiers,
     sessions, boot recovery, R8). It supersedes the "HAL dropped LIMIT" claim for *this build only*.
+    **Unexplained later observation, recorded so this row does not overclaim**: a few hours after the run above,
+    the device was found at **78 %** with `charging_control_charging_limit` still reading `70` — i.e. a level
+    above the cap. It is **not attributable** and must not be read either as enforcement failing or as anything
+    else: by then the phone had left this run's control entirely — physically unplugged and moved, and its
+    system clock force-set to `Tue Jul 21 02:01 CEST` (a month in the past, at 02:00) by another workflow, which
+    is a scheduled/night-charge experiment signature. Any of that could produce the rise. The controlled
+    observations above stand as recorded; this one is logged only so a later reader does not find it and
+    conclude the row was written selectively. Re-check under controlled conditions before treating either as
+    settled.
     **Why it matters beyond oriole**: same device, same Lineage major version, different build, opposite HAL
     capability. That is the concrete case for HAL capability being **build-scoped, not codename-scoped**, and it
     is why enforcement evidence is keyed on a composite build identity (fingerprint + incremental + build time +

--- a/.claude/skills/device-qualification/SKILL.md
+++ b/.claude/skills/device-qualification/SKILL.md
@@ -56,10 +56,36 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
 
 ## Known gaps
 
-- **LineageOS** — landed **diagnostics-only**: `QUALIFIED_CODENAMES` ships **empty**, so the live adapter never
-  matches and every LineageOS build falls to `LineageLabAdapter`. A codename is added only after that device passes
-  qualification (real charging cessation at the limit, wired + wireless, below/at/above threshold) and gets a
-  "Verified devices" row.
+- **LineageOS** — the live adapter now **matches every LineageOS build that ships the `lineagesettings` provider**;
+  `QUALIFIED_CODENAMES` still ships **empty** but is only a maintainer fast path, no longer what makes the adapter
+  reachable. Control is gated on **per-build enforcement evidence** instead: a device is a candidate with controls
+  off until the user explicitly enables control on an unconfirmed build, and loses control permanently for that
+  build if the battery is observed charging past the cap. A codename still goes into `QUALIFIED_CODENAMES` only
+  after full qualification (real charging cessation at the limit, wired + wireless, below/at/above threshold) plus
+  a "Verified devices" row — that list now buys skipping the opt-in, not access itself.
+  - **Observation can only refute, never confirm** (established 2026-08-17, see the oriole re-observation below):
+    no passively observable signal distinguishes a cap hold from a thermal or weak-supply pause. Both present as
+    plugged + `BATTERY_STATUS_NOT_CHARGING` + a static level. `EXTRA_CHARGING_STATUS` does **not** break the tie —
+    it is session-scoped, measured still reading `4` while the device charged ten points *below* its cap. A guided
+    two-cap cut/resume/cut challenge (raise the cap, verify charging resumes and re-stops at the new threshold) is
+    the known way to earn real confirmation and is deliberately not implemented.
+  - **Pixel 6 (oriole) on LineageOS 23.2 / Android build `BP4A.251205.006` — re-observed 2026-08-17. The
+    2026-07-22 LOS 23.2 NO-GO below does NOT hold on this build.** `dumpsys lineagehealth` binds
+    `ccprovider.Limit` (so the HAL *does* advertise the LIMIT mode bit again), `charging_control_mode` reads back
+    as `3` and is **not** coerced to `1`, and with `enabled=1 / mode=3 / limit=70` the device sat at exactly 70 %
+    on AC for ~4 h: `status: 4` (NOT_CHARGING), `Charging state: 4`, `Charging policy: 1`, voltage 4072 mV.
+    **Causal check**: raising `charging_control_charging_limit` to `80` resumed charging within 20 s —
+    `status: 2`, voltage 4072 → 4183 mV, temperature 294 → 311, charge counter 2908000 → 2910000 — i.e. the
+    setting demonstrably drives the charging hardware, which is stronger evidence than an observed plateau.
+    The limit was restored to `70` and re-verified by read-back; `enabled`/`mode` were never written.
+    **This is NOT a GO and oriole is NOT in `QUALIFIED_CODENAMES`**: only part of step 2 was run — wired only, no
+    wireless, no below/at/above sweep, no hold observed at the raised cap, and none of steps 3-5 (access tiers,
+    sessions, boot recovery, R8). It supersedes the "HAL dropped LIMIT" claim for *this build only*.
+    **Why it matters beyond oriole**: same device, same Lineage major version, different build, opposite HAL
+    capability. That is the concrete case for HAL capability being **build-scoped, not codename-scoped**, and it
+    is why enforcement evidence is keyed on a composite build identity (fingerprint + incremental + build time +
+    provider package version) rather than a codename — LineageOS spoofs `Build.FINGERPRINT` to stock, so the
+    fingerprint alone cannot carry it.
   - **Pixel 6 (oriole) on LineageOS 20.0 / Android 13 — tested 2026-07-22, result NO-GO (no hardware enforcement).**
     The *software chain is fully validated* — both raw (shell-UID `content query`/`content insert`) **and through the
     app's real Shizuku backend end-to-end** (R8 debug build + Shizuku granted): tapping 80 % wrote the trio via

--- a/app/src/debug/java/eu/darken/amply/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/amply/screenshots/ScreenshotContent.kt
@@ -93,6 +93,7 @@ private fun DashboardShot(state: DashboardUiState) = PreviewWrapper {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingPreferences.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingPreferences.kt
@@ -87,6 +87,30 @@ class ChargingPreferences @Inject constructor(
         writer = { state -> json.encodeToString(PolicyState.serializer(), state) },
     )
 
+    /**
+     * The build identity (see `charging/core/enforcement/BuildIdentity`) the user explicitly started
+     * enforcement verification for, or null. Its own key rather than a [PolicyState] field: it is
+     * written once by a deliberate user action and read on every adapter selection, so it must not
+     * wake the policy record's collectors — and it degrades independently of the protective baseline.
+     *
+     * Scoped to a build because that is what the evidence is scoped to: a ROM update re-opens the
+     * question, and the opt-in for the old build must not silently carry over to the new one.
+     */
+    private val verificationStarted = dataStore.createValue(
+        key = stringPreferencesKey("enforcement.verification_started_for"),
+        reader = { raw -> raw as? String },
+        writer = { value -> value },
+    )
+
+    val verificationStartedFor: Flow<String?> = verificationStarted.flow
+
+    suspend fun verificationStartedForNow(): String? = verificationStarted.value()
+
+    /** Record the explicit "verify charge limiting on this device" opt-in for [buildIdentity]. */
+    suspend fun startVerification(buildIdentity: String) {
+        verificationStarted.value(buildIdentity)
+    }
+
     // Each projection dedupes on its own: they all ride one record now, so without this a
     // lastRequestedAt-only write would re-emit every one of them.
     val lastRequested: Flow<ChargePolicy?> = policyState.flow

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingPreferences.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingPreferences.kt
@@ -106,7 +106,7 @@ class ChargingPreferences @Inject constructor(
 
     suspend fun verificationStartedForNow(): String? = verificationStarted.value()
 
-    /** Record the explicit "verify charge limiting on this device" opt-in for [buildIdentity]. */
+    /** Record the explicit "enable charge limiting anyway" opt-in for [buildIdentity]. */
     suspend fun startVerification(buildIdentity: String) {
         verificationStarted.value(buildIdentity)
     }

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -15,6 +15,10 @@ import eu.darken.amply.charging.core.adapter.AdapterSelection
 import eu.darken.amply.charging.core.adapter.ChargingAdapter
 import eu.darken.amply.charging.core.adapter.VerificationStrategy
 import eu.darken.amply.charging.core.ChargingPreferences
+import eu.darken.amply.charging.core.enforcement.BuildIdentitySource
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceState
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceStore
+import eu.darken.amply.charging.core.enforcement.EnforcementStatus
 import eu.darken.amply.common.ca.CaString
 import eu.darken.amply.common.ca.caString
 import eu.darken.amply.common.ca.toCaString
@@ -73,6 +77,13 @@ data class ChargingState(
     /** True when applying a policy needs Shizuku (system-namespace adapter WSS can't write). */
     val writeRequiresShizuku: Boolean = false,
     val controlEnabled: Boolean = false,
+    /**
+     * Where this device sits on the "does the hardware actually enforce the cap" question, or null
+     * where the question doesn't apply (every adapter but LineageOS today). Surfaces must not present
+     * a settings-level read-back as proof while this is
+     * [eu.darken.amply.charging.core.enforcement.EnforcementStatus.UNDER_TEST].
+     */
+    val enforcement: EnforcementStatus? = null,
     val contributionWanted: Boolean = false,
     /** See [eu.darken.amply.charging.core.adapter.AdapterSupport.guidedCaptureUseful]. */
     val guidedCaptureUseful: Boolean = true,
@@ -156,6 +167,8 @@ class ChargingRepository @Inject constructor(
     private val shizukuController: ShizukuController,
     private val settleScheduler: SettleScheduler,
     private val batteryReader: BatteryReader,
+    private val evidenceStore: EnforcementEvidenceStore,
+    private val buildIdentity: BuildIdentitySource,
 ) {
     private val operationMutex = Mutex()
 
@@ -258,13 +271,22 @@ class ChargingRepository @Inject constructor(
         }
     }
 
-    fun nativeSettingsIntent() = registry.select().adapter?.nativeSettingsIntent(context)
+    /**
+     * The selected adapter's *capabilities* only. The enforcement gate decides whether control is
+     * allowed, never which adapter matched, so these callers pass the fail-closed
+     * [EnforcementEvidenceState.Loading] rather than paying for a store read: the worst this can
+     * produce is `controlEnabled = false`, which none of them reads.
+     */
+    private fun capabilityAdapter(): ChargingAdapter? =
+        registry.select(evidenceState = EnforcementEvidenceState.Loading).adapter
 
-    fun currentAdapter(): ChargingAdapter? = registry.select().adapter
+    fun nativeSettingsIntent() = capabilityAdapter()?.nativeSettingsIntent(context)
+
+    fun currentAdapter(): ChargingAdapter? = capabilityAdapter()
 
     /** Configured-settings readback, only for adapters whose writes are synchronously verifiable. */
     suspend fun syncReadback(): ChargeObservation? {
-        val adapter = registry.select().adapter ?: return null
+        val adapter = capabilityAdapter() ?: return null
         if (adapter.verification != VerificationStrategy.SYNC_READBACK) return null
         return readSyncWithFallback(adapter)
     }
@@ -293,7 +315,7 @@ class ChargingRepository @Inject constructor(
         log(TAG, Logging.Priority.INFO) {
             "apply(policy=${policy.stableId}, persistent=$persistent, forceNotify=$forceNotify)"
         }
-        val selection = registry.select()
+        val selection = selectGated()
         val adapter = selection.adapter
         if (adapter == null || !selection.support.controlEnabled) {
             val detail = selection.support.detail.toCaString()
@@ -475,8 +497,29 @@ class ChargingRepository @Inject constructor(
         }
     }
 
+    /**
+     * Adapter selection with the real enforcement gate applied — the only form that may decide
+     * whether a policy write is allowed. Reads the durable evidence and the verification opt-in, so
+     * it is confined to the suspend apply/refresh paths.
+     */
+    private suspend fun selectGated(device: DeviceInfo = DeviceInfo.current(context)): AdapterSelection =
+        registry.select(
+            device = device,
+            evidenceState = evidenceStore.currentState(),
+            verificationStarted = preferences.verificationStartedForNow() == buildIdentity.current(),
+        )
+
+    /** The gated selection, for callers that must observe the real control decision (the support report). */
+    suspend fun currentSelection(): AdapterSelection = selectGated()
+
+    /** Record the user's explicit opt-in to verify charge limiting on this exact build. */
+    suspend fun startEnforcementVerification() {
+        preferences.startVerification(buildIdentity.current())
+        refresh()
+    }
+
     private suspend fun refreshLocked(message: CaString?): ChargingState {
-        val selection: AdapterSelection = registry.select()
+        val selection: AdapterSelection = selectGated()
         val access = accessResolver.snapshot()
         val adapter = selection.adapter
         // ONE sticky observation for everything hardware-derived this refresh — plug state, the
@@ -562,6 +605,7 @@ class ChargingRepository @Inject constructor(
             syncVerification = adapter?.verification == VerificationStrategy.SYNC_READBACK,
             writeRequiresShizuku = adapter?.preferShizukuForWrites == true,
             controlEnabled = selection.support.controlEnabled,
+            enforcement = selection.support.enforcement,
             contributionWanted = selection.support.contributionWanted,
             guidedCaptureUseful = selection.support.guidedCaptureUseful,
             // controlEnabled implies detail is the adapter's *_ready string (every probe's when-cascade

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -82,7 +82,7 @@ data class ChargingState(
      * Where this device sits on the "does the hardware actually enforce the cap" question, or null
      * where the question doesn't apply (every adapter but LineageOS today). Surfaces must not present
      * a settings-level read-back as proof while this is
-     * [eu.darken.amply.charging.core.enforcement.EnforcementStatus.UNDER_TEST].
+     * [eu.darken.amply.charging.core.enforcement.EnforcementStatus.UNVERIFIED].
      */
     val enforcement: EnforcementStatus? = null,
     val contributionWanted: Boolean = false,
@@ -555,7 +555,7 @@ class ChargingRepository @Inject constructor(
     /** The gated selection, for callers that must observe the real control decision (the support report). */
     suspend fun currentSelection(): AdapterSelection = selectGated()
 
-    /** Record the user's explicit opt-in to verify charge limiting on this exact build. */
+    /** Record the user's explicit opt-in to charging control on this exact unconfirmed build. */
     suspend fun startEnforcementVerification() {
         preferences.startVerification(buildIdentity.current())
         refresh()

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -12,6 +12,7 @@ import eu.darken.amply.charging.core.access.AccessSnapshot
 import eu.darken.amply.charging.core.access.shizuku.ShizukuController
 import eu.darken.amply.charging.core.adapter.AdapterRegistry
 import eu.darken.amply.charging.core.adapter.AdapterSelection
+import eu.darken.amply.charging.core.adapter.AdapterSupport
 import eu.darken.amply.charging.core.adapter.ChargingAdapter
 import eu.darken.amply.charging.core.adapter.VerificationStrategy
 import eu.darken.amply.charging.core.ChargingPreferences
@@ -219,6 +220,26 @@ class ChargingRepository @Inject constructor(
         applyLocked(policy, persistent = true, forceNotify = true)
     }
 
+    /**
+     * Repay a protective policy the user ALREADY had: the session restore, its rollback, and boot
+     * recovery. Identical to [applyPersistent]/[reapplyPersistent] except that it does not apply the
+     * enforcement evidence tier.
+     *
+     * The gate exists to withhold NEW control on a build whose hardware was never observed honouring
+     * a cap; withholding a restore instead strands the device in the temporary session's Unrestricted
+     * state, which is the opposite of what the gate is for. The composite build identity changes on
+     * every nightly/OTA, so a confirmed device with a session open across an update comes back as a
+     * candidate with a restore still owed. Every other precondition still applies — the adapter must
+     * match, the probe's own `controlEnabled` must hold (system user, provider present), the policy
+     * must be supported, and a write backend must exist.
+     *
+     * Ordinary persistent and temporary user writes stay on the gated path.
+     */
+    internal suspend fun restorePersistent(policy: ChargePolicy, forceNotify: Boolean = false): ApplyResult =
+        operationMutex.withLock {
+            applyLocked(policy, persistent = true, forceNotify = forceNotify, evidenceGated = false)
+        }
+
     suspend fun requestShizukuPermission(): Boolean {
         val result = runCatching { shizukuController.requestPermission() }.getOrDefault(false)
         refresh(
@@ -311,11 +332,13 @@ class ChargingRepository @Inject constructor(
         policy: ChargePolicy,
         persistent: Boolean,
         forceNotify: Boolean = false,
+        evidenceGated: Boolean = true,
     ): ApplyResult {
         log(TAG, Logging.Priority.INFO) {
-            "apply(policy=${policy.stableId}, persistent=$persistent, forceNotify=$forceNotify)"
+            "apply(policy=${policy.stableId}, persistent=$persistent, forceNotify=$forceNotify, " +
+                "evidenceGated=$evidenceGated)"
         }
-        val selection = selectGated()
+        val selection = if (evidenceGated) selectGated() else selectForRestore()
         val adapter = selection.adapter
         if (adapter == null || !selection.support.controlEnabled) {
             val detail = selection.support.detail.toCaString()
@@ -508,6 +531,26 @@ class ChargingRepository @Inject constructor(
             evidenceState = evidenceStore.currentState(),
             verificationStarted = preferences.verificationStartedForNow() == buildIdentity.current(),
         )
+
+    /**
+     * Adapter selection for [restorePersistent]: the matched adapter with its OWN probe result, i.e.
+     * every capability gate the adapter enforces (system user, provider/key presence, ROM version)
+     * but not the enforcement evidence tier. Not usable for a fresh user write — that is exactly what
+     * the tier decides.
+     */
+    private fun selectForRestore(device: DeviceInfo = DeviceInfo.current(context)): AdapterSelection {
+        val adapter = registry.select(device, EnforcementEvidenceState.Loading).adapter
+            ?: return AdapterSelection(
+                adapter = null,
+                support = AdapterSupport(
+                    matched = false,
+                    controlEnabled = false,
+                    detail = R.string.adapter_detail_none,
+                    contributionWanted = true,
+                ),
+            )
+        return AdapterSelection(adapter = adapter, support = adapter.probe(device))
+    }
 
     /** The gated selection, for callers that must observe the real control decision (the support report). */
     suspend fun currentSelection(): AdapterSelection = selectGated()

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/AdapterRegistry.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/AdapterRegistry.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.amply.R
 import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceState
+import eu.darken.amply.charging.core.enforcement.EnforcementStatus
+import eu.darken.amply.charging.core.enforcement.EnforcementVerdict
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,23 +33,38 @@ class AdapterRegistry @Inject constructor(
 ) {
     // Custom-ROM adapters come FIRST: a custom ROM changes charging control regardless of the OEM
     // hardware underneath, so a LineageOS build on Samsung/Xiaomi/OnePlus/Pixel must be handled by the
-    // Lineage live/lab pair — never swallowed by a manufacturer-based OEM adapter. lineageLab (any
-    // LineageOS build) sits right after the live adapter (qualified codenames) and before all OEM
-    // adapters. GrapheneOS is the same class and must precede `pixel` specifically: it ships only on
-    // Pixels, and the Pixel probe matches any Google/Pixel* device, which would swallow it as a
-    // matched-but-diagnostics-only stock Pixel. Stock devices match neither ROM identity, so all
-    // three skip and OEM matching proceeds.
+    // Lineage live/lab pair — never swallowed by a manufacturer-based OEM adapter. lineageLab sits
+    // right after the live adapter and before all OEM adapters, catching a derivative that reports the
+    // Lineage feature without shipping the settings provider. GrapheneOS is the same class and must
+    // precede `pixel` specifically: it ships only on Pixels, and the Pixel probe matches any
+    // Google/Pixel* device, which would swallow it as a matched-but-diagnostics-only stock Pixel.
+    // Stock devices match neither ROM identity, so all three skip and OEM matching proceeds.
     // Live adapters otherwise match only their verified scopes; same-OEM misses fall to the lab adapters.
     private val adapters = listOf(
         lineage, lineageLab, grapheneOs,
         pixel, samsungModern, samsungLegacy, samsungLab, xiaomi, xiaomiHyperOs3, xiaomiLab, onePlus, onePlusLab,
     )
 
-    fun select(device: DeviceInfo = DeviceInfo.current(context)): AdapterSelection {
+    /**
+     * Select the adapter for [device] and resolve what its enforcement evidence permits.
+     *
+     * [evidenceState] has **no default on purpose**: with one, "the caller forgot", "the store hasn't
+     * been read yet" and "genuinely nothing stored" would all collapse into the control-enabled
+     * branch. Callers that only need adapter *capabilities* (settings URIs, the native-settings
+     * intent, the reconnect-gesture flag) pass [EnforcementEvidenceState.Loading], which resolves
+     * fail-closed and can never enable control.
+     *
+     * [verificationStarted] is whether the user opted this build into verification; it only ever
+     * *withholds* less, so it defaults to the conservative false.
+     */
+    fun select(
+        device: DeviceInfo = DeviceInfo.current(context),
+        evidenceState: EnforcementEvidenceState,
+        verificationStarted: Boolean = false,
+    ): AdapterSelection {
         val match = adapters.firstNotNullOfOrNull { adapter ->
             adapter.probe(device).takeIf { it.matched }?.let { adapter to it }
-        }
-        return match?.let { AdapterSelection(it.first, it.second) } ?: AdapterSelection(
+        } ?: return AdapterSelection(
             adapter = null,
             support = AdapterSupport(
                 matched = false,
@@ -55,5 +73,64 @@ class AdapterRegistry @Inject constructor(
                 contributionWanted = true,
             ),
         )
+        val (adapter, support) = match
+        return AdapterSelection(
+            adapter = adapter,
+            support = resolveEnforcement(adapter, device, support, evidenceState, verificationStarted),
+        )
     }
 }
+
+/**
+ * Apply the enforcement gate to a matched adapter's [support]. The order is the contract:
+ *
+ *  1. a refutation — or an undecodable record, which may be one — disables control and asks for a
+ *     contribution, whatever else is true;
+ *  2. a maintainer-qualified device or a local confirmation leaves control exactly as the probe
+ *     decided. This step MUST precede step 4, or "no stored evidence" would override the
+ *     maintainer fast path and turn every qualified device into a candidate;
+ *  3. a user-started verification leaves control as probed, but the surfaces must not claim the cap
+ *     is proven;
+ *  4. otherwise the device is a candidate: control off until the user starts verification.
+ *
+ * [EnforcementEvidenceState.Loading] falls through to step 4 — fail-closed.
+ */
+internal fun resolveEnforcement(
+    adapter: ChargingAdapter,
+    device: DeviceInfo,
+    support: AdapterSupport,
+    evidenceState: EnforcementEvidenceState,
+    verificationStarted: Boolean,
+): AdapterSupport {
+    if (!adapter.enforcementEvidenceRequired) return support
+    val evidence = (evidenceState as? EnforcementEvidenceState.Present)
+        ?.evidence
+        ?.takeIf { it.adapterId == adapter.id }
+    return when {
+        evidence?.verdict == EnforcementVerdict.REFUTED || evidenceState is EnforcementEvidenceState.Corrupt ->
+            support.copy(
+                controlEnabled = false,
+                detail = support.gateDetail(R.string.adapter_detail_enforcement_refuted),
+                // A device that accepts the setting and charges past it anyway is exactly the report
+                // the maintainer wants, even though the adapter itself is fully mapped.
+                contributionWanted = true,
+                enforcement = EnforcementStatus.REFUTED,
+            )
+        adapter.maintainerQualified(device) || evidence?.verdict == EnforcementVerdict.CONFIRMED ->
+            support.copy(enforcement = EnforcementStatus.CONFIRMED)
+        verificationStarted -> support.copy(enforcement = EnforcementStatus.UNDER_TEST)
+        else -> support.copy(
+            controlEnabled = false,
+            detail = support.gateDetail(R.string.adapter_detail_enforcement_candidate),
+            enforcement = EnforcementStatus.CANDIDATE,
+        )
+    }
+}
+
+/**
+ * The enforcement reason replaces the probe's detail only when the probe itself was happy. A device
+ * that already failed a gate (secondary user, missing provider) keeps that more specific reason —
+ * telling the user to run a verification they cannot complete would be the wrong instruction.
+ */
+private fun AdapterSupport.gateDetail(enforcementDetail: Int): Int =
+    if (controlEnabled) enforcementDetail else detail

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/AdapterRegistry.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/AdapterRegistry.kt
@@ -54,7 +54,8 @@ class AdapterRegistry @Inject constructor(
      * intent, the reconnect-gesture flag) pass [EnforcementEvidenceState.Loading], which resolves
      * fail-closed and can never enable control.
      *
-     * [verificationStarted] is whether the user opted this build into verification; it only ever
+     * [verificationStarted] is whether the user accepted control on this unconfirmed build (the
+     * `enforcement.verification_started_for` opt-in, kept under its original key); it only ever
      * *withholds* less, so it defaults to the conservative false.
      */
     fun select(
@@ -86,20 +87,21 @@ class AdapterRegistry @Inject constructor(
  *
  *  1. a refutation — or an undecodable record, which may be one — disables control and asks for a
  *     contribution, whatever else is true;
- *  2. a maintainer-qualified device or a local confirmation leaves control exactly as the probe
- *     decided. This step MUST precede step 4, or "no stored evidence" would override the
- *     maintainer fast path and turn every qualified device into a candidate;
- *  3. a user-started verification leaves control as probed, but the surfaces must not claim the cap
- *     is proven;
- *  4. otherwise the device is a candidate: control off until the user starts verification.
+ *  2. a maintainer-qualified device leaves control exactly as the probe decided. That is the only
+ *     route to CONFIRMED: physical qualification, never observation (see [EnforcementVerdictEngine]).
+ *     This step MUST precede step 4, or "no stored evidence" would override the maintainer fast path
+ *     and turn every qualified device into a candidate;
+ *  3. a user who accepted the unconfirmed build gets control as probed, but the surfaces must not
+ *     claim the cap holds;
+ *  4. otherwise the device is a candidate: control off until the user accepts it unconfirmed.
  *
  * [EnforcementEvidenceState.Loading] falls through to step 4 — fail-closed.
  *
  * A probe that already refused control (secondary user, missing provider) short-circuits before any
- * of it: enforcement stays **null**, so the surfaces show the specific probe reason and no
- * verification action. Verification is unobservable there anyway — the recorder refuses to observe
- * off the system user and `canApply` never becomes true — so offering it would start a check that
- * can never finish, on a card claiming controls are available.
+ * of it: enforcement stays **null**, so the surfaces show the specific probe reason and no opt-in
+ * action. Control is unreachable there anyway — the recorder refuses to observe off the system user
+ * and `canApply` never becomes true — so offering the opt-in would be an offer that changes nothing,
+ * on a card claiming controls are available.
  */
 internal fun resolveEnforcement(
     adapter: ChargingAdapter,
@@ -109,8 +111,8 @@ internal fun resolveEnforcement(
     verificationStarted: Boolean,
 ): AdapterSupport {
     if (!adapter.enforcementEvidenceRequired) return support
-    // The probe already said no for a reason the user cannot verify their way out of; keep that
-    // reason and leave enforcement unset rather than routing them into a check that cannot complete.
+    // The probe already said no for a reason the user cannot opt their way out of; keep that reason
+    // and leave enforcement unset rather than offering an opt-in that cannot change anything.
     if (!support.controlEnabled) return support
     val evidence = (evidenceState as? EnforcementEvidenceState.Present)
         ?.evidence
@@ -125,9 +127,8 @@ internal fun resolveEnforcement(
                 contributionWanted = true,
                 enforcement = EnforcementStatus.REFUTED,
             )
-        adapter.maintainerQualified(device) || evidence?.verdict == EnforcementVerdict.CONFIRMED ->
-            support.copy(enforcement = EnforcementStatus.CONFIRMED)
-        verificationStarted -> support.copy(enforcement = EnforcementStatus.UNDER_TEST)
+        adapter.maintainerQualified(device) -> support.copy(enforcement = EnforcementStatus.CONFIRMED)
+        verificationStarted -> support.copy(enforcement = EnforcementStatus.UNVERIFIED)
         else -> support.copy(
             controlEnabled = false,
             detail = R.string.adapter_detail_enforcement_candidate,

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/AdapterRegistry.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/AdapterRegistry.kt
@@ -94,6 +94,12 @@ class AdapterRegistry @Inject constructor(
  *  4. otherwise the device is a candidate: control off until the user starts verification.
  *
  * [EnforcementEvidenceState.Loading] falls through to step 4 — fail-closed.
+ *
+ * A probe that already refused control (secondary user, missing provider) short-circuits before any
+ * of it: enforcement stays **null**, so the surfaces show the specific probe reason and no
+ * verification action. Verification is unobservable there anyway — the recorder refuses to observe
+ * off the system user and `canApply` never becomes true — so offering it would start a check that
+ * can never finish, on a card claiming controls are available.
  */
 internal fun resolveEnforcement(
     adapter: ChargingAdapter,
@@ -103,6 +109,9 @@ internal fun resolveEnforcement(
     verificationStarted: Boolean,
 ): AdapterSupport {
     if (!adapter.enforcementEvidenceRequired) return support
+    // The probe already said no for a reason the user cannot verify their way out of; keep that
+    // reason and leave enforcement unset rather than routing them into a check that cannot complete.
+    if (!support.controlEnabled) return support
     val evidence = (evidenceState as? EnforcementEvidenceState.Present)
         ?.evidence
         ?.takeIf { it.adapterId == adapter.id }
@@ -110,7 +119,7 @@ internal fun resolveEnforcement(
         evidence?.verdict == EnforcementVerdict.REFUTED || evidenceState is EnforcementEvidenceState.Corrupt ->
             support.copy(
                 controlEnabled = false,
-                detail = support.gateDetail(R.string.adapter_detail_enforcement_refuted),
+                detail = R.string.adapter_detail_enforcement_refuted,
                 // A device that accepts the setting and charges past it anyway is exactly the report
                 // the maintainer wants, even though the adapter itself is fully mapped.
                 contributionWanted = true,
@@ -121,16 +130,8 @@ internal fun resolveEnforcement(
         verificationStarted -> support.copy(enforcement = EnforcementStatus.UNDER_TEST)
         else -> support.copy(
             controlEnabled = false,
-            detail = support.gateDetail(R.string.adapter_detail_enforcement_candidate),
+            detail = R.string.adapter_detail_enforcement_candidate,
             enforcement = EnforcementStatus.CANDIDATE,
         )
     }
 }
-
-/**
- * The enforcement reason replaces the probe's detail only when the probe itself was happy. A device
- * that already failed a gate (secondary user, missing provider) keeps that more specific reason —
- * telling the user to run a verification they cannot complete would be the wrong instruction.
- */
-private fun AdapterSupport.gateDetail(enforcementDetail: Int): Int =
-    if (controlEnabled) enforcementDetail else detail

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
@@ -102,6 +102,22 @@ interface ChargingAdapter {
         false
 
     /**
+     * An unambiguous HARDWARE signal that the charging policy is holding the battery **right now**:
+     * true when the hardware reports a hold, false when it reports something else, and **null when
+     * this adapter has no such signal at all** — enforcement can then never be CONFIRMED on it (only
+     * REFUTED, which needs no hardware corroboration). Null by default, so no other adapter changes.
+     *
+     * Deliberately NOT folded into [decodeHardware]: that result also feeds the dashboard's
+     * observation and the settling/pending logic, and widening it for this question would change
+     * behavior far beyond the enforcement verdict.
+     *
+     * @param chargingStatus `BatteryManager.EXTRA_CHARGING_STATUS` from the same battery readout.
+     * @param plugged whether external power is present. Unplugged the sticky broadcast keeps its last
+     *   powered value, which is evidence of nothing — such adapters return null there.
+     */
+    fun hardwareHoldSignal(chargingStatus: Int?, plugged: Boolean): Boolean? = null
+
+    /**
      * Whether control on this adapter must be justified by **observed hardware enforcement** on the
      * user's own device, not by the settings read-back alone. Set where the setting can be written
      * and read back perfectly while the charging HAL never limits (LineageOS): such a device is a

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
@@ -8,6 +8,7 @@ import eu.darken.amply.charging.core.access.AccessBackend
 import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.enforcement.EnforcementStatus
 import eu.darken.amply.common.ca.CaString
 
 data class AdapterSupport(
@@ -29,6 +30,17 @@ data class AdapterSupport(
      * this instrument.
      */
     val guidedCaptureUseful: Boolean = true,
+    /**
+     * Where this device sits on the "does the hardware actually enforce the cap" question, or **null**
+     * when the question does not apply to this adapter (every adapter but the ones setting
+     * [ChargingAdapter.enforcementEvidenceRequired]). Deliberately nullable rather than a blanket
+     * "qualified" default: labelling the lab and unsupported adapters CONFIRMED would claim exactly
+     * what they cannot.
+     *
+     * Filled in by [AdapterRegistry], not by the probes — the probes see immutable device information,
+     * while this depends on stored evidence and an opt-in.
+     */
+    val enforcement: EnforcementStatus? = null,
 )
 
 /** How an adapter's applied configuration can be confirmed. */
@@ -88,6 +100,22 @@ interface ChargingAdapter {
      */
     fun confirmationExpected(policy: ChargePolicy, chargingStatus: Int?, plugged: Boolean): Boolean =
         false
+
+    /**
+     * Whether control on this adapter must be justified by **observed hardware enforcement** on the
+     * user's own device, not by the settings read-back alone. Set where the setting can be written
+     * and read back perfectly while the charging HAL never limits (LineageOS): such a device is a
+     * CANDIDATE with control OFF until either a maintainer qualified it ([maintainerQualified]) or a
+     * user-started verification observed the cap holding. Defaulted, so no other adapter changes.
+     */
+    val enforcementEvidenceRequired: Boolean get() = false
+
+    /**
+     * The maintainer fast path for [enforcementEvidenceRequired] adapters: a device physically
+     * qualified against the protocol in the `device-qualification` skill, which needs no local
+     * evidence. False everywhere else, including on adapters that require no evidence at all.
+     */
+    fun maintainerQualified(device: DeviceInfo): Boolean = false
 
     fun probe(device: DeviceInfo): AdapterSupport
     fun readHardware(context: Context): ChargeObservation? = null

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
@@ -102,27 +102,12 @@ interface ChargingAdapter {
         false
 
     /**
-     * An unambiguous HARDWARE signal that the charging policy is holding the battery **right now**:
-     * true when the hardware reports a hold, false when it reports something else, and **null when
-     * this adapter has no such signal at all** — enforcement can then never be CONFIRMED on it (only
-     * REFUTED, which needs no hardware corroboration). Null by default, so no other adapter changes.
-     *
-     * Deliberately NOT folded into [decodeHardware]: that result also feeds the dashboard's
-     * observation and the settling/pending logic, and widening it for this question would change
-     * behavior far beyond the enforcement verdict.
-     *
-     * @param chargingStatus `BatteryManager.EXTRA_CHARGING_STATUS` from the same battery readout.
-     * @param plugged whether external power is present. Unplugged the sticky broadcast keeps its last
-     *   powered value, which is evidence of nothing — such adapters return null there.
-     */
-    fun hardwareHoldSignal(chargingStatus: Int?, plugged: Boolean): Boolean? = null
-
-    /**
-     * Whether control on this adapter must be justified by **observed hardware enforcement** on the
-     * user's own device, not by the settings read-back alone. Set where the setting can be written
-     * and read back perfectly while the charging HAL never limits (LineageOS): such a device is a
-     * CANDIDATE with control OFF until either a maintainer qualified it ([maintainerQualified]) or a
-     * user-started verification observed the cap holding. Defaulted, so no other adapter changes.
+     * Whether control on this adapter must be justified by more than the settings read-back. Set
+     * where the setting can be written and read back perfectly while the charging HAL never limits
+     * (LineageOS): such a device is a CANDIDATE with control OFF until either a maintainer qualified
+     * it ([maintainerQualified]) or the user accepted the unconfirmed build. Nothing observable can
+     * *confirm* the cap — see `EnforcementVerdictEngine` — so control there stays a claim Amply never
+     * makes, and an observed climb past the cap withdraws it. Defaulted, so no other adapter changes.
      */
     val enforcementEvidenceRequired: Boolean get() = false
 

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/LabChargingAdapters.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/LabChargingAdapters.kt
@@ -65,8 +65,11 @@ class LineageLabAdapter @Inject constructor() : DisabledLabAdapter() {
     override val id = "lineageos-lab"
     override val displayName = R.string.adapter_name_lineageos.toCaString()
 
-    // Any LineageOS build whose device codename is not in the live adapter's qualified allowlist.
-    // Charging control is HAL-dependent and unverified here, so it stays diagnostics/contribution only.
+    // Reached by a LineageOS build (or a derivative reporting the platform feature) that does NOT ship
+    // the `lineagesettings` provider — there is nothing to write, so it stays diagnostics/contribution
+    // only. Builds WITH the provider are handled by LineageChargingAdapter, which matches first and
+    // holds control back on its own enforcement evidence. Those devices used to see a more specific
+    // "not available on this build" note and now get the generic lab text.
     override fun matches(device: DeviceInfo) = device.isLineageOs
 
     // The three charging_control_* keys are already mapped and live in a provider the wizard does not capture,

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapter.kt
@@ -30,11 +30,23 @@ import javax.inject.Singleton
  * `WRITE_SECURE_SETTINGS` cannot write it — [preferShizukuForWrites]). Verified with read-back equality
  * ([VerificationStrategy.SYNC_READBACK]).
  *
- * The HAL is device-dependent (some devices flip the setting but never limit — the `mIsLimitSet:false`
- * class of bug), so control is gated to a **physically-qualified codename allowlist**
- * ([QUALIFIED_CODENAMES]) that ships **empty** until a device passes qualification; every LineageOS build
- * otherwise falls through to [LineageLabAdapter]. See the qualification ledger in
- * `.claude/skills/device-qualification/`.
+ * The gate is **two-layered**, because the two layers answer different questions:
+ *
+ *  - *Did the ROM accept the configuration?* — the write read-back ([VerificationStrategy.SYNC_READBACK]).
+ *  - *Did the hardware act on it?* — observed enforcement. The HAL is device- AND build-dependent (some
+ *    builds flip the setting but never limit — the `mIsLimitSet:false` class of bug; oriole exposed the
+ *    LIMIT mode bit on LineageOS 20 and dropped it on 23.2 on identical hardware), and no read can
+ *    answer it. So this adapter sets [enforcementEvidenceRequired]: it *matches* every LineageOS build
+ *    that ships the settings provider, but control stays off until either the maintainer qualified the
+ *    codename ([QUALIFIED_CODENAMES], the fast path, still empty) or the user ran a verification on
+ *    their own device and the cap was observed holding. See
+ *    `charging/core/enforcement/EnforcementVerdictEngine` and the ledger in
+ *    `.claude/skills/device-qualification/`.
+ *
+ * A LineageOS build **without** the provider no longer matches here at all and falls through to
+ * [LineageLabAdapter] (generic diagnostics text): keeping provider presence in [probe]'s `matched`
+ * preserves the registry's custom-ROM-before-OEM ordering for those devices, at the cost of the more
+ * specific "not available on this build" note this adapter used to show them.
  */
 @Singleton
 class LineageChargingAdapter @Inject constructor(
@@ -57,21 +69,27 @@ class LineageChargingAdapter @Inject constructor(
     override val sessionOverridePolicy = ChargePolicy.Unrestricted
     override val verification = VerificationStrategy.SYNC_READBACK
     override val preferShizukuForWrites = true
+    override val enforcementEvidenceRequired = true
+
+    override fun maintainerQualified(device: DeviceInfo) = device.codename in qualifiedCodenames
 
     override fun probe(device: DeviceInfo): AdapterSupport {
-        val matched = device.isLineageOs && device.codename in qualifiedCodenames
+        val matched = device.isLineageOs && device.hasLineageSettingsProvider
         return AdapterSupport(
             matched = matched,
-            controlEnabled = matched && device.hasLineageSettingsProvider && device.isSystemUser,
+            controlEnabled = matched && device.isSystemUser,
             detail = when {
                 !matched -> R.string.adapter_detail_requires_lineageos
-                !device.hasLineageSettingsProvider -> R.string.adapter_detail_lineageos_no_provider
                 !device.isSystemUser -> R.string.adapter_detail_secondary_user
                 else -> R.string.adapter_detail_lineageos_ready
             },
-            // Unqualified LineageOS builds are handled by LineageLabAdapter, so this live adapter never
-            // solicits a contribution itself.
+            // Whether this device is worth a report is decided by the enforcement gate (a refutation is),
+            // not by the adapter: its keys are fully mapped either way.
             contributionWanted = false,
+            // The three charging_control_* keys are already mapped and live in a provider the wizard does
+            // not capture, so a guided run always diffs to nothing and cannot be delivered — same reason
+            // LineageLabAdapter withholds it. A refuted device contributes through the direct report.
+            guidedCaptureUseful = false,
         )
     }
 
@@ -163,10 +181,12 @@ class LineageChargingAdapter @Inject constructor(
         private val CANONICAL_LIMIT_STRINGS = SUPPORTED_LIMITS.map { it.toString() }.toSet()
 
         /**
-         * Physically-qualified device codenames (`Build.DEVICE`) where the charge-control HAL is confirmed
-         * to enforce the limit. **Ships empty** — the adapter is diagnostics-only until a device passes the
-         * qualification protocol and gets a ledger row (see `.claude/skills/device-qualification/`). Widen
-         * ONLY with a qualified device.
+         * The **maintainer fast path**: device codenames (`Build.DEVICE`) whose charge-control HAL was
+         * physically confirmed to enforce the limit, which therefore need no local evidence. **Ships
+         * empty** — it is no longer what makes the adapter reachable (every provider-carrying LineageOS
+         * build matches now), only what lets a device skip verification. Widen ONLY with a qualified
+         * device plus a ledger row (see `.claude/skills/device-qualification/`), and remember that HAL
+         * capability is build-scoped: a bare codename here claims every build on that device.
          */
         val QUALIFIED_CODENAMES = emptySet<String>()
     }

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapter.kt
@@ -15,6 +15,7 @@ import eu.darken.amply.charging.core.access.LineageChargeReader
 import eu.darken.amply.charging.core.access.SettingMutation
 import eu.darken.amply.charging.core.access.SettingNamespace
 import eu.darken.amply.common.ca.toCaString
+import eu.darken.amply.stats.core.StatsLimitHitDetector
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -72,6 +73,19 @@ class LineageChargingAdapter @Inject constructor(
     override val enforcementEvidenceRequired = true
 
     override fun maintainerQualified(device: DeviceInfo) = device.codename in qualifiedCodenames
+
+    /**
+     * LineageOS drives AOSP's charge-policy plumbing, so while its Charging Control HAL holds the
+     * battery at the limit the public battery broadcast reports
+     * [StatsLimitHitDetector.HARDWARE_HOLD_STATE] — `Charging state: 4`, observed on a Pixel 6
+     * (`oriole`, LineageOS 23.2) sitting at its cap. That is the corroboration a CONFIRMED verdict
+     * needs, because a passive plateau cannot tell a cap hold from a thermal or supply-induced pause.
+     *
+     * Unplugged the extra is a stale sticky value from the last plug session, so it is not evidence
+     * in either direction: null, which the verdict engine reads as "cannot confirm".
+     */
+    override fun hardwareHoldSignal(chargingStatus: Int?, plugged: Boolean): Boolean? =
+        if (plugged) chargingStatus == StatsLimitHitDetector.HARDWARE_HOLD_STATE else null
 
     override fun probe(device: DeviceInfo): AdapterSupport {
         val matched = device.isLineageOs && device.hasLineageSettingsProvider

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapter.kt
@@ -15,7 +15,6 @@ import eu.darken.amply.charging.core.access.LineageChargeReader
 import eu.darken.amply.charging.core.access.SettingMutation
 import eu.darken.amply.charging.core.access.SettingNamespace
 import eu.darken.amply.common.ca.toCaString
-import eu.darken.amply.stats.core.StatsLimitHitDetector
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -34,15 +33,25 @@ import javax.inject.Singleton
  * The gate is **two-layered**, because the two layers answer different questions:
  *
  *  - *Did the ROM accept the configuration?* — the write read-back ([VerificationStrategy.SYNC_READBACK]).
- *  - *Did the hardware act on it?* — observed enforcement. The HAL is device- AND build-dependent (some
- *    builds flip the setting but never limit — the `mIsLimitSet:false` class of bug; oriole exposed the
- *    LIMIT mode bit on LineageOS 20 and dropped it on 23.2 on identical hardware), and no read can
- *    answer it. So this adapter sets [enforcementEvidenceRequired]: it *matches* every LineageOS build
- *    that ships the settings provider, but control stays off until either the maintainer qualified the
- *    codename ([QUALIFIED_CODENAMES], the fast path, still empty) or the user ran a verification on
- *    their own device and the cap was observed holding. See
- *    `charging/core/enforcement/EnforcementVerdictEngine` and the ledger in
- *    `.claude/skills/device-qualification/`.
+ *  - *Did the hardware act on it?* — the HAL is device- AND build-dependent (some builds flip the
+ *    setting but never limit — the `mIsLimitSet:false` class of bug; oriole exposed the LIMIT mode bit
+ *    on LineageOS 20 and dropped it on 23.2 on identical hardware), and no read can answer it. So this
+ *    adapter sets [enforcementEvidenceRequired]: it *matches* every LineageOS build that ships the
+ *    settings provider, but control stays off until either the maintainer qualified the codename
+ *    ([QUALIFIED_CODENAMES], the fast path, still empty) or the user explicitly accepted the
+ *    unconfirmed build.
+ *
+ * **Amply never claims the cap is confirmed from observation here, and this adapter deliberately
+ * exposes no hardware hold signal.** `BatteryManager.EXTRA_CHARGING_STATUS` looked like one — a Pixel 6
+ * (`oriole`, LineageOS 23.2) holding at a 70% cap reports `Charging state: 4` — but the value is
+ * *session-scoped*: after raising the cap to 80 the same device was actively charging at level 70,
+ * ten points below the cap, and still reported 4. It means "limit mode is enabled for this plug
+ * session", not "charging is stopped right now", exactly as `StatsLimitHitDetector`'s KDoc documents
+ * for Pixel. Nothing else in the public broadcast separates a cap hold from a thermal or weak-supply
+ * pause either (only `status` differs, which a thermal pause produces too), so the only remaining
+ * evidence is **refutation**: a level observed climbing past the cap. See
+ * `charging/core/enforcement/EnforcementVerdictEngine` and the ledger in
+ * `.claude/skills/device-qualification/`.
  *
  * A LineageOS build **without** the provider no longer matches here at all and falls through to
  * [LineageLabAdapter] (generic diagnostics text): keeping provider presence in [probe]'s `matched`
@@ -73,19 +82,6 @@ class LineageChargingAdapter @Inject constructor(
     override val enforcementEvidenceRequired = true
 
     override fun maintainerQualified(device: DeviceInfo) = device.codename in qualifiedCodenames
-
-    /**
-     * LineageOS drives AOSP's charge-policy plumbing, so while its Charging Control HAL holds the
-     * battery at the limit the public battery broadcast reports
-     * [StatsLimitHitDetector.HARDWARE_HOLD_STATE] — `Charging state: 4`, observed on a Pixel 6
-     * (`oriole`, LineageOS 23.2) sitting at its cap. That is the corroboration a CONFIRMED verdict
-     * needs, because a passive plateau cannot tell a cap hold from a thermal or supply-induced pause.
-     *
-     * Unplugged the extra is a stale sticky value from the last plug session, so it is not evidence
-     * in either direction: null, which the verdict engine reads as "cannot confirm".
-     */
-    override fun hardwareHoldSignal(chargingStatus: Int?, plugged: Boolean): Boolean? =
-        if (plugged) chargingStatus == StatsLimitHitDetector.HARDWARE_HOLD_STATE else null
 
     override fun probe(device: DeviceInfo): AdapterSupport {
         val matched = device.isLineageOs && device.hasLineageSettingsProvider

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/BuildIdentity.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/BuildIdentity.kt
@@ -1,0 +1,72 @@
+package eu.darken.amply.charging.core.enforcement
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.pm.PackageInfoCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.amply.charging.core.DeviceInfo
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Compose the opaque identity a stored [EnforcementEvidence] is scoped to.
+ *
+ * Deliberately NOT `Build.FINGERPRINT` alone: LineageOS **spoofs the fingerprint to stock**
+ * (`google/oriole/oriole:16/…/release-keys`, verified on oriole — see the qualification ledger), so
+ * two nightlies with different charge-control behavior share one fingerprint. The build's own
+ * incremental id and timestamp move with every ROM build, and the `lineagesettings` provider
+ * package's version code moves when the platform component that drives the HAL is updated.
+ *
+ * Hashed so nothing device-identifying is ever held in a preference or shown in a report; equality is
+ * the only thing any caller needs.
+ */
+internal fun composeBuildIdentity(
+    fingerprint: String,
+    incremental: String,
+    buildTimeMillis: Long,
+    settingsProviderVersionCode: Long,
+): String {
+    val raw = listOf(fingerprint, incremental, buildTimeMillis.toString(), settingsProviderVersionCode.toString())
+        .joinToString("|")
+    val digest = MessageDigest.getInstance("SHA-256").digest(raw.toByteArray())
+    return digest.take(IDENTITY_BYTES).joinToString("") { "%02x".format(it) }
+}
+
+/** 8 bytes / 16 hex chars: an equality token, not a cryptographic commitment. */
+private const val IDENTITY_BYTES = 8
+
+/** An interface so stores and engines stay unit-testable without the Android build environment. */
+interface BuildIdentitySource {
+    fun current(): String
+}
+
+@Singleton
+class DeviceBuildIdentitySource @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : BuildIdentitySource {
+
+    // Immutable for the process lifetime: every input is fixed at boot, and this is read on every
+    // adapter selection.
+    private val identity: String by lazy {
+        composeBuildIdentity(
+            fingerprint = Build.FINGERPRINT.orEmpty(),
+            incremental = Build.VERSION.INCREMENTAL.orEmpty(),
+            buildTimeMillis = Build.TIME,
+            settingsProviderVersionCode = settingsProviderVersionCode(),
+        )
+    }
+
+    override fun current(): String = identity
+
+    /** 0 when the provider (or its package) can't be resolved — absence is itself part of the identity. */
+    private fun settingsProviderVersionCode(): Long = runCatching {
+        val packageManager = context.packageManager
+        val provider = packageManager.resolveContentProvider(DeviceInfo.LINEAGE_SETTINGS_AUTHORITY, 0)
+            ?: return@runCatching 0L
+        PackageInfoCompat.getLongVersionCode(
+            packageManager.getPackageInfo(provider.packageName, PackageManager.GET_META_DATA),
+        )
+    }.getOrDefault(0L)
+}

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidence.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidence.kt
@@ -25,14 +25,16 @@ enum class EnforcementVerdict {
  * default so a record written by an older build still decodes. [verdict] defaults to
  * [EnforcementVerdict.REFUTED] — a record that lost its verdict field must never read as a claim of
  * enforcement. A record naming a verdict this build no longer knows does not decode at all and reads
- * as [EnforcementEvidenceState.Corrupt], i.e. control off — the safe direction, and unreachable in
- * practice since the confirmation path never shipped.
+ * as [EnforcementEvidenceState.Corrupt], i.e. control off — the safe direction. The one such name that
+ * really exists on disk, version 1's `"CONFIRMED"`, is translated before deserialization is attempted
+ * (see [EnforcementEvidenceStore]).
  *
  * @param buildIdentity see [composeBuildIdentity]; scopes the verdict to the exact ROM build it was
  *   observed on, because charge-control HAL capability is build-scoped, not device-scoped.
  * @param algorithmVersion the [EnforcementVerdictEngine.ALGORITHM_VERSION] that produced the verdict.
- *   A later tightening of the heuristic bumps it, and every record from the weaker one stops counting
- *   (it reads as no evidence, exactly like a build-identity mismatch).
+ *   A later tightening of the heuristic bumps it, and a record from the weaker one only survives
+ *   where the tightening left its verdict intact — [EnforcementEvidenceStore] migrates those per
+ *   verdict, so dropping an arm never hands control back to a device that failed under the old one.
  * @param capPercent the configured cap the observation was made against.
  * @param observedPercent the battery level at the moment the verdict was reached.
  */

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidence.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidence.kt
@@ -1,0 +1,58 @@
+package eu.darken.amply.charging.core.enforcement
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** What was observed about the charging hardware, never about the configured setting. */
+@Serializable
+enum class EnforcementVerdict {
+    /** The battery was observed held at the configured cap: the hardware acts on the setting. */
+    @SerialName("CONFIRMED")
+    CONFIRMED,
+
+    /** The battery was observed charging past the configured cap: the setting is cosmetic here. */
+    @SerialName("REFUTED")
+    REFUTED,
+}
+
+/**
+ * One durable verdict about whether this build's charging hardware enforces a configured cap.
+ *
+ * A stored wire format (see `code-style.md`): every property carries an explicit [SerialName] and a
+ * default so a record written by an older build still decodes. [verdict] defaults to
+ * [EnforcementVerdict.REFUTED] on purpose — a record that lost its verdict field must never read as
+ * a claim of enforcement.
+ *
+ * @param buildIdentity see [composeBuildIdentity]; scopes the verdict to the exact ROM build it was
+ *   observed on, because charge-control HAL capability is build-scoped, not device-scoped.
+ * @param algorithmVersion the [EnforcementVerdictEngine.ALGORITHM_VERSION] that produced the verdict.
+ *   A later tightening of the heuristic bumps it, and every record from the weaker one stops counting
+ *   (it reads as no evidence, exactly like a build-identity mismatch).
+ * @param capPercent the configured cap the observation was made against.
+ * @param observedPercent the battery level at the moment the verdict was reached.
+ */
+@Serializable
+data class EnforcementEvidence(
+    @SerialName("adapterId") val adapterId: String = "",
+    @SerialName("buildIdentity") val buildIdentity: String = "",
+    @SerialName("algorithmVersion") val algorithmVersion: Int = 0,
+    @SerialName("verdict") val verdict: EnforcementVerdict = EnforcementVerdict.REFUTED,
+    @SerialName("capPercent") val capPercent: Int = 0,
+    @SerialName("observedPercent") val observedPercent: Int = 0,
+    @SerialName("observedAtWallMillis") val observedAtWallMillis: Long = 0L,
+)
+
+/** Where a device sits on the "does the hardware actually enforce the cap" question. */
+enum class EnforcementStatus {
+    /** No evidence yet and the user has not started verification: control stays off. */
+    CANDIDATE,
+
+    /** The user started verification on this build: control is available but claims nothing. */
+    UNDER_TEST,
+
+    /** Maintainer-qualified, or locally observed holding at the cap. */
+    CONFIRMED,
+
+    /** Observed charging past the cap on this build: control is off and stays off. */
+    REFUTED,
+}

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidence.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidence.kt
@@ -3,13 +3,16 @@ package eu.darken.amply.charging.core.enforcement
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/** What was observed about the charging hardware, never about the configured setting. */
+/**
+ * What was observed about the charging hardware, never about the configured setting.
+ *
+ * **One value on purpose.** Passive observation can only ever *refute* a cap — see
+ * [EnforcementVerdictEngine] for the measurement that removed the confirmation path. It stays an
+ * enum rather than collapsing into a boolean or disappearing so the stored wire format and its
+ * [SerialName] keep decoding unchanged.
+ */
 @Serializable
 enum class EnforcementVerdict {
-    /** The battery was observed held at the configured cap: the hardware acts on the setting. */
-    @SerialName("CONFIRMED")
-    CONFIRMED,
-
     /** The battery was observed charging past the configured cap: the setting is cosmetic here. */
     @SerialName("REFUTED")
     REFUTED,
@@ -20,8 +23,10 @@ enum class EnforcementVerdict {
  *
  * A stored wire format (see `code-style.md`): every property carries an explicit [SerialName] and a
  * default so a record written by an older build still decodes. [verdict] defaults to
- * [EnforcementVerdict.REFUTED] on purpose — a record that lost its verdict field must never read as
- * a claim of enforcement.
+ * [EnforcementVerdict.REFUTED] — a record that lost its verdict field must never read as a claim of
+ * enforcement. A record naming a verdict this build no longer knows does not decode at all and reads
+ * as [EnforcementEvidenceState.Corrupt], i.e. control off — the safe direction, and unreachable in
+ * practice since the confirmation path never shipped.
  *
  * @param buildIdentity see [composeBuildIdentity]; scopes the verdict to the exact ROM build it was
  *   observed on, because charge-control HAL capability is build-scoped, not device-scoped.
@@ -44,13 +49,20 @@ data class EnforcementEvidence(
 
 /** Where a device sits on the "does the hardware actually enforce the cap" question. */
 enum class EnforcementStatus {
-    /** No evidence yet and the user has not started verification: control stays off. */
+    /** No evidence and the user has not accepted the unconfirmed build: control stays off. */
     CANDIDATE,
 
-    /** The user started verification on this build: control is available but claims nothing. */
-    UNDER_TEST,
+    /**
+     * The user accepted control on an unconfirmed build: it is available, but nothing here shows the
+     * cap holding and nothing ever will — only a refutation can still arrive.
+     */
+    UNVERIFIED,
 
-    /** Maintainer-qualified, or locally observed holding at the cap. */
+    /**
+     * Maintainer-qualified: a device physically qualified against the protocol in the
+     * `device-qualification` skill. This is the ONLY route to a confirmed cap — local observation
+     * cannot produce one (see [EnforcementVerdictEngine]).
+     */
     CONFIRMED,
 
     /** Observed charging past the cap on this build: control is off and stays off. */

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStore.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStore.kt
@@ -43,8 +43,7 @@ sealed interface EnforcementEvidenceState {
  *
  * Reads are **scoped**: a record from another ROM build or from an older
  * [EnforcementVerdictEngine.ALGORITHM_VERSION] reads as [EnforcementEvidenceState.Absent], since
- * charge-control HAL capability is build-scoped and an older heuristic's confirmation is not this
- * one's.
+ * charge-control HAL capability is build-scoped and an older heuristic's verdict is not this one's.
  */
 @Singleton
 class EnforcementEvidenceStore @Inject constructor(
@@ -66,24 +65,17 @@ class EnforcementEvidenceStore @Inject constructor(
     suspend fun currentState(): EnforcementEvidenceState = scope(decode(stored.value()))
 
     /**
-     * Persist [evidence], honouring the one asymmetry that matters: a REFUTED record for the same
-     * scope is terminal, so a later CONFIRMED must not overwrite it — a device that charged past its
-     * cap is not redeemed by a later plateau. A REFUTED verdict overwrites anything, including a
-     * corrupt record. A CONFIRMED verdict declines to overwrite a corrupt record: what it would
-     * replace is unknown, and unknown fails closed.
+     * Persist [evidence]. A refutation is **terminal**: an existing one for the same scope is kept as
+     * first observed rather than restamped, since nothing that can be observed later changes it (only
+     * a refutation is observable at all — see [EnforcementVerdictEngine]). It does overwrite a corrupt
+     * record: both fail closed, and the refutation is the more informative of the two.
      *
      * @return true when the store now holds exactly [evidence].
      */
     suspend fun record(evidence: EnforcementEvidence): Boolean {
         val encoded = encode(evidence)
         val updated = stored.update { raw ->
-            val current = decode(raw)
-            when {
-                evidence.verdict == EnforcementVerdict.REFUTED -> encoded
-                current is EnforcementEvidenceState.Corrupt -> raw
-                current.terminalFor(evidence) -> raw
-                else -> encoded
-            }
+            if (decode(raw).terminalFor(evidence)) raw else encoded
         }
         val accepted = updated.new == encoded
         log(TAG, Logging.Priority.INFO) {
@@ -124,7 +116,7 @@ class EnforcementEvidenceStore @Inject constructor(
     }
 }
 
-/** Whether the stored state blocks [candidate]: a refutation for the very same scope. */
+/** Whether the stored state is already terminal for [candidate]: a refutation for the very same scope. */
 private fun EnforcementEvidenceState.terminalFor(candidate: EnforcementEvidence): Boolean {
     val existing = (this as? EnforcementEvidenceState.Present)?.evidence ?: return false
     return existing.verdict == EnforcementVerdict.REFUTED &&

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStore.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStore.kt
@@ -11,6 +11,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -41,9 +45,13 @@ sealed interface EnforcementEvidenceState {
  * a write that declines to replace it, which a state-typed writer could not express — it would
  * encode the undecodable state as "clear the key".
  *
- * Reads are **scoped**: a record from another ROM build or from an older
- * [EnforcementVerdictEngine.ALGORITHM_VERSION] reads as [EnforcementEvidenceState.Absent], since
- * charge-control HAL capability is build-scoped and an older heuristic's verdict is not this one's.
+ * Reads are **scoped**: a record from another ROM build reads as [EnforcementEvidenceState.Absent],
+ * since charge-control HAL capability is build-scoped.
+ *
+ * A record from an older [EnforcementVerdictEngine.ALGORITHM_VERSION] is **migrated per verdict**,
+ * not dropped wholesale — see [decode]. Dropping them all would fail *open*: the version-1 to -2 bump
+ * only invalidated the confirmation arm, so discarding a version-1 refutation would re-enable control
+ * on a build already observed charging past its cap, with the opt-in preference still set.
  */
 @Singleton
 class EnforcementEvidenceStore @Inject constructor(
@@ -94,10 +102,21 @@ class EnforcementEvidenceStore @Inject constructor(
         else -> state
     }
 
+    /**
+     * The wire version and verdict are read **before** typed deserialization, because a version-1
+     * record can no longer be deserialized into today's types at all (its `"CONFIRMED"` constant is
+     * gone) and because the two version-1 verdicts must migrate in opposite directions.
+     */
     private fun decode(raw: String?): EnforcementEvidenceState {
         if (raw == null) return EnforcementEvidenceState.Absent
         return try {
-            EnforcementEvidenceState.Present(json.decodeFromString(EnforcementEvidence.serializer(), raw))
+            val wire = json.parseToJsonElement(raw).jsonObject
+            val version = wire[FIELD_ALGORITHM_VERSION]?.jsonPrimitive?.intOrNull
+            if (version == SUPERSEDED_ALGORITHM_VERSION) {
+                migrateSuperseded(wire[FIELD_VERDICT]?.jsonPrimitive?.contentOrNull, raw)
+            } else {
+                EnforcementEvidenceState.Present(json.decodeFromString(EnforcementEvidence.serializer(), raw))
+            }
         } catch (e: SerializationException) {
             log(TAG, Logging.Priority.ERROR) { "Corrupt enforcement evidence: ${e.message}" }
             EnforcementEvidenceState.Corrupt
@@ -107,11 +126,47 @@ class EnforcementEvidenceStore @Inject constructor(
         }
     }
 
+    /**
+     * Version 1 → 2, decided by the verdict on the wire. The bump invalidated exactly one arm:
+     *
+     * - a version-1 `"CONFIRMED"` rested on a hardware signal now known to be session-scoped, so it is
+     *   worth nothing and reads as [EnforcementEvidenceState.Absent] — the same "no evidence" a fresh
+     *   install has, which is what the constant's removal was meant to produce (untranslated it would
+     *   fail to deserialize and read [EnforcementEvidenceState.Corrupt], locking the device out for
+     *   good);
+     * - a version-1 `"REFUTED"` never depended on that signal and is semantically unchanged, so it is
+     *   kept and **restamped to the current version** — a refutation is terminal, and leaving the old
+     *   stamp on it would let the very next observation re-record over it;
+     * - anything else is a record this build cannot reason about: fail closed with
+     *   [EnforcementEvidenceState.Corrupt], which the gate treats as a refutation.
+     */
+    private fun migrateSuperseded(wireVerdict: String?, raw: String): EnforcementEvidenceState = when (wireVerdict) {
+        WIRE_VERDICT_CONFIRMED -> {
+            log(TAG, Logging.Priority.INFO) { "Dropping a superseded version-1 confirmation" }
+            EnforcementEvidenceState.Absent
+        }
+        WIRE_VERDICT_REFUTED -> EnforcementEvidenceState.Present(
+            json.decodeFromString(EnforcementEvidence.serializer(), raw)
+                .copy(algorithmVersion = EnforcementVerdictEngine.ALGORITHM_VERSION),
+        )
+        else -> {
+            log(TAG, Logging.Priority.ERROR) { "Unreadable version-1 verdict: $wireVerdict" }
+            EnforcementEvidenceState.Corrupt
+        }
+    }
+
     private fun encode(evidence: EnforcementEvidence): String =
         json.encodeToString(EnforcementEvidence.serializer(), evidence)
 
     private companion object {
         const val KEY = "enforcement.evidence.v1"
+        const val FIELD_ALGORITHM_VERSION = "algorithmVersion"
+        const val FIELD_VERDICT = "verdict"
+        /** The heuristic that also weighed the hardware signal; superseded by version 2. */
+        const val SUPERSEDED_ALGORITHM_VERSION = 1
+        /** Wire literals, not enum names: `CONFIRMED` no longer exists as a Kotlin constant. */
+        const val WIRE_VERDICT_CONFIRMED = "CONFIRMED"
+        const val WIRE_VERDICT_REFUTED = "REFUTED"
         val TAG = logTag("Charging", "Enforcement", "Store")
     }
 }

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStore.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStore.kt
@@ -1,0 +1,134 @@
+package eu.darken.amply.charging.core.enforcement
+
+import androidx.datastore.preferences.core.stringPreferencesKey
+import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.datastore.createValue
+import eu.darken.amply.common.datastore.value
+import eu.darken.amply.common.debug.logging.Logging
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * What the store knows about this build's enforcement evidence. Explicit rather than a nullable
+ * record, because the three "no evidence" shapes must not collapse into one:
+ *
+ * - [Loading] — a caller that has not read the store yet. Resolves as a candidate (control off).
+ * - [Absent] — genuinely nothing stored for this build and algorithm version.
+ * - [Corrupt] — a record exists but cannot be decoded. Fail-closed, NOT treated as [Absent]: the
+ *   unreadable record could be a REFUTED one, and treating it as absent would reopen control on a
+ *   device already proven not to enforce.
+ */
+sealed interface EnforcementEvidenceState {
+    data object Loading : EnforcementEvidenceState
+    data object Absent : EnforcementEvidenceState
+    data class Present(val evidence: EnforcementEvidence) : EnforcementEvidenceState
+    data object Corrupt : EnforcementEvidenceState
+}
+
+/**
+ * Single-slot persistence for the enforcement verdict, over the shared [AppDataStore].
+ *
+ * The stored value is kept as the **raw JSON string** and decoded here rather than through a typed
+ * `fallbackToDefault` reader. Two reasons, both fail-closed: a corrupt record must surface as
+ * [EnforcementEvidenceState.Corrupt] instead of silently degrading to "no evidence" (which would
+ * hand control back to a device observed charging past its cap), and a corrupt payload must survive
+ * a write that declines to replace it, which a state-typed writer could not express — it would
+ * encode the undecodable state as "clear the key".
+ *
+ * Reads are **scoped**: a record from another ROM build or from an older
+ * [EnforcementVerdictEngine.ALGORITHM_VERSION] reads as [EnforcementEvidenceState.Absent], since
+ * charge-control HAL capability is build-scoped and an older heuristic's confirmation is not this
+ * one's.
+ */
+@Singleton
+class EnforcementEvidenceStore @Inject constructor(
+    dataStore: AppDataStore,
+    private val buildIdentity: BuildIdentitySource,
+    private val json: Json,
+) {
+    private val stored = dataStore.createValue(
+        key = stringPreferencesKey(KEY),
+        // `as?`, not `as`: a key name reused for a non-String type must not throw a
+        // ClassCastException, which no decode guard below would cover.
+        reader = { raw -> raw as? String },
+        writer = { value -> value },
+    )
+
+    /** The evidence that applies to *this* build, scoped and fail-closed. */
+    val state: Flow<EnforcementEvidenceState> = stored.flow.map { scope(decode(it)) }
+
+    suspend fun currentState(): EnforcementEvidenceState = scope(decode(stored.value()))
+
+    /**
+     * Persist [evidence], honouring the one asymmetry that matters: a REFUTED record for the same
+     * scope is terminal, so a later CONFIRMED must not overwrite it — a device that charged past its
+     * cap is not redeemed by a later plateau. A REFUTED verdict overwrites anything, including a
+     * corrupt record. A CONFIRMED verdict declines to overwrite a corrupt record: what it would
+     * replace is unknown, and unknown fails closed.
+     *
+     * @return true when the store now holds exactly [evidence].
+     */
+    suspend fun record(evidence: EnforcementEvidence): Boolean {
+        val encoded = encode(evidence)
+        val updated = stored.update { raw ->
+            val current = decode(raw)
+            when {
+                evidence.verdict == EnforcementVerdict.REFUTED -> encoded
+                current is EnforcementEvidenceState.Corrupt -> raw
+                current.terminalFor(evidence) -> raw
+                else -> encoded
+            }
+        }
+        val accepted = updated.new == encoded
+        log(TAG, Logging.Priority.INFO) {
+            "record(${evidence.verdict}, cap=${evidence.capPercent}%, at=${evidence.observedPercent}%): $accepted"
+        }
+        return accepted
+    }
+
+    private fun scope(state: EnforcementEvidenceState): EnforcementEvidenceState = when (state) {
+        is EnforcementEvidenceState.Present -> {
+            val evidence = state.evidence
+            val applies = evidence.buildIdentity == buildIdentity.current() &&
+                evidence.algorithmVersion == EnforcementVerdictEngine.ALGORITHM_VERSION
+            if (applies) state else EnforcementEvidenceState.Absent
+        }
+        else -> state
+    }
+
+    private fun decode(raw: String?): EnforcementEvidenceState {
+        if (raw == null) return EnforcementEvidenceState.Absent
+        return try {
+            EnforcementEvidenceState.Present(json.decodeFromString(EnforcementEvidence.serializer(), raw))
+        } catch (e: SerializationException) {
+            log(TAG, Logging.Priority.ERROR) { "Corrupt enforcement evidence: ${e.message}" }
+            EnforcementEvidenceState.Corrupt
+        } catch (e: IllegalArgumentException) {
+            log(TAG, Logging.Priority.ERROR) { "Unreadable enforcement evidence: ${e.message}" }
+            EnforcementEvidenceState.Corrupt
+        }
+    }
+
+    private fun encode(evidence: EnforcementEvidence): String =
+        json.encodeToString(EnforcementEvidence.serializer(), evidence)
+
+    private companion object {
+        const val KEY = "enforcement.evidence.v1"
+        val TAG = logTag("Charging", "Enforcement", "Store")
+    }
+}
+
+/** Whether the stored state blocks [candidate]: a refutation for the very same scope. */
+private fun EnforcementEvidenceState.terminalFor(candidate: EnforcementEvidence): Boolean {
+    val existing = (this as? EnforcementEvidenceState.Present)?.evidence ?: return false
+    return existing.verdict == EnforcementVerdict.REFUTED &&
+        existing.adapterId == candidate.adapterId &&
+        existing.buildIdentity == candidate.buildIdentity &&
+        existing.algorithmVersion == candidate.algorithmVersion
+}

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementModule.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementModule.kt
@@ -1,0 +1,40 @@
+package eu.darken.amply.charging.core.enforcement
+
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.amply.monitor.core.ChargeMonitorWatcher
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Qualifier
+
+/**
+ * Contributes [EnforcementWatcher] into the shared [Set] of [ChargeMonitorWatcher]s the charge-session
+ * service fans battery ticks out to — the entire integration point with the service, matching how the
+ * charge alarm and the statistics recorder bind themselves.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class EnforcementModule {
+    @Binds
+    @IntoSet
+    abstract fun bindEnforcementWatcher(impl: EnforcementWatcher): ChargeMonitorWatcher
+
+    companion object {
+        @Provides
+        @EnforcementDispatcher
+        fun enforcementDispatcher(): CoroutineDispatcher = Dispatchers.IO
+    }
+}
+
+/**
+ * The dispatcher [EnforcementRecorder] runs its serialized tick loop on. Injected rather than
+ * hardcoded purely so tests can substitute a deterministic scheduler; production is always
+ * [Dispatchers.IO]. Qualified so this doesn't become an unqualified app-wide `CoroutineDispatcher`.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class EnforcementDispatcher

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorder.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorder.kt
@@ -137,9 +137,6 @@ class EnforcementRecorder @Inject constructor(
             percent = tick.percent.takeIf { it >= 0 } ?: readout.levelPercent ?: -1,
             batteryStatus = tick.batteryStatus,
             chargingStatus = readout.chargingStatus,
-            // The adapter's own reading of the hardware hold signal — null where it has none, which
-            // makes CONFIRMED unreachable (the engine's asymmetry, not a defect here).
-            hardwareHold = adapter.hardwareHoldSignal(readout.chargingStatus, tick.plugged),
             currentNowMicroamps = readout.currentNowMicroamps,
             policyGeneration = preferences.lastRequestedAtNow(),
             plugSessionId = plugSessionId,

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorder.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorder.kt
@@ -147,7 +147,7 @@ class EnforcementRecorder @Inject constructor(
         progress = outcome.progress
         val verdict = outcome.verdict ?: return
         // The engine keeps reaching the same verdict while the condition holds; only a change is news.
-        if (existing?.verdict == verdict && existing.adapterId == adapter.id) return
+        if (existing != null && existing.verdict == verdict && existing.adapterId == adapter.id) return
         persist(verdict, adapter.id, outcome.progress?.epoch?.capPercent ?: 0, sample)
     }
 

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorder.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorder.kt
@@ -3,7 +3,6 @@ package eu.darken.amply.charging.core.enforcement
 import android.content.Context
 import android.content.Intent
 import dagger.hilt.android.qualifiers.ApplicationContext
-import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.battery.core.BatteryReader
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.ChargingPreferences
@@ -31,10 +30,9 @@ import javax.inject.Singleton
 data class RawEnforcementTick(
     val plugged: Boolean,
     val percent: Int,
-    val batteryStatus: Int,
     val sessionActive: Boolean,
+    /** Only read for the level fallback below; the verdict needs nothing else from the broadcast. */
     val batteryIntent: Intent?,
-    val observedElapsedRealtimeMillis: Long,
     val wallMillis: Long,
 )
 
@@ -125,7 +123,6 @@ class EnforcementRecorder @Inject constructor(
         if (!adapter.enforcementEvidenceRequired || !device.isSystemUser) return
         if (preferences.verificationStartedForNow() != buildIdentity.current()) return
 
-        val readout = tick.batteryIntent?.let { batteryReader.read(it) } ?: BatteryReadout.UNKNOWN
         val sample = EnforcementSample(
             adapterId = adapter.id,
             buildIdentity = buildIdentity.current(),
@@ -134,13 +131,13 @@ class EnforcementRecorder @Inject constructor(
             configured = repository.syncReadback(),
             sessionActive = tick.sessionActive,
             plugged = tick.plugged,
-            percent = tick.percent.takeIf { it >= 0 } ?: readout.levelPercent ?: -1,
-            batteryStatus = tick.batteryStatus,
-            chargingStatus = readout.chargingStatus,
-            currentNowMicroamps = readout.currentNowMicroamps,
+            // The level is the whole observation, so a tick without one falls back to the broadcast
+            // this tick was taken from rather than dropping the sample.
+            percent = tick.percent.takeIf { it >= 0 }
+                ?: tick.batteryIntent?.let { batteryReader.read(it).levelPercent }
+                ?: -1,
             policyGeneration = preferences.lastRequestedAtNow(),
             plugSessionId = plugSessionId,
-            elapsedRealtimeMillis = tick.observedElapsedRealtimeMillis,
             wallMillis = tick.wallMillis,
         )
         val outcome = EnforcementVerdictEngine.evaluate(progress, sample)

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorder.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorder.kt
@@ -1,0 +1,207 @@
+package eu.darken.amply.charging.core.enforcement
+
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.battery.core.BatteryReader
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.ChargingPreferences
+import eu.darken.amply.charging.core.ChargingRepository
+import eu.darken.amply.charging.core.DeviceInfo
+import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.common.debug.logging.Logging
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import eu.darken.amply.main.core.SurfaceUpdater
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * One battery evaluation as handed over by [EnforcementWatcher]: raw fields only, so the watcher can
+ * enqueue it without touching the disk, a Binder, or DataStore on the charge-session service's
+ * dispatch lock.
+ */
+data class RawEnforcementTick(
+    val plugged: Boolean,
+    val percent: Int,
+    val batteryStatus: Int,
+    val sessionActive: Boolean,
+    val batteryIntent: Intent?,
+    val observedElapsedRealtimeMillis: Long,
+    val wallMillis: Long,
+)
+
+/**
+ * Serialized, off-service-thread runner for [EnforcementVerdictEngine].
+ *
+ * Mirrors `ChargeStatsRecorder`: [offer] only enqueues, and every read the verdict needs — the
+ * configured-policy read-back, the durable evidence, the policy generation, the live battery
+ * properties — happens on this recorder's own IO coroutine. That is what keeps a slow read here from
+ * delaying the safety-critical charge-policy restore.
+ *
+ * A reached verdict is persisted once (the engine keeps re-reaching it while the condition holds),
+ * and a *stored* verdict immediately refreshes [ChargingRepository] and re-pushes the widget and
+ * tile: the tier it changes decides whether those surfaces may offer control at all.
+ */
+@Singleton
+class EnforcementRecorder @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val registry: AdapterRegistry,
+    private val evidenceStore: EnforcementEvidenceStore,
+    private val preferences: ChargingPreferences,
+    private val buildIdentity: BuildIdentitySource,
+    private val repository: ChargingRepository,
+    private val batteryReader: BatteryReader,
+    @EnforcementDispatcher dispatcher: CoroutineDispatcher,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+    private val ticks = Channel<RawEnforcementTick>(Channel.UNLIMITED)
+
+    // Mutated only by the single consumer coroutine below — no locking needed.
+    private var progress: EnforcementProgress? = null
+    private var previousPlugged: Boolean? = null
+    private var plugSessionId: Long = 0L
+
+    init {
+        scope.launch {
+            for (tick in ticks) {
+                try {
+                    onTick(tick)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, Logging.Priority.WARN) { "Enforcement tick failed: ${e.message}" }
+                }
+            }
+        }
+    }
+
+    /** Enqueue a raw tick. Returns immediately; the caller (a monitor watcher) never awaits I/O. */
+    fun offer(tick: RawEnforcementTick) {
+        ticks.trySend(tick)
+    }
+
+    /**
+     * Whether this observation needs the monitor service alive. Deliberately narrower than "the
+     * adapter wants evidence": holding the foreground service up at boot with no cap configured, on a
+     * secondary user, or after a terminal refutation would be a persistent notification bought for
+     * nothing.
+     *
+     * The configured-policy condition uses Amply's own last *persistent* write rather than a provider
+     * read: this runs under a query budget on the service-start path, and the authoritative read-back
+     * still gates every individual tick in [onTick].
+     */
+    suspend fun shouldObserve(): Boolean {
+        val evidence = evidenceStore.currentState()
+        val device = DeviceInfo.current(context)
+        return shouldObserveEnforcement(
+            evidence = evidence,
+            isSystemUser = device.isSystemUser,
+            adapterRequiresEvidence = registry.select(device, evidence).adapter?.enforcementEvidenceRequired == true,
+            verificationStarted = preferences.verificationStartedForNow() == buildIdentity.current(),
+            persistentPolicy = preferences.lastPersistentPolicyNow(),
+        )
+    }
+
+    private suspend fun onTick(tick: RawEnforcementTick) {
+        if (tick.plugged && previousPlugged == false) plugSessionId++
+        previousPlugged = tick.plugged
+
+        val evidence = evidenceStore.currentState()
+        val existing = (evidence as? EnforcementEvidenceState.Present)?.evidence
+        // A refutation is terminal and a corrupt record is treated as one: nothing left to observe.
+        if (evidence is EnforcementEvidenceState.Corrupt) return
+        if (existing?.verdict == EnforcementVerdict.REFUTED) return
+
+        val device = DeviceInfo.current(context)
+        val adapter = registry.select(device, evidence).adapter ?: return
+        if (!adapter.enforcementEvidenceRequired || !device.isSystemUser) return
+        if (preferences.verificationStartedForNow() != buildIdentity.current()) return
+
+        val readout = tick.batteryIntent?.let { batteryReader.read(it) } ?: BatteryReadout.UNKNOWN
+        val sample = EnforcementSample(
+            adapterId = adapter.id,
+            buildIdentity = buildIdentity.current(),
+            // The authoritative *configured* state. Null on adapters that cannot be read back
+            // synchronously, which the engine then declines to evaluate.
+            configured = repository.syncReadback(),
+            sessionActive = tick.sessionActive,
+            plugged = tick.plugged,
+            percent = tick.percent.takeIf { it >= 0 } ?: readout.levelPercent ?: -1,
+            batteryStatus = tick.batteryStatus,
+            chargingStatus = readout.chargingStatus,
+            currentNowMicroamps = readout.currentNowMicroamps,
+            policyGeneration = preferences.lastRequestedAtNow(),
+            plugSessionId = plugSessionId,
+            elapsedRealtimeMillis = tick.observedElapsedRealtimeMillis,
+            wallMillis = tick.wallMillis,
+        )
+        val outcome = EnforcementVerdictEngine.evaluate(progress, sample)
+        progress = outcome.progress
+        val verdict = outcome.verdict ?: return
+        // The engine keeps reaching the same verdict while the condition holds; only a change is news.
+        if (existing?.verdict == verdict && existing.adapterId == adapter.id) return
+        persist(verdict, adapter.id, outcome.progress?.epoch?.capPercent ?: 0, sample)
+    }
+
+    private suspend fun persist(
+        verdict: EnforcementVerdict,
+        adapterId: String,
+        capPercent: Int,
+        sample: EnforcementSample,
+    ) {
+        val evidence = EnforcementEvidence(
+            adapterId = adapterId,
+            buildIdentity = sample.buildIdentity,
+            algorithmVersion = EnforcementVerdictEngine.ALGORITHM_VERSION,
+            verdict = verdict,
+            capPercent = capPercent,
+            observedPercent = sample.percent,
+            observedAtWallMillis = sample.wallMillis,
+        )
+        if (!evidenceStore.record(evidence)) return
+        log(TAG, Logging.Priority.INFO) { "Enforcement $verdict at ${sample.percent}% (cap $capPercent%)" }
+        // The verdict decides whether control may be offered at all, so the surfaces must not keep
+        // rendering the previous tier until something else happens to refresh them.
+        repository.refresh()
+        try {
+            SurfaceUpdater.updateNow(context)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, Logging.Priority.WARN) { "Surface push failed: ${e.message}" }
+        }
+    }
+
+    private companion object {
+        val TAG = logTag("Charging", "Enforcement", "Recorder")
+    }
+}
+
+/**
+ * Whether enforcement observation currently needs the monitor service alive. Pure so the conditions
+ * are JVM-testable: this is what keeps a foreground service (and its persistent notification) from
+ * being held up at boot with no cap configured, on a secondary user, or after a terminal refutation.
+ *
+ * [persistentPolicy] is Amply's own last persistent write, the cheap durable stand-in for "a cap is
+ * configured" — the authoritative read-back still gates each individual tick.
+ */
+internal fun shouldObserveEnforcement(
+    evidence: EnforcementEvidenceState,
+    isSystemUser: Boolean,
+    adapterRequiresEvidence: Boolean,
+    verificationStarted: Boolean,
+    persistentPolicy: ChargePolicy?,
+): Boolean {
+    if (evidence is EnforcementEvidenceState.Corrupt) return false
+    if ((evidence as? EnforcementEvidenceState.Present)?.evidence?.verdict == EnforcementVerdict.REFUTED) return false
+    if (!adapterRequiresEvidence || !isSystemUser || !verificationStarted) return false
+    return persistentPolicy is ChargePolicy.FixedLimit && persistentPolicy.percent < 100
+}

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorder.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorder.kt
@@ -137,6 +137,9 @@ class EnforcementRecorder @Inject constructor(
             percent = tick.percent.takeIf { it >= 0 } ?: readout.levelPercent ?: -1,
             batteryStatus = tick.batteryStatus,
             chargingStatus = readout.chargingStatus,
+            // The adapter's own reading of the hardware hold signal — null where it has none, which
+            // makes CONFIRMED unreachable (the engine's asymmetry, not a defect here).
+            hardwareHold = adapter.hardwareHoldSignal(readout.chargingStatus, tick.plugged),
             currentNowMicroamps = readout.currentNowMicroamps,
             policyGeneration = preferences.lastRequestedAtNow(),
             plugSessionId = plugSessionId,

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
@@ -1,0 +1,186 @@
+package eu.darken.amply.charging.core.enforcement
+
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.stats.core.StatsLimitHitDetector
+
+/**
+ * The window a verdict is made inside. Any change to the adapter, the ROM build, the configured cap,
+ * the policy generation (Amply wrote something), or the plug session RESETS observation progress.
+ *
+ * That reset is not bookkeeping, it prevents a concrete false REFUTE: with a bare "seen below the
+ * cap" watermark, a user sitting at 78% under a 80% cap who switches to a 70% cap would instantly
+ * look like a device charging past its limit, and a perfectly good device would be refuted for good.
+ */
+data class EnforcementEpoch(
+    val adapterId: String,
+    val buildIdentity: String,
+    val capPercent: Int,
+    /** Changes whenever Amply writes a policy — see `ChargingPreferences.lastRequestedAt`. */
+    val policyGeneration: Long,
+    /** Monotonic counter of unplugged→plugged transitions; a new plug session starts a new window. */
+    val plugSessionId: Long,
+)
+
+/** One evaluation tick, everything the verdict depends on, and nothing Android-specific. */
+data class EnforcementSample(
+    val adapterId: String,
+    val buildIdentity: String,
+    /** The adapter's *configured* state readback; only [ChargeObservation.Verified] can be evaluated. */
+    val configured: ChargeObservation?,
+    /** A temporary full-charge session deliberately lifts the cap, so nothing is observable then. */
+    val sessionActive: Boolean,
+    val plugged: Boolean,
+    /** Battery level, or -1 when unknown. An unknown level moves no state at all. */
+    val percent: Int,
+    val batteryStatus: Int?,
+    val chargingStatus: Int?,
+    val currentNowMicroamps: Int?,
+    val policyGeneration: Long,
+    val plugSessionId: Long,
+    val elapsedRealtimeMillis: Long,
+    val wallMillis: Long,
+)
+
+/** Rolling observation state for one [EnforcementEpoch]; carried by the caller, never global. */
+data class EnforcementProgress(
+    val epoch: EnforcementEpoch,
+    /** True once the level was observed strictly increasing inside this epoch. */
+    val rose: Boolean,
+    /**
+     * The level a still-unbroken upward climb started from, or null. Only set from a sample at or
+     * below the cap: a device that was already above the cap when the epoch opened proves nothing by
+     * staying there. Cleared whenever the level drops (the climb is no longer monotonic).
+     */
+    val climbBase: Int?,
+    val holdSamples: Int,
+    val holdSinceElapsedMillis: Long,
+    val lastPercent: Int,
+)
+
+data class EnforcementOutcome(
+    val progress: EnforcementProgress?,
+    val verdict: EnforcementVerdict?,
+)
+
+/**
+ * Decides whether the charging hardware actually enforces a configured cap, from the public battery
+ * broadcast alone. Pure and JVM-testable: the caller threads [EnforcementProgress] through.
+ *
+ * The asymmetry between the two verdicts is deliberate.
+ *
+ * **CONFIRM** needs a *sustained plateau*, never one tick. [StatsLimitHitDetector.heldNow] answers
+ * "limit likely reached" and fires on any plugged, below-full, NOT_CHARGING sample — thermal
+ * suspension, a weak or renegotiating charger, and a kernel charge pause all qualify. So a
+ * confirmation additionally requires an observed rise inside the same epoch, the level parked in the
+ * band just below the cap, and the hold to persist across [MIN_HOLD_SAMPLES] samples spanning
+ * [MIN_HOLD_MILLIS]. Anything weaker leaves the device a candidate.
+ *
+ * **REFUTE** keys on a *trend*, not a status sample. Requiring `BATTERY_STATUS_CHARGING` would be a
+ * false-negative source: a ROM can carry the level past the cap while reporting UNKNOWN, NOT_CHARGING
+ * or FULL, which would leave an earlier CONFIRMED build trusted indefinitely. Battery status and
+ * charge current corroborate a hold but never gate the refutation.
+ */
+object EnforcementVerdictEngine {
+
+    /**
+     * Bumped whenever this heuristic is tightened. Stored on every [EnforcementEvidence], so a
+     * confirmation produced by a weaker version stops counting instead of being trusted forever.
+     */
+    const val ALGORITHM_VERSION = 1
+
+    /**
+     * How far BELOW the cap a hold still counts. Upstream's `Limit.java` sets the HAL floor to
+     * `targetPct - margin` and `Toggle` resumes only after falling that far, so a device that really
+     * enforces legitimately rests a few points under the number Amply wrote. Covers that margin plus
+     * level-reporting rounding.
+     */
+    const val HOLD_BAND = 5
+
+    /**
+     * How far ABOVE the cap the level must climb before enforcement is refuted. Small and INDEPENDENT
+     * of [HOLD_BAND]: upstream's margin is hysteresis *below* the target and justifies no allowance
+     * above it, and every extra point here only delays detecting a device that never limits. Three
+     * points absorb a one-off level-reporting overshoot without hiding a real climb. Keeping this ≥ 1
+     * is also what makes the confirm band and the refute band disjoint.
+     */
+    const val OVERSHOOT_ALLOWANCE = 3
+
+    /** The charge monitor evaluates roughly every 30s, so this is a plateau, not a single reading. */
+    const val MIN_HOLD_SAMPLES = 3
+
+    /**
+     * A thermal pause or a charger renegotiation resolves well inside this; five minutes of a plugged,
+     * non-advancing battery parked in the cap band is the cap holding. Measured on
+     * `elapsedRealtime`, so a wall-clock change cannot shorten it.
+     */
+    const val MIN_HOLD_MILLIS = 5 * 60 * 1000L
+
+    fun evaluate(previous: EnforcementProgress?, sample: EnforcementSample): EnforcementOutcome {
+        val epoch = epochOf(sample) ?: return EnforcementOutcome(null, null)
+        val prior = previous?.takeIf { it.epoch == epoch }
+        // An unknown level is not evidence of anything: it must not open, advance, or break a climb.
+        if (sample.percent !in 0..100) return EnforcementOutcome(prior, null)
+
+        val cap = epoch.capPercent
+        val last = prior?.lastPercent
+        val rose = prior?.rose == true || (last != null && sample.percent > last)
+        val climbBase = when {
+            // A drop breaks the monotonic climb; the new level re-opens one only from inside the cap.
+            last != null && sample.percent < last -> sample.percent.takeIf { it <= cap }
+            prior?.climbBase != null -> prior.climbBase
+            else -> sample.percent.takeIf { it <= cap }
+        }
+        val held = sample.percent in (cap - HOLD_BAND)..cap &&
+            (last == null || sample.percent <= last) &&
+            StatsLimitHitDetector.heldNow(
+                plugged = sample.plugged,
+                chargingStatus = sample.chargingStatus,
+                batteryStatus = sample.batteryStatus,
+                percent = sample.percent,
+                currentNowMicroamps = sample.currentNowMicroamps,
+            )
+        val holdSamples = if (held) (prior?.holdSamples ?: 0) + 1 else 0
+        val holdSince = when {
+            !held -> 0L
+            prior != null && prior.holdSamples > 0 -> prior.holdSinceElapsedMillis
+            else -> sample.elapsedRealtimeMillis
+        }
+        val progress = EnforcementProgress(
+            epoch = epoch,
+            rose = rose,
+            climbBase = climbBase,
+            holdSamples = holdSamples,
+            holdSinceElapsedMillis = holdSince,
+            lastPercent = sample.percent,
+        )
+        val verdict = when {
+            climbBase != null && sample.percent >= cap + OVERSHOOT_ALLOWANCE -> EnforcementVerdict.REFUTED
+            rose && holdSamples >= MIN_HOLD_SAMPLES &&
+                sample.elapsedRealtimeMillis - holdSince >= MIN_HOLD_MILLIS -> EnforcementVerdict.CONFIRMED
+            else -> null
+        }
+        return EnforcementOutcome(progress, verdict)
+    }
+
+    /**
+     * The window this sample belongs to, or null when nothing is observable: unplugged (no charge to
+     * limit), a running full-charge session (the cap is deliberately lifted), a configured state that
+     * is not a *verified* [ChargePolicy.FixedLimit] (Adaptive has no observable cap, and a merely
+     * last-requested policy is not known to be configured at all), or a 100% "cap", which limits
+     * nothing.
+     */
+    private fun epochOf(sample: EnforcementSample): EnforcementEpoch? {
+        if (!sample.plugged || sample.sessionActive) return null
+        val verified = sample.configured as? ChargeObservation.Verified ?: return null
+        val cap = (verified.policy as? ChargePolicy.FixedLimit)?.percent ?: return null
+        if (cap >= 100) return null
+        return EnforcementEpoch(
+            adapterId = sample.adapterId,
+            buildIdentity = sample.buildIdentity,
+            capPercent = cap,
+            policyGeneration = sample.policyGeneration,
+            plugSessionId = sample.plugSessionId,
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
@@ -35,6 +35,13 @@ data class EnforcementSample(
     val percent: Int,
     val batteryStatus: Int?,
     val chargingStatus: Int?,
+    /**
+     * The selected adapter's hardware hold signal for this tick — see
+     * [eu.darken.amply.charging.core.adapter.ChargingAdapter.hardwareHoldSignal]. True is the ONLY
+     * value a CONFIRMED verdict is reachable from; false and null both leave the device under test.
+     * REFUTED never consults it.
+     */
+    val hardwareHold: Boolean?,
     val currentNowMicroamps: Int?,
     val policyGeneration: Long,
     val plugSessionId: Long,
@@ -45,14 +52,24 @@ data class EnforcementSample(
 /** Rolling observation state for one [EnforcementEpoch]; carried by the caller, never global. */
 data class EnforcementProgress(
     val epoch: EnforcementEpoch,
-    /** True once the level was observed strictly increasing inside this epoch. */
-    val rose: Boolean,
     /**
-     * The level a still-unbroken upward climb started from, or null. Only set from a sample at or
-     * below the cap: a device that was already above the cap when the epoch opened proves nothing by
-     * staying there. Cleared whenever the level drops (the climb is no longer monotonic).
+     * The level the still-unbroken climb started from, or null before the epoch's first valid sample.
+     * Only set from a sample at or below the cap: a device that was already above the cap when the
+     * epoch opened proves nothing by staying there. Reset to the new level whenever the level drops
+     * (the climb is no longer monotonic).
      */
     val climbBase: Int?,
+    /**
+     * True once the level was observed increasing since [climbBase], i.e. within the CURRENT climb.
+     * Phase-local on purpose: a global "rose at some point in this epoch" flag would let a rise from
+     * hours ago keep vouching for a plateau that the battery has since been *losing* charge into.
+     */
+    val climbRose: Boolean,
+    /**
+     * The level the running hold is pinned to, or null when no hold is running. A hold sustains only
+     * while the level stays EXACTLY here; any change (up or down) starts a new hold instead.
+     */
+    val holdPercent: Int?,
     val holdSamples: Int,
     val holdSinceElapsedMillis: Long,
     val lastPercent: Int,
@@ -69,17 +86,25 @@ data class EnforcementOutcome(
  *
  * The asymmetry between the two verdicts is deliberate.
  *
- * **CONFIRM** needs a *sustained plateau*, never one tick. [StatsLimitHitDetector.heldNow] answers
- * "limit likely reached" and fires on any plugged, below-full, NOT_CHARGING sample — thermal
- * suspension, a weak or renegotiating charger, and a kernel charge pause all qualify. So a
- * confirmation additionally requires an observed rise inside the same epoch, the level parked in the
- * band just below the cap, and the hold to persist across [MIN_HOLD_SAMPLES] samples spanning
- * [MIN_HOLD_MILLIS]. Anything weaker leaves the device a candidate.
+ * **CONFIRM is hardware-corroborated only.** A passive plateau cannot distinguish a cap hold from a
+ * thermal pause, a charger renegotiation or a weak supply: all of them park a plugged battery below
+ * full while [StatsLimitHitDetector.heldNow] reads true, and five minutes of it is well within what
+ * a hot phone on a weak charger produces. So a confirmation requires the adapter's
+ * [eu.darken.amply.charging.core.adapter.ChargingAdapter.hardwareHoldSignal] to report a hold
+ * ([EnforcementSample.hardwareHold] == true) *and* the behavioural evidence: a rise inside the
+ * current climb, [StatsLimitHitDetector.heldNow], the level parked in the band just below the cap,
+ * and that exact level sustained across [MIN_HOLD_SAMPLES] samples spanning [MIN_HOLD_MILLIS]. On an
+ * adapter with no hardware signal (`hardwareHold == null`) CONFIRMED is unreachable and the device
+ * simply stays under test forever — a stalled verification is a far cheaper error than claiming
+ * protection that isn't there. The known alternative for such adapters is a *behavioural* challenge
+ * (write a lower cap, watch charging cut, raise it, watch it resume, cut again), which no passive
+ * observer can fake; it is deliberately NOT implemented here.
  *
- * **REFUTE** keys on a *trend*, not a status sample. Requiring `BATTERY_STATUS_CHARGING` would be a
- * false-negative source: a ROM can carry the level past the cap while reporting UNKNOWN, NOT_CHARGING
- * or FULL, which would leave an earlier CONFIRMED build trusted indefinitely. Battery status and
- * charge current corroborate a hold but never gate the refutation.
+ * **REFUTE deliberately needs no hardware corroboration at all.** It keys on a *trend*: the level
+ * climbing past the cap is self-evident, whatever the hardware reports. Requiring
+ * `BATTERY_STATUS_CHARGING` or a hardware signal would be a false-negative source — a ROM can carry
+ * the level past the cap while reporting UNKNOWN, NOT_CHARGING or FULL, and a build with no hold
+ * signal must still be refutable, or an unenforced cap would go on looking harmless.
  */
 object EnforcementVerdictEngine {
 
@@ -94,6 +119,9 @@ object EnforcementVerdictEngine {
      * `targetPct - margin` and `Toggle` resumes only after falling that far, so a device that really
      * enforces legitimately rests a few points under the number Amply wrote. Covers that margin plus
      * level-reporting rounding.
+     *
+     * Only reachable on the hardware path: like [MIN_HOLD_SAMPLES] and [MIN_HOLD_MILLIS] it shapes a
+     * confirmation, and no confirmation happens without [EnforcementSample.hardwareHold] == true.
      */
     const val HOLD_BAND = 5
 
@@ -106,13 +134,18 @@ object EnforcementVerdictEngine {
      */
     const val OVERSHOOT_ALLOWANCE = 3
 
-    /** The charge monitor evaluates roughly every 30s, so this is a plateau, not a single reading. */
+    /**
+     * The charge monitor evaluates roughly every 30s, so this is a plateau, not a single reading.
+     * Reachable only on the hardware path (see [HOLD_BAND]).
+     */
     const val MIN_HOLD_SAMPLES = 3
 
     /**
-     * A thermal pause or a charger renegotiation resolves well inside this; five minutes of a plugged,
-     * non-advancing battery parked in the cap band is the cap holding. Measured on
-     * `elapsedRealtime`, so a wall-clock change cannot shorten it.
+     * How long the hardware-corroborated hold must persist. Measured on `elapsedRealtime`, so a
+     * wall-clock change cannot shorten it. This duration is NOT what separates a cap hold from a
+     * thermal pause — nothing about a plateau's length can, which is why the hardware signal gates
+     * the verdict; it only rejects a momentary coincidence. Reachable only on the hardware path
+     * (see [HOLD_BAND]).
      */
     const val MIN_HOLD_MILLIS = 5 * 60 * 1000L
 
@@ -124,15 +157,24 @@ object EnforcementVerdictEngine {
 
         val cap = epoch.capPercent
         val last = prior?.lastPercent
-        val rose = prior?.rose == true || (last != null && sample.percent > last)
+        // Phase-local climb tracking: a drop resets the base AND clears the rise, so the rise that
+        // vouches for a hold is always the one that led into it. Equal samples continue the climb
+        // (they are what a hold looks like) without ever establishing a rise on their own.
+        val dropped = last != null && sample.percent < last
         val climbBase = when {
-            // A drop breaks the monotonic climb; the new level re-opens one only from inside the cap.
-            last != null && sample.percent < last -> sample.percent.takeIf { it <= cap }
-            prior?.climbBase != null -> prior.climbBase
-            else -> sample.percent.takeIf { it <= cap }
+            last == null || dropped -> sample.percent.takeIf { it <= cap }
+            else -> prior?.climbBase
         }
-        val held = sample.percent in (cap - HOLD_BAND)..cap &&
-            (last == null || sample.percent <= last) &&
+        val climbRose = when {
+            last == null || dropped -> false
+            sample.percent > last -> true
+            else -> prior?.climbRose == true
+        }
+        // A hold pins to ONE level: "not increasing" would count a battery losing charge on a weak
+        // charger as held. Any change restarts the hold; the hardware signal gates it entirely.
+        val holding = sample.hardwareHold == true &&
+            climbRose &&
+            sample.percent in (cap - HOLD_BAND)..cap &&
             StatsLimitHitDetector.heldNow(
                 plugged = sample.plugged,
                 chargingStatus = sample.chargingStatus,
@@ -140,23 +182,30 @@ object EnforcementVerdictEngine {
                 percent = sample.percent,
                 currentNowMicroamps = sample.currentNowMicroamps,
             )
-        val holdSamples = if (held) (prior?.holdSamples ?: 0) + 1 else 0
+        val sustains = holding && prior?.holdPercent == sample.percent
+        val holdSamples = when {
+            !holding -> 0
+            sustains -> (prior?.holdSamples ?: 0) + 1
+            else -> 1
+        }
         val holdSince = when {
-            !held -> 0L
-            prior != null && prior.holdSamples > 0 -> prior.holdSinceElapsedMillis
+            !holding -> 0L
+            sustains -> prior?.holdSinceElapsedMillis ?: sample.elapsedRealtimeMillis
             else -> sample.elapsedRealtimeMillis
         }
         val progress = EnforcementProgress(
             epoch = epoch,
-            rose = rose,
             climbBase = climbBase,
+            climbRose = climbRose,
+            holdPercent = sample.percent.takeIf { holding },
             holdSamples = holdSamples,
             holdSinceElapsedMillis = holdSince,
             lastPercent = sample.percent,
         )
         val verdict = when {
             climbBase != null && sample.percent >= cap + OVERSHOOT_ALLOWANCE -> EnforcementVerdict.REFUTED
-            rose && holdSamples >= MIN_HOLD_SAMPLES &&
+            // hardwareHold, the rise and the band are already folded into `holding`.
+            holdSamples >= MIN_HOLD_SAMPLES &&
                 sample.elapsedRealtimeMillis - holdSince >= MIN_HOLD_MILLIS -> EnforcementVerdict.CONFIRMED
             else -> null
         }

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
@@ -103,8 +103,12 @@ object EnforcementVerdictEngine {
     /**
      * Bumped whenever this heuristic materially changes. Stored on every [EnforcementEvidence], so a
      * verdict produced by a different version stops counting instead of being trusted forever.
+     *
+     * Version 2 dropped the confirmation arm entirely (see above); a version-1 record was produced by
+     * a heuristic that also weighed a hardware signal now known to be session-scoped, so it reads as
+     * no evidence at all.
      */
-    const val ALGORITHM_VERSION = 1
+    const val ALGORITHM_VERSION = 2
 
     /**
      * How far ABOVE the cap the level must climb before enforcement is refuted. Upstream's

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
@@ -21,7 +21,14 @@ data class EnforcementEpoch(
     val plugSessionId: Long,
 )
 
-/** One evaluation tick, everything the verdict depends on, and nothing Android-specific. */
+/**
+ * One evaluation tick, everything the verdict depends on, and nothing Android-specific.
+ *
+ * It carries **no battery-status or charge-current field on purpose**. The refutation keys on the
+ * level trend alone (see below), so a status field could only ever suppress a real refutation, and
+ * the hardware charging state is session-scoped and decides nothing. [wallMillis] is not read by the
+ * engine either; it is what the reached verdict is stamped with when it is persisted.
+ */
 data class EnforcementSample(
     val adapterId: String,
     val buildIdentity: String,
@@ -32,12 +39,8 @@ data class EnforcementSample(
     val plugged: Boolean,
     /** Battery level, or -1 when unknown. An unknown level moves no state at all. */
     val percent: Int,
-    val batteryStatus: Int?,
-    val chargingStatus: Int?,
-    val currentNowMicroamps: Int?,
     val policyGeneration: Long,
     val plugSessionId: Long,
-    val elapsedRealtimeMillis: Long,
     val wallMillis: Long,
 )
 
@@ -45,17 +48,14 @@ data class EnforcementSample(
 data class EnforcementProgress(
     val epoch: EnforcementEpoch,
     /**
-     * The level the still-unbroken climb started from, or null before the epoch's first valid sample.
-     * Set from ANY level, above the cap included: an epoch legitimately opens above the cap (a
-     * full-charge session restored early at 84%, a process death at 82%), and refusing to track a
-     * climb there is what let such a device charge on to 100% without ever being refuted. Reset to
-     * the new level whenever the level drops (the climb is no longer monotonic).
-     */
-    val climbBase: Int?,
-    /**
-     * True once the level was observed increasing since [climbBase], i.e. within the CURRENT climb.
-     * Phase-local on purpose: a global "rose at some point in this epoch" flag would let a rise from
-     * hours ago justify refuting a level the battery has merely been sitting at since.
+     * True once the level was observed increasing within the CURRENT climb, i.e. since the epoch's
+     * first valid sample or the last drop. Phase-local on purpose: a global "rose at some point in
+     * this epoch" flag would let a rise from hours ago justify refuting a level the battery has
+     * merely been sitting at since.
+     *
+     * The climb is tracked from ANY level, above the cap included: an epoch legitimately opens above
+     * the cap (a full-charge session restored early at 84%, a process death at 82%), and refusing to
+     * track a climb there is what let such a device charge on to 100% without ever being refuted.
      *
      * It is what keeps an above-cap epoch from refuting on its own: a device sitting still at 95%
      * under a 70% cap is a device that stopped charging, and only an observed climb from there says
@@ -126,11 +126,10 @@ object EnforcementVerdictEngine {
         if (sample.percent !in 0..100) return EnforcementOutcome(prior, null)
 
         val cap = epoch.capPercent
-        // Phase-local climb tracking: a drop resets the base AND clears the rise, so the rise a
-        // refutation rests on is always the one that led into the current level. Equal samples
-        // continue the climb without ever establishing a rise on their own.
+        // Phase-local climb tracking: a drop clears the rise, so the rise a refutation rests on is
+        // always the one that led into the current level. Equal samples continue the climb without
+        // ever establishing a rise on their own.
         val dropped = prior != null && sample.percent < prior.lastPercent
-        val climbBase = if (prior == null || dropped) sample.percent else prior.climbBase
         val climbRose = when {
             prior == null || dropped -> false
             sample.percent > prior.lastPercent -> true
@@ -138,7 +137,6 @@ object EnforcementVerdictEngine {
         }
         val progress = EnforcementProgress(
             epoch = epoch,
-            climbBase = climbBase,
             climbRose = climbRose,
             lastPercent = sample.percent,
         )

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
@@ -2,7 +2,6 @@ package eu.darken.amply.charging.core.enforcement
 
 import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
-import eu.darken.amply.stats.core.StatsLimitHitDetector
 
 /**
  * The window a verdict is made inside. Any change to the adapter, the ROM build, the configured cap,
@@ -35,13 +34,6 @@ data class EnforcementSample(
     val percent: Int,
     val batteryStatus: Int?,
     val chargingStatus: Int?,
-    /**
-     * The selected adapter's hardware hold signal for this tick — see
-     * [eu.darken.amply.charging.core.adapter.ChargingAdapter.hardwareHoldSignal]. True is the ONLY
-     * value a CONFIRMED verdict is reachable from; false and null both leave the device under test.
-     * REFUTED never consults it.
-     */
-    val hardwareHold: Boolean?,
     val currentNowMicroamps: Int?,
     val policyGeneration: Long,
     val plugSessionId: Long,
@@ -63,20 +55,13 @@ data class EnforcementProgress(
     /**
      * True once the level was observed increasing since [climbBase], i.e. within the CURRENT climb.
      * Phase-local on purpose: a global "rose at some point in this epoch" flag would let a rise from
-     * hours ago keep vouching for a plateau that the battery has since been *losing* charge into.
+     * hours ago justify refuting a level the battery has merely been sitting at since.
      *
-     * It is also what keeps an above-cap epoch from refuting on its own: a device sitting still at
-     * 95% under a 70% cap is a device that stopped charging, and only an observed climb from there
-     * says the cap is being ignored.
+     * It is what keeps an above-cap epoch from refuting on its own: a device sitting still at 95%
+     * under a 70% cap is a device that stopped charging, and only an observed climb from there says
+     * the cap is being ignored.
      */
     val climbRose: Boolean,
-    /**
-     * The level the running hold is pinned to, or null when no hold is running. A hold sustains only
-     * while the level stays EXACTLY here; any change (up or down) starts a new hold instead.
-     */
-    val holdPercent: Int?,
-    val holdSamples: Int,
-    val holdSinceElapsedMillis: Long,
     val lastPercent: Int,
 )
 
@@ -86,76 +71,48 @@ data class EnforcementOutcome(
 )
 
 /**
- * Decides whether the charging hardware actually enforces a configured cap, from the public battery
- * broadcast alone. Pure and JVM-testable: the caller threads [EnforcementProgress] through.
+ * Decides whether the charging hardware **fails** to enforce a configured cap, from the public
+ * battery broadcast alone. Pure and JVM-testable: the caller threads [EnforcementProgress] through.
  *
- * The asymmetry between the two verdicts is deliberate.
+ * **There is only one verdict, [EnforcementVerdict.REFUTED]. Nothing observable can confirm a cap.**
+ * That is a measured conclusion, not caution: `BatteryManager.EXTRA_CHARGING_STATUS` == 4 looked like
+ * a hardware hold signal — a Pixel 6 (`oriole`, LineageOS 23.2) holding at a 70% cap reports it — but
+ * it is *session-scoped*. On the same device, raising the cap to 80 left the extra reading 4 while
+ * the battery was actively charging at level 70, ten points below the cap. It means "limit mode is
+ * enabled for this plug session", not "charging is stopped right now", which is exactly what
+ * `StatsLimitHitDetector`'s KDoc documents for Pixel. Nothing else in the broadcast discriminates
+ * either: between a cap hold and a thermal or weak-supply pause the only field that differs is
+ * `BatteryManager.EXTRA_STATUS`, which a thermal pause produces too. So a passive observer cannot
+ * tell "the cap is working" from "charging happens to be paused", and Amply never claims a cap is
+ * verified from observation.
  *
- * **CONFIRM is hardware-corroborated only.** A passive plateau cannot distinguish a cap hold from a
- * thermal pause, a charger renegotiation or a weak supply: all of them park a plugged battery below
- * full while [StatsLimitHitDetector.heldNow] reads true, and five minutes of it is well within what
- * a hot phone on a weak charger produces. So a confirmation requires the adapter's
- * [eu.darken.amply.charging.core.adapter.ChargingAdapter.hardwareHoldSignal] to report a hold
- * ([EnforcementSample.hardwareHold] == true) *and* the behavioural evidence: a rise inside the
- * current climb, [StatsLimitHitDetector.heldNow], the level parked in the band just below the cap,
- * and that exact level sustained across [MIN_HOLD_SAMPLES] samples spanning [MIN_HOLD_MILLIS]. On an
- * adapter with no hardware signal (`hardwareHold == null`) CONFIRMED is unreachable and the device
- * simply stays under test forever — a stalled verification is a far cheaper error than claiming
- * protection that isn't there. The known alternative for such adapters is a *behavioural* challenge
- * (write a lower cap, watch charging cut, raise it, watch it resume, cut again), which no passive
- * observer can fake; it is deliberately NOT implemented here.
+ * The known way to earn a real confirmation is a **guided two-cap challenge**: write a cap below the
+ * current level and watch charging cut, raise it and watch charging resume, cut again — a sequence
+ * no thermal pause can imitate. It needs the user to keep the device plugged through a scripted
+ * write sequence, and it is deliberately NOT implemented here.
  *
- * **REFUTE deliberately needs no hardware corroboration at all.** It keys on a *trend*: the level
- * climbing past the cap is self-evident, whatever the hardware reports. Requiring
- * `BATTERY_STATUS_CHARGING` or a hardware signal would be a false-negative source — a ROM can carry
- * the level past the cap while reporting UNKNOWN, NOT_CHARGING or FULL, and a build with no hold
- * signal must still be refutable, or an unenforced cap would go on looking harmless. The climb is
- * tracked from ANY level, above the cap included: epochs routinely open above it (a full-charge
- * session restored early at 84%, a process death at 82%), and those are exactly the runs where an
- * unenforced cap keeps climbing to 100%.
+ * **REFUTE needs no hardware corroboration at all.** It keys on a *trend*: the level climbing past
+ * the cap is self-evident, whatever the hardware reports. Requiring `BATTERY_STATUS_CHARGING` or a
+ * hardware signal would be a false-negative source — a ROM can carry the level past the cap while
+ * reporting UNKNOWN, NOT_CHARGING or FULL. The climb is tracked from ANY level, above the cap
+ * included: epochs routinely open above it (a full-charge session restored early at 84%, a process
+ * death at 82%), and those are exactly the runs where an unenforced cap keeps climbing to 100%.
  */
 object EnforcementVerdictEngine {
 
     /**
-     * Bumped whenever this heuristic is tightened. Stored on every [EnforcementEvidence], so a
-     * confirmation produced by a weaker version stops counting instead of being trusted forever.
+     * Bumped whenever this heuristic materially changes. Stored on every [EnforcementEvidence], so a
+     * verdict produced by a different version stops counting instead of being trusted forever.
      */
     const val ALGORITHM_VERSION = 1
 
     /**
-     * How far BELOW the cap a hold still counts. Upstream's `Limit.java` sets the HAL floor to
-     * `targetPct - margin` and `Toggle` resumes only after falling that far, so a device that really
-     * enforces legitimately rests a few points under the number Amply wrote. Covers that margin plus
-     * level-reporting rounding.
-     *
-     * Only reachable on the hardware path: like [MIN_HOLD_SAMPLES] and [MIN_HOLD_MILLIS] it shapes a
-     * confirmation, and no confirmation happens without [EnforcementSample.hardwareHold] == true.
-     */
-    const val HOLD_BAND = 5
-
-    /**
-     * How far ABOVE the cap the level must climb before enforcement is refuted. Small and INDEPENDENT
-     * of [HOLD_BAND]: upstream's margin is hysteresis *below* the target and justifies no allowance
-     * above it, and every extra point here only delays detecting a device that never limits. Three
-     * points absorb a one-off level-reporting overshoot without hiding a real climb. Keeping this ≥ 1
-     * is also what makes the confirm band and the refute band disjoint.
+     * How far ABOVE the cap the level must climb before enforcement is refuted. Upstream's
+     * `Limit.java` margin is hysteresis *below* the target and justifies no allowance above it, and
+     * every extra point here only delays detecting a device that never limits. Three points absorb a
+     * one-off level-reporting overshoot without hiding a real climb.
      */
     const val OVERSHOOT_ALLOWANCE = 3
-
-    /**
-     * The charge monitor evaluates roughly every 30s, so this is a plateau, not a single reading.
-     * Reachable only on the hardware path (see [HOLD_BAND]).
-     */
-    const val MIN_HOLD_SAMPLES = 3
-
-    /**
-     * How long the hardware-corroborated hold must persist. Measured on `elapsedRealtime`, so a
-     * wall-clock change cannot shorten it. This duration is NOT what separates a cap hold from a
-     * thermal pause — nothing about a plateau's length can, which is why the hardware signal gates
-     * the verdict; it only rejects a momentary coincidence. Reachable only on the hardware path
-     * (see [HOLD_BAND]).
-     */
-    const val MIN_HOLD_MILLIS = 5 * 60 * 1000L
 
     fun evaluate(previous: EnforcementProgress?, sample: EnforcementSample): EnforcementOutcome {
         val epoch = epochOf(sample) ?: return EnforcementOutcome(null, null)
@@ -164,62 +121,27 @@ object EnforcementVerdictEngine {
         if (sample.percent !in 0..100) return EnforcementOutcome(prior, null)
 
         val cap = epoch.capPercent
-        val last = prior?.lastPercent
-        // Phase-local climb tracking: a drop resets the base AND clears the rise, so the rise that
-        // vouches for a hold is always the one that led into it. Equal samples continue the climb
-        // (they are what a hold looks like) without ever establishing a rise on their own.
-        val dropped = last != null && sample.percent < last
-        val climbBase = when {
-            last == null || dropped -> sample.percent
-            else -> prior?.climbBase
-        }
+        // Phase-local climb tracking: a drop resets the base AND clears the rise, so the rise a
+        // refutation rests on is always the one that led into the current level. Equal samples
+        // continue the climb without ever establishing a rise on their own.
+        val dropped = prior != null && sample.percent < prior.lastPercent
+        val climbBase = if (prior == null || dropped) sample.percent else prior.climbBase
         val climbRose = when {
-            last == null || dropped -> false
-            sample.percent > last -> true
-            else -> prior?.climbRose == true
-        }
-        // A hold pins to ONE level: "not increasing" would count a battery losing charge on a weak
-        // charger as held. Any change restarts the hold; the hardware signal gates it entirely.
-        val holding = sample.hardwareHold == true &&
-            climbRose &&
-            sample.percent in (cap - HOLD_BAND)..cap &&
-            StatsLimitHitDetector.heldNow(
-                plugged = sample.plugged,
-                chargingStatus = sample.chargingStatus,
-                batteryStatus = sample.batteryStatus,
-                percent = sample.percent,
-                currentNowMicroamps = sample.currentNowMicroamps,
-            )
-        val sustains = holding && prior?.holdPercent == sample.percent
-        val holdSamples = when {
-            !holding -> 0
-            sustains -> (prior?.holdSamples ?: 0) + 1
-            else -> 1
-        }
-        val holdSince = when {
-            !holding -> 0L
-            sustains -> prior?.holdSinceElapsedMillis ?: sample.elapsedRealtimeMillis
-            else -> sample.elapsedRealtimeMillis
+            prior == null || dropped -> false
+            sample.percent > prior.lastPercent -> true
+            else -> prior.climbRose
         }
         val progress = EnforcementProgress(
             epoch = epoch,
             climbBase = climbBase,
             climbRose = climbRose,
-            holdPercent = sample.percent.takeIf { holding },
-            holdSamples = holdSamples,
-            holdSinceElapsedMillis = holdSince,
             lastPercent = sample.percent,
         )
-        val verdict = when {
-            // The refutation keys on the CLIMB, not on the level alone: a lone or flat above-cap
-            // sample proves nothing (the epoch may simply have opened there), while an observed rise
-            // to beyond the cap does — wherever inside or above the cap that rise started.
-            climbRose && sample.percent >= cap + OVERSHOOT_ALLOWANCE -> EnforcementVerdict.REFUTED
-            // hardwareHold, the rise and the band are already folded into `holding`.
-            holdSamples >= MIN_HOLD_SAMPLES &&
-                sample.elapsedRealtimeMillis - holdSince >= MIN_HOLD_MILLIS -> EnforcementVerdict.CONFIRMED
-            else -> null
-        }
+        // The refutation keys on the CLIMB, not on the level alone: a lone or flat above-cap sample
+        // proves nothing (the epoch may simply have opened there), while an observed rise to beyond
+        // the cap does — wherever inside or above the cap that rise started.
+        val verdict = EnforcementVerdict.REFUTED
+            .takeIf { climbRose && sample.percent >= cap + OVERSHOOT_ALLOWANCE }
         return EnforcementOutcome(progress, verdict)
     }
 

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
@@ -54,15 +54,20 @@ data class EnforcementProgress(
     val epoch: EnforcementEpoch,
     /**
      * The level the still-unbroken climb started from, or null before the epoch's first valid sample.
-     * Only set from a sample at or below the cap: a device that was already above the cap when the
-     * epoch opened proves nothing by staying there. Reset to the new level whenever the level drops
-     * (the climb is no longer monotonic).
+     * Set from ANY level, above the cap included: an epoch legitimately opens above the cap (a
+     * full-charge session restored early at 84%, a process death at 82%), and refusing to track a
+     * climb there is what let such a device charge on to 100% without ever being refuted. Reset to
+     * the new level whenever the level drops (the climb is no longer monotonic).
      */
     val climbBase: Int?,
     /**
      * True once the level was observed increasing since [climbBase], i.e. within the CURRENT climb.
      * Phase-local on purpose: a global "rose at some point in this epoch" flag would let a rise from
      * hours ago keep vouching for a plateau that the battery has since been *losing* charge into.
+     *
+     * It is also what keeps an above-cap epoch from refuting on its own: a device sitting still at
+     * 95% under a 70% cap is a device that stopped charging, and only an observed climb from there
+     * says the cap is being ignored.
      */
     val climbRose: Boolean,
     /**
@@ -104,7 +109,10 @@ data class EnforcementOutcome(
  * climbing past the cap is self-evident, whatever the hardware reports. Requiring
  * `BATTERY_STATUS_CHARGING` or a hardware signal would be a false-negative source — a ROM can carry
  * the level past the cap while reporting UNKNOWN, NOT_CHARGING or FULL, and a build with no hold
- * signal must still be refutable, or an unenforced cap would go on looking harmless.
+ * signal must still be refutable, or an unenforced cap would go on looking harmless. The climb is
+ * tracked from ANY level, above the cap included: epochs routinely open above it (a full-charge
+ * session restored early at 84%, a process death at 82%), and those are exactly the runs where an
+ * unenforced cap keeps climbing to 100%.
  */
 object EnforcementVerdictEngine {
 
@@ -162,7 +170,7 @@ object EnforcementVerdictEngine {
         // (they are what a hold looks like) without ever establishing a rise on their own.
         val dropped = last != null && sample.percent < last
         val climbBase = when {
-            last == null || dropped -> sample.percent.takeIf { it <= cap }
+            last == null || dropped -> sample.percent
             else -> prior?.climbBase
         }
         val climbRose = when {
@@ -203,7 +211,10 @@ object EnforcementVerdictEngine {
             lastPercent = sample.percent,
         )
         val verdict = when {
-            climbBase != null && sample.percent >= cap + OVERSHOOT_ALLOWANCE -> EnforcementVerdict.REFUTED
+            // The refutation keys on the CLIMB, not on the level alone: a lone or flat above-cap
+            // sample proves nothing (the epoch may simply have opened there), while an observed rise
+            // to beyond the cap does — wherever inside or above the cap that rise started.
+            climbRose && sample.percent >= cap + OVERSHOOT_ALLOWANCE -> EnforcementVerdict.REFUTED
             // hardwareHold, the rise and the band are already folded into `holding`.
             holdSamples >= MIN_HOLD_SAMPLES &&
                 sample.elapsedRealtimeMillis - holdSince >= MIN_HOLD_MILLIS -> EnforcementVerdict.CONFIRMED

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngine.kt
@@ -104,9 +104,10 @@ object EnforcementVerdictEngine {
      * Bumped whenever this heuristic materially changes. Stored on every [EnforcementEvidence], so a
      * verdict produced by a different version stops counting instead of being trusted forever.
      *
-     * Version 2 dropped the confirmation arm entirely (see above); a version-1 record was produced by
-     * a heuristic that also weighed a hardware signal now known to be session-scoped, so it reads as
-     * no evidence at all.
+     * Version 2 dropped the confirmation arm entirely (see above). A version-1 record is therefore
+     * migrated per verdict rather than discarded (see [EnforcementEvidenceStore]): its confirmation
+     * rested on a hardware signal now known to be session-scoped and reads as no evidence, while its
+     * refutation never depended on that signal and is kept, restamped to this version.
      */
     const val ALGORITHM_VERSION = 2
 

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementWatcher.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementWatcher.kt
@@ -1,0 +1,39 @@
+package eu.darken.amply.charging.core.enforcement
+
+import eu.darken.amply.monitor.core.ChargeMonitorTick
+import eu.darken.amply.monitor.core.ChargeMonitorWatcher
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Contributes enforcement observation to the charge-session monitor.
+ *
+ * [onBatteryTick] does no blocking work: it copies the tick — including the exact battery intent, so
+ * the recorder can read charge current off the *same* observation — and hands it to
+ * [EnforcementRecorder], which does every DataStore, provider and Binder read on its own IO thread.
+ * This runs under the service's dispatch lock, so a slow read here could delay the safety-critical
+ * charge-policy restore.
+ */
+@Singleton
+class EnforcementWatcher @Inject constructor(
+    private val recorder: EnforcementRecorder,
+) : ChargeMonitorWatcher {
+
+    override val id = "enforcement_evidence"
+
+    override suspend fun isEnabled(): Boolean = recorder.shouldObserve()
+
+    override suspend fun onBatteryTick(tick: ChargeMonitorTick) {
+        recorder.offer(
+            RawEnforcementTick(
+                plugged = tick.plugged,
+                percent = tick.percent,
+                batteryStatus = tick.batteryStatus,
+                sessionActive = tick.sessionActive,
+                batteryIntent = tick.batteryIntent,
+                observedElapsedRealtimeMillis = tick.observedElapsedRealtimeMillis,
+                wallMillis = tick.wallClockMillis,
+            ),
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementWatcher.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/enforcement/EnforcementWatcher.kt
@@ -9,7 +9,7 @@ import javax.inject.Singleton
  * Contributes enforcement observation to the charge-session monitor.
  *
  * [onBatteryTick] does no blocking work: it copies the tick — including the exact battery intent, so
- * the recorder can read charge current off the *same* observation — and hands it to
+ * the recorder can fall back to the level off the *same* observation — and hands it to
  * [EnforcementRecorder], which does every DataStore, provider and Binder read on its own IO thread.
  * This runs under the service's dispatch lock, so a slow read here could delay the safety-critical
  * charge-policy restore.
@@ -28,10 +28,8 @@ class EnforcementWatcher @Inject constructor(
             RawEnforcementTick(
                 plugged = tick.plugged,
                 percent = tick.percent,
-                batteryStatus = tick.batteryStatus,
                 sessionActive = tick.sessionActive,
                 batteryIntent = tick.batteryIntent,
-                observedElapsedRealtimeMillis = tick.observedElapsedRealtimeMillis,
                 wallMillis = tick.wallClockMillis,
             ),
         )

--- a/app/src/main/java/eu/darken/amply/diagnostics/core/ContributionRepository.kt
+++ b/app/src/main/java/eu/darken/amply/diagnostics/core/ContributionRepository.kt
@@ -9,6 +9,7 @@ import eu.darken.amply.charging.core.access.NamespaceSnapshot
 import eu.darken.amply.charging.core.access.STANDARD_SETTINGS_NAMESPACES
 import eu.darken.amply.charging.core.access.SettingsSnapshotSource
 import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceState
 import eu.darken.amply.common.ca.CaString
 import eu.darken.amply.common.ca.toCaString
 import javax.inject.Inject
@@ -61,7 +62,8 @@ class DefaultContributionRepository @Inject constructor(
 
     override fun deviceContext(): DeviceContext {
         val device = DeviceInfo.current(context)
-        return DeviceContext(device, registry.select(device).adapter?.id)
+        // Adapter identity only — the enforcement gate decides control, never which adapter matched.
+        return DeviceContext(device, registry.select(device, EnforcementEvidenceState.Loading).adapter?.id)
     }
 }
 

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/BootReceiver.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/BootReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.content.ContextCompat
 import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceState
 import eu.darken.amply.common.debug.logging.Logging
 import eu.darken.amply.common.debug.logging.log
 import eu.darken.amply.common.debug.logging.logTag
@@ -42,7 +43,8 @@ class BootReceiver : BroadcastReceiver() {
                 val sessionExists = sessionStore.currentSession() != null
                 val pendingRecovery = sessionStore.pendingRecoveryTarget() != null
                 val gestureEnabled = sessionStore.isQuickFullChargeEnabled() &&
-                    adapterRegistry.select().adapter?.reconnectGestureSupported == true
+                    adapterRegistry.select(evidenceState = EnforcementEvidenceState.Loading)
+                        .adapter?.reconnectGestureSupported == true
                 val mandatory = sessionExists || pendingRecovery || gestureEnabled
                 val action = ServiceDispatch.startAction(
                     trigger = trigger,

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/BootRecoveryFlow.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/BootRecoveryFlow.kt
@@ -1,7 +1,9 @@
 package eu.darken.amply.fullcharge.core
 
+import eu.darken.amply.charging.core.ApplyResult
 import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.ChargingRepository
 import eu.darken.amply.common.debug.logging.Logging
 import eu.darken.amply.common.debug.logging.log
 import eu.darken.amply.common.debug.logging.logTag
@@ -18,19 +20,36 @@ data class BatterySnapshot(
  * [BootRecoveryEngine] until the charging hardware confirms it, a nudge re-write was sent,
  * or the budget runs out. The pending target persists across process death so a killed
  * service resumes the check instead of losing it.
+ *
+ * A resumed target carries its [RecoveryOrigin], which travels with every re-write: not everything
+ * that ends up pending is a restore the user is already owed, and only those may bypass the
+ * enforcement evidence gate (see [writeRecoveryTarget]).
  */
 class BootRecoveryFlow(private val hooks: Hooks) {
 
+    /** A persisted recovery target plus WHY it is owed — see [RecoveryOrigin]. */
+    data class PendingRecovery(
+        val target: ChargePolicy,
+        val origin: RecoveryOrigin,
+    )
+
     interface Hooks {
         suspend fun currentSessionTarget(): ChargePolicy?
-        suspend fun pendingTarget(): ChargePolicy?
+        suspend fun pendingTarget(): PendingRecovery?
+
+        /** Persists a target seeded from the session being recovered, i.e. [RecoveryOrigin.SESSION_RESTORE]. */
         suspend fun setPendingTarget(policy: ChargePolicy)
         suspend fun clearPendingTarget()
         suspend fun restoreSession(): Boolean
 
         /** Drops a session record that a newer pending target has made stale, without restoring it. */
         suspend fun dropStaleSession()
-        suspend fun rewrite(policy: ChargePolicy): Boolean
+
+        /**
+         * Re-write [policy]. [origin] decides the write path: an owed restore bypasses the
+         * enforcement evidence tier, a user-requested policy must not.
+         */
+        suspend fun rewrite(policy: ChargePolicy, origin: RecoveryOrigin): Boolean
 
         /** The policy Amply itself was most recently asked to configure, if any. */
         suspend fun intendedTarget(): ChargePolicy?
@@ -72,12 +91,15 @@ class BootRecoveryFlow(private val hooks: Hooks) {
         var rewrites = 0
         val sessionTarget = hooks.currentSessionTarget()
         val pendingTarget = hooks.pendingTarget()
-        val target = pendingTarget ?: sessionTarget ?: return Result(
+        val target = pendingTarget?.target ?: sessionTarget ?: return Result(
             outcome = Outcome.NOTHING_TO_DO,
             restoreAttempted = false,
             rewrites = 0,
             retryRemaining = false,
         )
+        // A target seeded from the session below is by definition an owed restore; a persisted one
+        // carries the origin of whoever created it.
+        val origin = pendingTarget?.origin ?: RecoveryOrigin.SESSION_RESTORE
         var staleIntended: ChargePolicy? = null
         if (pendingTarget != null) {
             // The pending target is always the newest intent: setPersistentPolicy persists it
@@ -145,8 +167,8 @@ class BootRecoveryFlow(private val hooks: Hooks) {
                 RecoveryDecision.WAIT -> Unit
                 RecoveryDecision.REWRITE -> {
                     rewrites++
-                    log(TAG) { "Boot recovery: re-writing ${target.stableId} (attempt $rewrites)" }
-                    if (!hooks.rewrite(target)) {
+                    log(TAG) { "Boot recovery: re-writing ${target.stableId} as $origin (attempt $rewrites)" }
+                    if (!hooks.rewrite(target, origin)) {
                         // Keep the pending target: a re-write failure (lost access, partial
                         // write) should be retried by the next service start.
                         log(TAG, Logging.Priority.ERROR) { "Boot recovery re-write failed" }
@@ -190,4 +212,23 @@ class BootRecoveryFlow(private val hooks: Hooks) {
     companion object {
         val TAG = logTag("BootRecoveryFlow")
     }
+}
+
+/**
+ * Write a recovery target the way its [RecoveryOrigin] demands.
+ *
+ * A [RecoveryOrigin.SESSION_RESTORE] repays a protective policy the user already had, so it takes
+ * the ungated [ChargingRepository.restorePersistent] — an OTA mid-session changes the build identity
+ * and would otherwise leave the owed write refused, stranding the device Unrestricted. A
+ * [RecoveryOrigin.USER_REQUEST] is a *fresh* choice that merely happens to be pending (the widget's
+ * persistent-policy write persists its target before the risky write), so it stays on the gated
+ * [ChargingRepository.reapplyPersistent]: a build that became a candidate or was refuted in the
+ * meantime must not receive a new user write, least of all `Unrestricted`.
+ */
+internal suspend fun ChargingRepository.writeRecoveryTarget(
+    policy: ChargePolicy,
+    origin: RecoveryOrigin,
+): ApplyResult = when (origin) {
+    RecoveryOrigin.SESSION_RESTORE -> restorePersistent(policy, forceNotify = true)
+    RecoveryOrigin.USER_REQUEST -> reapplyPersistent(policy)
 }

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionManager.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionManager.kt
@@ -109,8 +109,9 @@ class ChargeSessionManager @Inject constructor(
             result
         } else {
             // A two-key OEM transition can partially succeed. Keep recovery state unless the
-            // original protective policy is successfully written back immediately.
-            val rollback = repository.applyPersistent(restorePolicy)
+            // original protective policy is successfully written back immediately. Repaying a policy
+            // the user already had is not new control, so it goes through the ungated restore path.
+            val rollback = repository.restorePersistent(restorePolicy)
             if (rollback.success) sessionStore.clearSession()
             result.copy(
                 message = if (rollback.success) {
@@ -128,7 +129,11 @@ class ChargeSessionManager @Inject constructor(
             observation = repository.state.value.observation,
             message = "No temporary session is active",
         )
-        val result = repository.applyPersistent(session.restorePolicy)
+        // The session's restore obligation predates any evidence tier change (a nightly/OTA moves the
+        // build identity, so a confirmed device can come back a candidate with a restore still owed).
+        // The gate withholds NEW control; it must never keep Amply from repaying protection the user
+        // already had, which would strand the device in the session's Unrestricted state.
+        val result = repository.restorePersistent(session.restorePolicy)
         if (result.success) sessionStore.clearSession()
         result
     }

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -20,6 +20,8 @@ import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.ChargingPreferences
 import eu.darken.amply.charging.core.ChargingRepository
 import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.adapter.ChargingAdapter
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceState
 import eu.darken.amply.common.debug.logging.Logging
 import eu.darken.amply.common.debug.logging.log
 import eu.darken.amply.common.debug.logging.logTag
@@ -459,7 +461,7 @@ class ChargeSessionService : Service() {
         // check already resolved a selection at exactly this point, and the hardware decode below
         // reuses this one.
         val gestureEnabled = fullChargeStore.isQuickFullChargeEnabled()
-        val adapter = if (gestureEnabled) adapterRegistry.select().adapter else null
+        val adapter = if (gestureEnabled) capabilityAdapter() else null
         if (!gestureEnabled || adapter?.reconnectGestureSupported != true) {
             dispatchWatchers(plugged, percent, status, sessionOwned = false, battery, observedAtElapsed)
             // Gesture inactive: keep running only if a watcher still wants the service, showing the
@@ -695,7 +697,7 @@ class ChargeSessionService : Service() {
         }
 
         override fun hardwareObservation(snapshot: BatterySnapshot) =
-            adapterRegistry.select().adapter?.decodeHardware(snapshot.chargingState, snapshot.plugged)
+            capabilityAdapter()?.decodeHardware(snapshot.chargingState, snapshot.plugged)
 
         override suspend fun settingsObservation() = repository.syncReadback()
 
@@ -809,16 +811,26 @@ class ChargeSessionService : Service() {
         createdAtMillis = System.currentTimeMillis(),
     )
 
+    /**
+     * The matched adapter's *capabilities* (gesture support, hardware decode, observed URIs, plug
+     * latching) — never a control decision, so the enforcement gate is deliberately fed the
+     * fail-closed [EnforcementEvidenceState.Loading] instead of a durable store read on the service's
+     * dispatch path. Every write this service performs goes through the repository, which applies the
+     * real gate.
+     */
+    private fun capabilityAdapter(): ChargingAdapter? =
+        adapterRegistry.select(evidenceState = EnforcementEvidenceState.Loading).adapter
+
     // The gesture's arming preconditions (hardware charging-state 4) are Pixel-specific; on
     // adapters without that signal the monitor would never arm and must not run.
     private fun reconnectGestureAvailable() =
-        adapterRegistry.select().adapter?.reconnectGestureSupported == true
+        capabilityAdapter()?.reconnectGestureSupported == true
 
     // Resolved once per service lifetime: adapter selection is immutable device information, and
     // per-tick selection is deliberately avoided in the session branch (see the note in
     // evaluateBattery about DeviceInfo.current()'s cost under the dispatch lock).
     private val policyLatchesAtPlug by lazy {
-        adapterRegistry.select().adapter?.policyLatchesAtPlug == true
+        capabilityAdapter()?.policyLatchesAtPlug == true
     }
 
     private fun stopMonitoring() {
@@ -852,7 +864,7 @@ class ChargeSessionService : Service() {
 
     private fun registerSettingObserver() {
         if (settingObserverRegistered) return
-        val uris = adapterRegistry.select().adapter?.observedSettingUris.orEmpty()
+        val uris = capabilityAdapter()?.observedSettingUris.orEmpty()
         if (uris.isEmpty()) return
         uris.forEach { contentResolver.registerContentObserver(it, false, settingObserver) }
         settingObserverRegistered = true

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -679,8 +679,11 @@ class ChargeSessionService : Service() {
         override suspend fun clearPendingTarget() = fullChargeStore.clearPendingRecoveryTarget()
         override suspend fun restoreSession() = manager.restore().success
         override suspend fun dropStaleSession() = manager.cancelWithoutRestore()
+        // Boot recovery repays an obligation the user already had, so it takes the ungated restore
+        // path: an OTA between the session start and this boot changes the build identity, which
+        // would otherwise leave the owed protective write refused by the enforcement gate.
         override suspend fun rewrite(policy: ChargePolicy) =
-            repository.reapplyPersistent(policy).success
+            repository.restorePersistent(policy, forceNotify = true).success
 
         override suspend fun intendedTarget() = preferences.lastRequestedNow()
 

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -668,22 +668,33 @@ class ChargeSessionService : Service() {
 
     private val recoveryHooks = object : BootRecoveryFlow.Hooks {
         override suspend fun currentSessionTarget() = fullChargeStore.currentSession()?.restorePolicy
-        override suspend fun pendingTarget() = fullChargeStore.pendingRecoveryTarget()
+
+        // One record read, not target-then-origin: the two must never be paired across a concurrent
+        // write (see FullChargeStore.currentRecovery).
+        override suspend fun pendingTarget() = fullChargeStore.currentRecovery()?.let {
+            BootRecoveryFlow.PendingRecovery(target = it.target, origin = it.origin)
+        }
+
         override suspend fun setPendingTarget(policy: ChargePolicy) {
             // A session-only recovery seeds the pending target from the session it is recovering, so it
             // continues the SAME owed work — inherit the session's work id; otherwise mint a fresh one.
             val workId = fullChargeStore.currentSession()?.workId ?: UUID.randomUUID().toString()
-            fullChargeStore.setPendingRecoveryTarget(policy, workId, currentWorkProvenance())
+            fullChargeStore.setPendingRecoveryTarget(
+                policy = policy,
+                workId = workId,
+                provenance = currentWorkProvenance(),
+                origin = RecoveryOrigin.SESSION_RESTORE,
+            )
         }
 
         override suspend fun clearPendingTarget() = fullChargeStore.clearPendingRecoveryTarget()
         override suspend fun restoreSession() = manager.restore().success
         override suspend fun dropStaleSession() = manager.cancelWithoutRestore()
-        // Boot recovery repays an obligation the user already had, so it takes the ungated restore
-        // path: an OTA between the session start and this boot changes the build identity, which
-        // would otherwise leave the owed protective write refused by the enforcement gate.
-        override suspend fun rewrite(policy: ChargePolicy) =
-            repository.restorePersistent(policy, forceNotify = true).success
+
+        // The origin decides the write path: an owed restore bypasses the enforcement evidence tier,
+        // a pending user request does not. See writeRecoveryTarget.
+        override suspend fun rewrite(policy: ChargePolicy, origin: RecoveryOrigin) =
+            repository.writeRecoveryTarget(policy, origin).success
 
         override suspend fun intendedTarget() = preferences.lastRequestedNow()
 
@@ -775,8 +786,15 @@ class ChargeSessionService : Service() {
         // Persist the intended end state as the recovery target BEFORE the risky write and before dropping
         // the session, so a failed write or a mid-write process death still converges here on next boot
         // instead of leaving charging in whatever transient state the session had. An explicit persistent
-        // choice is new owed work, so it gets a fresh work id.
-        fullChargeStore.setPendingRecoveryTarget(policy, UUID.randomUUID().toString(), currentWorkProvenance())
+        // choice is new owed work, so it gets a fresh work id — and USER_REQUEST, so that a boot recovery
+        // resuming it writes it through the enforcement gate exactly like this call does, rather than
+        // through the ungated restore path (the build can be a candidate or refuted by then).
+        fullChargeStore.setPendingRecoveryTarget(
+            policy = policy,
+            workId = UUID.randomUUID().toString(),
+            provenance = currentWorkProvenance(),
+            origin = RecoveryOrigin.USER_REQUEST,
+        )
         restoring = true
         coordinator.close()
         try {

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/FullChargeStore.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/FullChargeStore.kt
@@ -61,8 +61,35 @@ data class ChargeSessionRecord(
 )
 
 /**
+ * Why a recovery target is owed, which decides how it may be written back later.
+ *
+ * The distinction is a safety boundary, not bookkeeping: a [SESSION_RESTORE] repays a protective
+ * policy the user ALREADY had and therefore takes the ungated
+ * `ChargingRepository.restorePersistent()`, while a [USER_REQUEST] is a fresh choice — possibly
+ * `Unrestricted` — and must go through the gated `reapplyPersistent()`. Between the write being
+ * persisted and it landing, the build can become a candidate (an OTA changes the composite build
+ * identity) or be refuted, and a fresh user write must not slip past the enforcement gate just
+ * because a process death turned it into recovery work.
+ */
+@Serializable
+enum class RecoveryOrigin {
+    /** Repaying the protective policy of a session or an earlier boot recovery: ungated. */
+    @SerialName("SESSION_RESTORE")
+    SESSION_RESTORE,
+
+    /** A policy the user explicitly asked for (widget/tile persistent choice): gated. */
+    @SerialName("USER_REQUEST")
+    USER_REQUEST,
+}
+
+/**
  * The restore Amply still owes after a boot or an interrupted session, held as one record so its
  * target, correlation id and provenance can never be read as a mismatched set.
+ *
+ * [origin] defaults to the **safe** [RecoveryOrigin.USER_REQUEST]: a record written by a build that
+ * did not know the field decodes to the gated path, so an older record can never bypass the
+ * enforcement gate. The cost of the wrong default in the other direction is a refused restore, which
+ * the boot recovery notification surfaces; the cost here would be a silent ungated write.
  */
 @Serializable
 data class RecoveryRecord(
@@ -71,6 +98,7 @@ data class RecoveryRecord(
     val target: ChargePolicy,
     @SerialName("workId") val workId: String? = null,
     @SerialName("provenance") val provenance: WorkProvenance? = null,
+    @SerialName("origin") val origin: RecoveryOrigin = RecoveryOrigin.USER_REQUEST,
 )
 
 /**
@@ -175,12 +203,19 @@ class FullChargeStore @Inject constructor(
 
     suspend fun pendingRecoveryWorkId(): String? = currentRecovery()?.workId
 
+    /**
+     * [origin] has no default: it decides whether the target may later be written through the ungated
+     * restore path, so every caller must state which kind of work it is persisting.
+     */
     suspend fun setPendingRecoveryTarget(
         policy: ChargePolicy,
         workId: String? = null,
         provenance: WorkProvenance? = null,
+        origin: RecoveryOrigin,
     ) {
-        recoveryValue.update { RecoveryRecord(target = policy, workId = workId, provenance = provenance) }
+        recoveryValue.update {
+            RecoveryRecord(target = policy, workId = workId, provenance = provenance, origin = origin)
+        }
     }
 
     /** Re-stamp the pending recovery target's provenance to the current process, if one is present. */

--- a/app/src/main/java/eu/darken/amply/main/core/ChargingCoreModule.kt
+++ b/app/src/main/java/eu/darken/amply/main/core/ChargingCoreModule.kt
@@ -9,6 +9,8 @@ import eu.darken.amply.charging.core.access.LineageChargeReader
 import eu.darken.amply.charging.core.access.LineageSettingsClient
 import eu.darken.amply.charging.core.access.SettingsSnapshotSource
 import eu.darken.amply.charging.core.access.ShizukuSettingsBackend
+import eu.darken.amply.charging.core.enforcement.BuildIdentitySource
+import eu.darken.amply.charging.core.enforcement.DeviceBuildIdentitySource
 import eu.darken.amply.diagnostics.core.ContributionRepository
 import eu.darken.amply.diagnostics.core.DefaultContributionRepository
 
@@ -28,4 +30,8 @@ abstract class ChargingCoreModule {
     /** LineageOS charge-control reads: unprivileged ContentResolver snapshot, shared by the Lineage adapter. */
     @Binds
     abstract fun bindLineageChargeReader(impl: LineageSettingsClient): LineageChargeReader
+
+    /** Behind an interface so the evidence store and its tests don't need the Android build environment. */
+    @Binds
+    abstract fun bindBuildIdentitySource(impl: DeviceBuildIdentitySource): BuildIdentitySource
 }

--- a/app/src/main/java/eu/darken/amply/main/core/DeviceSupportReporter.kt
+++ b/app/src/main/java/eu/darken/amply/main/core/DeviceSupportReporter.kt
@@ -14,7 +14,7 @@ import eu.darken.amply.charging.core.SettingProbe
 import eu.darken.amply.charging.core.probeSetting
 import eu.darken.amply.charging.core.access.LineageHealthSummary
 import eu.darken.amply.charging.core.access.SettingsSnapshotSource
-import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.ChargingRepository
 import eu.darken.amply.charging.core.adapter.OnePlusChargingAdapter
 import eu.darken.amply.common.AmplyLinks
 import kotlinx.coroutines.Dispatchers
@@ -105,12 +105,15 @@ data class DeviceSupportReport(
 @Singleton
 class DeviceSupportReporter @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val registry: AdapterRegistry,
+    // The gated selection, not a raw registry probe: the report's adapterControlEnabled /
+    // contributionWanted must say what the user actually has, which on an evidence-gated adapter
+    // depends on the stored enforcement verdict.
+    private val chargingRepository: ChargingRepository,
     private val snapshotSource: SettingsSnapshotSource,
 ) {
     suspend fun collect(): DeviceSupportReport = withContext(Dispatchers.IO) {
         val device = DeviceInfo.current(context)
-        val selection = registry.select(device)
+        val selection = chargingRepository.currentSelection()
         // Only meaningful on LineageOS, and only reachable with Shizuku (dumpsys needs the shell UID). Without it
         // the field stays null and the report is exactly as informative as before — never blocks a contribution.
         val lineageHealth = if (device.isLineageOs) snapshotSource.lineageHealth() else null

--- a/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
@@ -342,6 +342,7 @@ class MainActivity : ComponentActivity() {
                             onOpenBatteryHub = { destination = SettingsDestination.BATTERY },
                             // Re-dispatch the charge service after a failed start (charging card retry).
                             onRetryCapture = { viewModel.nudgeChargeService() },
+                            onStartVerification = { viewModel.startEnforcementVerification() },
                             onPinWidget = viewModel::requestPinWidget,
                             onAddTile = viewModel::requestAddTile,
                             onDismissQuickAccess = viewModel::dismissQuickAccess,

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -210,7 +210,9 @@ fun DashboardScreen(
                 // Directly under the hero on BOTH branches: on an unverified or refuted device the
                 // hero's "unsupported" line is exactly what this card has to explain, and while a
                 // verification is running it qualifies the policy the hero states.
-                state.charging.enforcement?.let { enforcement ->
+                // CONFIRMED renders nothing, so it must not claim a list slot either — an empty item
+                // would still cost the list's 12.dp inter-item spacing.
+                state.charging.enforcement?.takeIf { it != EnforcementStatus.CONFIRMED }?.let { enforcement ->
                     item(key = "dashboard.enforcement") {
                         EnforcementCard(status = enforcement, onStartVerification = onStartVerification)
                     }

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -225,6 +225,10 @@ fun DashboardScreen(
                     // Unsupported devices cannot use the Pixel policy/charge controls; showing them
                     // greyed-out (and a "Pixel settings" action) only confuses non-Pixel users. Offer
                     // a contribution path instead, and keep only the restore card if a session lingers.
+                    // The same holds for a CANDIDATE build, where the controls *would* work once the
+                    // user opts in: leaving them out is deliberate, not an oversight. The enforcement
+                    // card is the call to action, and a disabled-but-visible row of percentages beside
+                    // it reads as a broken control rather than an offer.
                     if (state.session != null) {
                         item(key = "dashboard.fullcharge") {
                             FullChargeCard(
@@ -438,6 +442,13 @@ private fun StatusCard(
     }
     val settling = state.charging.isSettling(now)
     val enforcementUnverified = state.charging.enforcement == EnforcementStatus.UNVERIFIED
+    // The two tiers that keep control off publish ChargeObservation.Unsupported, and its generic
+    // "Unsupported device" wording contradicts the enforcement card directly below: the adapter did
+    // match, and on a candidate build the controls are one tap away. Presentation only — the tier is
+    // read here, never decided here.
+    val gatedTier = state.charging.enforcement
+        ?.takeIf { observation is ChargeObservation.Unsupported }
+        ?.takeIf { it == EnforcementStatus.CANDIDATE || it == EnforcementStatus.REFUTED }
     // A settings-level readback proves the ROM stored the limit, never that the hardware honours it.
     // On an unconfirmed build that difference is the whole point, so the green check — which reads as
     // "your battery is protected" — is withheld until enforcement is confirmed (which, on these
@@ -472,7 +483,7 @@ private fun StatusCard(
                     settling -> stringResource(R.string.dashboard_applying)
                     presentation == SessionPresentation.ACTIVE ->
                         stringResource(R.string.dashboard_session_once_title)
-                    else -> observation.title().asComposable()
+                    else -> observation.title(gatedTier).asComposable()
                 },
                 style = MaterialTheme.typography.titleLarge,
                 modifier = Modifier.weight(1f),
@@ -487,6 +498,11 @@ private fun StatusCard(
                 state.session?.let {
                     stringResource(R.string.dashboard_session_returns, it.restorePolicy.shortLabel().asComposable())
                 }
+            } else if (gatedTier == EnforcementStatus.CANDIDATE) {
+                // There is no policy to describe yet, so this slot points at the opt-in card instead.
+                // REFUTED gets no line here: its title already carries the sense, and the provenance
+                // line below states the refutation — repeating the card's paragraph would be noise.
+                stringResource(R.string.dashboard_enforcement_candidate_hero_body)
             } else {
                 observation.policyOrNull()?.description()?.asComposable()
             }
@@ -915,7 +931,17 @@ private fun InterruptionCard(
     }
 }
 
-private fun ChargeObservation.title(): CaString = when (this) {
+/**
+ * [gatedTier] is the enforcement tier *when it is the reason control is off* (see StatusCard) — the
+ * device is matched and mapped, so the tier speaks for itself instead of the generic unsupported copy.
+ */
+private fun ChargeObservation.title(gatedTier: EnforcementStatus?): CaString = when (gatedTier) {
+    EnforcementStatus.CANDIDATE -> R.string.dashboard_enforcement_candidate_hero_title.toCaString()
+    EnforcementStatus.REFUTED -> R.string.dashboard_enforcement_refuted_hero_title.toCaString()
+    else -> untieredTitle()
+}
+
+private fun ChargeObservation.untieredTitle(): CaString = when (this) {
     is ChargeObservation.Verified -> if (backend == BackendKind.BATTERY_HARDWARE) {
         caString { it.getString(R.string.dashboard_status_verified_active, policy.shortLabel().get(it)) }
     } else {
@@ -1780,6 +1806,7 @@ private fun DashboardScreenUnsupportedPreview() = PreviewWrapper {
 
 // A LineageOS build nobody has qualified: the adapter matched and the keys are writable, but the
 // controls stay off until the user enables them anyway, so the card under the hero is the whole offer.
+// The hero says exactly that — an "unsupported device" line here would contradict the card below it.
 @AmplyPreview
 @Composable
 private fun DashboardScreenEnforcementCandidatePreview() = PreviewWrapper {
@@ -1805,7 +1832,73 @@ private fun DashboardScreenEnforcementCandidatePreview() = PreviewWrapper {
                     shizuku = BackendStatus(true, true, "Shizuku connected".toCaString()),
                 ),
                 observation = ChargeObservation.Unsupported(
-                    "Charge limiting has not been verified on this build yet".toCaString(),
+                    // The reason the registry actually publishes for this tier.
+                    R.string.adapter_detail_enforcement_candidate.toCaString(),
+                ),
+            ),
+        ),
+        adbCommand = "adb shell pm grant eu.darken.amply android.permission.WRITE_SECURE_SETTINGS",
+        onRefresh = {},
+        onSettings = {},
+        onStartFull = {},
+        onRestore = {},
+        onApply = {},
+        onQuickFullChargeChange = {},
+        onAlarmEnabledChange = {},
+        onAlarmTargetChange = {},
+        onFixNotifications = {},
+        onOpenBatteryHub = {},
+        onRetryCapture = {},
+        onStartVerification = {},
+        onPinWidget = {},
+        onAddTile = {},
+        onDismissQuickAccess = {},
+        onDismissInterruption = {},
+        onNativeSettings = {},
+        onOpenShizuku = {},
+        onAllowShizuku = {},
+        onGrantWss = {},
+        onCopyAdb = {},
+        onCopyWebUsbLink = {},
+        onPrepareSupportReport = {},
+        onCopySupportReport = {},
+        onOpenContribution = {},
+        onOpenSupportIssue = {},
+        onEmailSupport = {},
+        onHelp = {},
+    )
+}
+
+// The same build after it charged past the limit it accepted: control is withdrawn and the report
+// affordance appears. The hero names the refutation rather than calling the device unsupported, and
+// leaves the paragraph to the card below it.
+@AmplyPreview
+@Composable
+private fun DashboardScreenEnforcementRefutedPreview() = PreviewWrapper {
+    DashboardScreen(
+        state = DashboardUiState(
+            onboardingComplete = true,
+            batteryReadout = BatteryReadout(
+                levelPercent = 88,
+                status = android.os.BatteryManager.BATTERY_STATUS_CHARGING,
+                plugged = android.os.BatteryManager.BATTERY_PLUGGED_USB,
+                temperatureTenthsC = 304,
+            ),
+            charging = ChargingState(
+                device = DeviceInfo("Google", "Pixel 6", 36, "preview", hasLineageFeature = true),
+                adapterName = "LineageOS charging control".toCaString(),
+                adapterId = "lineageos-chargingcontrol-v1",
+                controlEnabled = false,
+                enforcement = EnforcementStatus.REFUTED,
+                contributionWanted = true,
+                syncVerification = true,
+                writeRequiresShizuku = true,
+                access = AccessSnapshot(
+                    direct = BackendStatus(true, true, "Charge-control access granted".toCaString()),
+                    shizuku = BackendStatus(true, true, "Shizuku connected".toCaString()),
+                ),
+                observation = ChargeObservation.Unsupported(
+                    R.string.adapter_detail_enforcement_refuted.toCaString(),
                 ),
             ),
         ),

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -1778,8 +1778,8 @@ private fun DashboardScreenUnsupportedPreview() = PreviewWrapper {
     )
 }
 
-// A LineageOS build nobody has verified: the adapter matched and the keys are writable, but the
-// controls stay off until the user runs the check, so the card under the hero is the whole offer.
+// A LineageOS build nobody has qualified: the adapter matched and the keys are writable, but the
+// controls stay off until the user enables them anyway, so the card under the hero is the whole offer.
 @AmplyPreview
 @Composable
 private fun DashboardScreenEnforcementCandidatePreview() = PreviewWrapper {
@@ -1841,11 +1841,12 @@ private fun DashboardScreenEnforcementCandidatePreview() = PreviewWrapper {
     )
 }
 
-// Verification running: the controls are live and the limit reads back verified, but the hero shows
-// the shield instead of the green check and says so on its own line.
+// Accepted unconfirmed: the controls are live and the limit reads back verified, but nothing here
+// shows the cap holding, so the hero shows the shield instead of the green check and says so on its
+// own line.
 @AmplyPreview
 @Composable
-private fun DashboardScreenEnforcementUnderTestPreview() = PreviewWrapper {
+private fun DashboardScreenEnforcementUnverifiedPreview() = PreviewWrapper {
     DashboardScreen(
         state = DashboardUiState(
             onboardingComplete = true,

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -207,9 +207,9 @@ fun DashboardScreen(
 
                 item(key = "dashboard.hero") { StatusCard(state, sessionPresentation) }
 
-                // Directly under the hero on BOTH branches: on an unverified or refuted device the
-                // hero's "unsupported" line is exactly what this card has to explain, and while a
-                // verification is running it qualifies the policy the hero states.
+                // Directly under the hero on BOTH branches: on a candidate or refuted device the
+                // hero's "unsupported" line is exactly what this card has to explain, and on an
+                // unconfirmed one it qualifies the policy the hero states.
                 // CONFIRMED renders nothing, so it must not claim a list slot either — an empty item
                 // would still cost the list's 12.dp inter-item spacing.
                 state.charging.enforcement?.takeIf { it != EnforcementStatus.CONFIRMED }?.let { enforcement ->
@@ -437,11 +437,12 @@ private fun StatusCard(
         }
     }
     val settling = state.charging.isSettling(now)
-    val underTest = state.charging.enforcement == EnforcementStatus.UNDER_TEST
+    val enforcementUnverified = state.charging.enforcement == EnforcementStatus.UNVERIFIED
     // A settings-level readback proves the ROM stored the limit, never that the hardware honours it.
-    // While a verification is running that difference is the whole point, so the green check — which
-    // reads as "your battery is protected" — is withheld until enforcement is actually confirmed.
-    val verified = observation is ChargeObservation.Verified && !underTest
+    // On an unconfirmed build that difference is the whole point, so the green check — which reads as
+    // "your battery is protected" — is withheld until enforcement is confirmed (which, on these
+    // adapters, only physical qualification can do — see EnforcementVerdictEngine).
+    val verified = observation is ChargeObservation.Verified && !enforcementUnverified
 
     // Not clickable. The card states the policy; the measurements (and the way through to them) live
     // in the charging card below. A whole-card tap here used to land on voltage and cycle counts,
@@ -520,12 +521,12 @@ private fun StatusCard(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        // The provenance line above says where the value was read; on a build under verification it
-        // must not be left to imply the hardware agreed.
-        if (underTest) {
+        // The provenance line above says where the value was read; on an unconfirmed build it must
+        // not be left to imply the hardware agreed.
+        if (enforcementUnverified) {
             Spacer(Modifier.height(4.dp))
             Text(
-                stringResource(R.string.dashboard_enforcement_testing_note),
+                stringResource(R.string.dashboard_enforcement_unverified_note),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.tertiary,
             )
@@ -1864,7 +1865,7 @@ private fun DashboardScreenEnforcementUnderTestPreview() = PreviewWrapper {
                     ChargePolicy.Unrestricted,
                 ),
                 controlEnabled = true,
-                enforcement = EnforcementStatus.UNDER_TEST,
+                enforcement = EnforcementStatus.UNVERIFIED,
                 syncVerification = true,
                 writeRequiresShizuku = true,
                 access = AccessSnapshot(

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -66,6 +66,7 @@ import eu.darken.amply.charging.core.PendingRequest
 import eu.darken.amply.charging.core.SETTLING_WINDOW_MILLIS
 import eu.darken.amply.charging.core.access.AccessSnapshot
 import eu.darken.amply.charging.core.access.BackendStatus
+import eu.darken.amply.charging.core.enforcement.EnforcementStatus
 import eu.darken.amply.charging.core.isAwaitingReplug
 import eu.darken.amply.charging.core.isSettling
 import eu.darken.amply.charging.core.settlingTarget
@@ -113,6 +114,7 @@ fun DashboardScreen(
     onFixNotifications: () -> Unit,
     onOpenBatteryHub: () -> Unit,
     onRetryCapture: () -> Unit,
+    onStartVerification: () -> Unit,
     onPinWidget: () -> Unit,
     onAddTile: () -> Unit,
     onDismissQuickAccess: () -> Unit,
@@ -204,6 +206,15 @@ fun DashboardScreen(
                 }
 
                 item(key = "dashboard.hero") { StatusCard(state, sessionPresentation) }
+
+                // Directly under the hero on BOTH branches: on an unverified or refuted device the
+                // hero's "unsupported" line is exactly what this card has to explain, and while a
+                // verification is running it qualifies the policy the hero states.
+                state.charging.enforcement?.let { enforcement ->
+                    item(key = "dashboard.enforcement") {
+                        EnforcementCard(status = enforcement, onStartVerification = onStartVerification)
+                    }
+                }
 
                 if (unsupported) {
                     // No interruption card or setup guide exists on this branch, so the charging card
@@ -424,7 +435,11 @@ private fun StatusCard(
         }
     }
     val settling = state.charging.isSettling(now)
-    val verified = observation is ChargeObservation.Verified
+    val underTest = state.charging.enforcement == EnforcementStatus.UNDER_TEST
+    // A settings-level readback proves the ROM stored the limit, never that the hardware honours it.
+    // While a verification is running that difference is the whole point, so the green check — which
+    // reads as "your battery is protected" — is withheld until enforcement is actually confirmed.
+    val verified = observation is ChargeObservation.Verified && !underTest
 
     // Not clickable. The card states the policy; the measurements (and the way through to them) live
     // in the charging card below. A whole-card tap here used to land on voltage and cycle counts,
@@ -503,6 +518,16 @@ private fun StatusCard(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+        // The provenance line above says where the value was read; on a build under verification it
+        // must not be left to imply the hardware agreed.
+        if (underTest) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                stringResource(R.string.dashboard_enforcement_testing_note),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.tertiary,
+            )
+        }
         // Standing adapter fact (write latency, Shizuku requirement, replug semantics) — only set
         // while control is enabled, so it never repeats a gate-failure reason shown above. Hidden
         // while a replug is pending: the transient hint below states the same fact as an instruction,
@@ -1003,6 +1028,7 @@ private fun DashboardScreenPreview() = PreviewWrapper {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1097,6 +1123,7 @@ private fun DashboardScreenLiveChargePreview() = PreviewWrapper {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1171,6 +1198,7 @@ private fun DashboardScreenHwUnconfirmedPreview() = PreviewWrapper {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1243,6 +1271,7 @@ private fun DashboardScreenApplyingPreview() = PreviewWrapper {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1326,6 +1355,7 @@ private fun DashboardScreenAwaitingReplugPreview() = PreviewWrapper {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1395,6 +1425,7 @@ private fun DashboardScreenSessionActivePreview() = PreviewWrapper {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1466,6 +1497,7 @@ private fun DashboardScreenSessionRecordedPreview() = PreviewWrapper {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1525,6 +1557,7 @@ private fun DashboardScreenWssOnlyPreview() = PreviewWrapper {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1598,6 +1631,7 @@ private fun DashboardScreenSamsungPreview() = PreviewWrapper {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1665,6 +1699,7 @@ private fun DashboardScreenOnePlusNeedsShizukuPreview() = PreviewWrapper {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},
@@ -1720,6 +1755,136 @@ private fun DashboardScreenUnsupportedPreview() = PreviewWrapper {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
+        onPinWidget = {},
+        onAddTile = {},
+        onDismissQuickAccess = {},
+        onDismissInterruption = {},
+        onNativeSettings = {},
+        onOpenShizuku = {},
+        onAllowShizuku = {},
+        onGrantWss = {},
+        onCopyAdb = {},
+        onCopyWebUsbLink = {},
+        onPrepareSupportReport = {},
+        onCopySupportReport = {},
+        onOpenContribution = {},
+        onOpenSupportIssue = {},
+        onEmailSupport = {},
+        onHelp = {},
+    )
+}
+
+// A LineageOS build nobody has verified: the adapter matched and the keys are writable, but the
+// controls stay off until the user runs the check, so the card under the hero is the whole offer.
+@AmplyPreview
+@Composable
+private fun DashboardScreenEnforcementCandidatePreview() = PreviewWrapper {
+    DashboardScreen(
+        state = DashboardUiState(
+            onboardingComplete = true,
+            batteryReadout = BatteryReadout(
+                levelPercent = 71,
+                status = android.os.BatteryManager.BATTERY_STATUS_CHARGING,
+                plugged = android.os.BatteryManager.BATTERY_PLUGGED_USB,
+                temperatureTenthsC = 301,
+            ),
+            charging = ChargingState(
+                device = DeviceInfo("Google", "Pixel 6", 36, "preview", hasLineageFeature = true),
+                adapterName = "LineageOS charging control".toCaString(),
+                adapterId = "lineageos-chargingcontrol-v1",
+                controlEnabled = false,
+                enforcement = EnforcementStatus.CANDIDATE,
+                syncVerification = true,
+                writeRequiresShizuku = true,
+                access = AccessSnapshot(
+                    direct = BackendStatus(true, true, "Charge-control access granted".toCaString()),
+                    shizuku = BackendStatus(true, true, "Shizuku connected".toCaString()),
+                ),
+                observation = ChargeObservation.Unsupported(
+                    "Charge limiting has not been verified on this build yet".toCaString(),
+                ),
+            ),
+        ),
+        adbCommand = "adb shell pm grant eu.darken.amply android.permission.WRITE_SECURE_SETTINGS",
+        onRefresh = {},
+        onSettings = {},
+        onStartFull = {},
+        onRestore = {},
+        onApply = {},
+        onQuickFullChargeChange = {},
+        onAlarmEnabledChange = {},
+        onAlarmTargetChange = {},
+        onFixNotifications = {},
+        onOpenBatteryHub = {},
+        onRetryCapture = {},
+        onStartVerification = {},
+        onPinWidget = {},
+        onAddTile = {},
+        onDismissQuickAccess = {},
+        onDismissInterruption = {},
+        onNativeSettings = {},
+        onOpenShizuku = {},
+        onAllowShizuku = {},
+        onGrantWss = {},
+        onCopyAdb = {},
+        onCopyWebUsbLink = {},
+        onPrepareSupportReport = {},
+        onCopySupportReport = {},
+        onOpenContribution = {},
+        onOpenSupportIssue = {},
+        onEmailSupport = {},
+        onHelp = {},
+    )
+}
+
+// Verification running: the controls are live and the limit reads back verified, but the hero shows
+// the shield instead of the green check and says so on its own line.
+@AmplyPreview
+@Composable
+private fun DashboardScreenEnforcementUnderTestPreview() = PreviewWrapper {
+    DashboardScreen(
+        state = DashboardUiState(
+            onboardingComplete = true,
+            batteryReadout = BatteryReadout(
+                levelPercent = 79,
+                status = android.os.BatteryManager.BATTERY_STATUS_CHARGING,
+                plugged = android.os.BatteryManager.BATTERY_PLUGGED_USB,
+                temperatureTenthsC = 299,
+            ),
+            charging = ChargingState(
+                device = DeviceInfo("Google", "Pixel 6", 36, "preview", hasLineageFeature = true),
+                adapterName = "LineageOS charging control".toCaString(),
+                adapterId = "lineageos-chargingcontrol-v1",
+                adapterDetail = "Charging control requires Shizuku on this device".toCaString(),
+                supportedPolicies = listOf(
+                    ChargePolicy.FixedLimit(80),
+                    ChargePolicy.Unrestricted,
+                ),
+                controlEnabled = true,
+                enforcement = EnforcementStatus.UNDER_TEST,
+                syncVerification = true,
+                writeRequiresShizuku = true,
+                access = AccessSnapshot(
+                    direct = BackendStatus(true, true, "Charge-control access granted".toCaString()),
+                    shizuku = BackendStatus(true, true, "Shizuku connected".toCaString()),
+                ),
+                observation = ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.SHIZUKU),
+            ),
+        ),
+        adbCommand = "adb shell pm grant eu.darken.amply android.permission.WRITE_SECURE_SETTINGS",
+        onRefresh = {},
+        onSettings = {},
+        onStartFull = {},
+        onRestore = {},
+        onApply = {},
+        onQuickFullChargeChange = {},
+        onAlarmEnabledChange = {},
+        onAlarmTargetChange = {},
+        onFixNotifications = {},
+        onOpenBatteryHub = {},
+        onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
@@ -395,9 +395,10 @@ class DashboardViewModel @Inject constructor(
     fun completeOnboarding() = viewModelScope.launch { onboardingSettings.complete() }
 
     /**
-     * Opt this build into enforcement verification. The controls become available immediately and are
-     * labelled as unproven until a charge is observed holding at the limit; the observation itself
-     * rides the monitor service, which the nudge below (re)starts now that a watcher wants it.
+     * Accept charging control on a build whose cap was never confirmed. The controls become available
+     * immediately and stay labelled as unconfirmed — nothing observable can confirm them (see
+     * `EnforcementVerdictEngine`) — while the refutation watch rides the monitor service, which the
+     * nudge below (re)starts now that a watcher wants it.
      */
     fun startEnforcementVerification() = viewModelScope.launch {
         log(TAG, Logging.Priority.INFO) { "startEnforcementVerification()" }

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
@@ -395,6 +395,20 @@ class DashboardViewModel @Inject constructor(
     fun completeOnboarding() = viewModelScope.launch { onboardingSettings.complete() }
 
     /**
+     * Opt this build into enforcement verification. The controls become available immediately and are
+     * labelled as unproven until a charge is observed holding at the limit; the observation itself
+     * rides the monitor service, which the nudge below (re)starts now that a watcher wants it.
+     */
+    fun startEnforcementVerification() = viewModelScope.launch {
+        log(TAG, Logging.Priority.INFO) { "startEnforcementVerification()" }
+        repository.startEnforcementVerification()
+        ContextCompat.startForegroundService(
+            context,
+            Intent(context, ChargeSessionService::class.java).setAction(ChargeSessionService.ACTION_MONITOR),
+        )
+    }
+
+    /**
      * Routed through the service (same command the widget's ∞ buttons use) rather than writing the
      * policy here: the service serializes the write against session/recovery writes, refuses when no
      * backend can write, persists the recovery target before the risky write, suppresses its own

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/EnforcementCard.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/EnforcementCard.kt
@@ -34,6 +34,11 @@ const val ENFORCEMENT_CARD_TEST_TAG = "dashboard.enforcement.card"
  * that is the ordinary case, and a card stating the ordinary case is noise. The three cases it does
  * render are the ones where the dashboard would otherwise lie by omission: controls withheld without
  * a reason, controls offered that prove nothing, and controls withdrawn after a refutation.
+ *
+ * [onStartVerification] is an opt-in to control on an unconfirmed build, NOT the start of a check:
+ * nothing Amply can observe confirms a cap (see `EnforcementVerdictEngine`), so the copy must not
+ * promise a verdict that never arrives. The callback keeps its name alongside the stored
+ * `enforcement.verification_started_for` opt-in it drives.
  */
 @Composable
 fun EnforcementCard(
@@ -61,18 +66,18 @@ fun EnforcementCard(
                 Text(stringResource(R.string.dashboard_enforcement_candidate_action))
             }
         }
-        EnforcementStatus.UNDER_TEST -> AmplyCard(
+        EnforcementStatus.UNVERIFIED -> AmplyCard(
             modifier = modifier.testTag(ENFORCEMENT_CARD_TEST_TAG),
             tone = AmplyCardTone.TertiaryContainer,
             verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing),
         ) {
             AmplyCardHeader(
-                title = stringResource(R.string.dashboard_enforcement_testing_title),
+                title = stringResource(R.string.dashboard_enforcement_unverified_title),
                 icon = Icons.Default.Science,
                 iconTint = MaterialTheme.colorScheme.onTertiaryContainer,
             )
             Text(
-                stringResource(R.string.dashboard_enforcement_testing_body),
+                stringResource(R.string.dashboard_enforcement_unverified_body),
                 style = MaterialTheme.typography.bodySmall,
             )
         }
@@ -102,7 +107,7 @@ fun EnforcementCard(
 private fun EnforcementCardPreview() = PreviewWrapper {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         EnforcementCard(status = EnforcementStatus.CANDIDATE, onStartVerification = {})
-        EnforcementCard(status = EnforcementStatus.UNDER_TEST, onStartVerification = {})
+        EnforcementCard(status = EnforcementStatus.UNVERIFIED, onStartVerification = {})
         EnforcementCard(status = EnforcementStatus.REFUTED, onStartVerification = {})
     }
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/EnforcementCard.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/EnforcementCard.kt
@@ -1,0 +1,108 @@
+package eu.darken.amply.main.ui.dashboard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Science
+import androidx.compose.material.icons.filled.WarningAmber
+import androidx.compose.material.icons.twotone.Shield
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.amply.R
+import eu.darken.amply.charging.core.enforcement.EnforcementStatus
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardDefaults
+import eu.darken.amply.common.compose.AmplyCardHeader
+import eu.darken.amply.common.compose.AmplyCardTone
+import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.PreviewWrapper
+
+const val ENFORCEMENT_CARD_TEST_TAG = "dashboard.enforcement.card"
+
+/**
+ * Explains the enforcement tier on adapters where a charge limit can be written and read back
+ * perfectly while the charging hardware ignores it (LineageOS).
+ *
+ * Nothing is shown for [EnforcementStatus.CONFIRMED] or for adapters the question doesn't apply to —
+ * that is the ordinary case, and a card stating the ordinary case is noise. The three cases it does
+ * render are the ones where the dashboard would otherwise lie by omission: controls withheld without
+ * a reason, controls offered that prove nothing, and controls withdrawn after a refutation.
+ */
+@Composable
+fun EnforcementCard(
+    status: EnforcementStatus,
+    onStartVerification: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (status) {
+        EnforcementStatus.CONFIRMED -> Unit
+        EnforcementStatus.CANDIDATE -> AmplyCard(
+            modifier = modifier.testTag(ENFORCEMENT_CARD_TEST_TAG),
+            tone = AmplyCardTone.TertiaryContainer,
+            verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing),
+        ) {
+            AmplyCardHeader(
+                title = stringResource(R.string.dashboard_enforcement_candidate_title),
+                icon = Icons.TwoTone.Shield,
+                iconTint = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+            Text(
+                stringResource(R.string.dashboard_enforcement_candidate_body),
+                style = MaterialTheme.typography.bodySmall,
+            )
+            Button(onClick = onStartVerification, modifier = Modifier.align(Alignment.End)) {
+                Text(stringResource(R.string.dashboard_enforcement_candidate_action))
+            }
+        }
+        EnforcementStatus.UNDER_TEST -> AmplyCard(
+            modifier = modifier.testTag(ENFORCEMENT_CARD_TEST_TAG),
+            tone = AmplyCardTone.TertiaryContainer,
+            verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing),
+        ) {
+            AmplyCardHeader(
+                title = stringResource(R.string.dashboard_enforcement_testing_title),
+                icon = Icons.Default.Science,
+                iconTint = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+            Text(
+                stringResource(R.string.dashboard_enforcement_testing_body),
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        // No contribution action here: a refuted device also flips contributionWanted, so the
+        // dashboard's unsupported-device card already carries the report affordance below.
+        EnforcementStatus.REFUTED -> AmplyCard(
+            modifier = modifier.testTag(ENFORCEMENT_CARD_TEST_TAG),
+            tone = AmplyCardTone.SurfaceContainer,
+            verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing),
+        ) {
+            AmplyCardHeader(
+                title = stringResource(R.string.dashboard_enforcement_refuted_title),
+                icon = Icons.Default.WarningAmber,
+                iconTint = MaterialTheme.colorScheme.error,
+            )
+            Text(
+                stringResource(R.string.dashboard_enforcement_refuted_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@AmplyPreview
+@Composable
+private fun EnforcementCardPreview() = PreviewWrapper {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        EnforcementCard(status = EnforcementStatus.CANDIDATE, onStartVerification = {})
+        EnforcementCard(status = EnforcementStatus.UNDER_TEST, onStartVerification = {})
+        EnforcementCard(status = EnforcementStatus.REFUTED, onStartVerification = {})
+    }
+}

--- a/app/src/main/java/eu/darken/amply/main/ui/tile/ChargeTileService.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/tile/ChargeTileService.kt
@@ -12,6 +12,7 @@ import androidx.core.content.ContextCompat
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.amply.R
 import eu.darken.amply.charging.core.ChargingRepository
+import eu.darken.amply.charging.core.enforcement.EnforcementStatus
 import eu.darken.amply.charging.core.isAwaitingReplug
 import eu.darken.amply.charging.core.isSettling
 import eu.darken.amply.common.debug.logging.Logging
@@ -70,6 +71,10 @@ class ChargeTileService : TileService() {
                             state.isAwaitingReplug() -> getString(R.string.tile_replug_hint)
                             state.isSettling(System.currentTimeMillis()) ->
                                 getString(R.string.tile_applying)
+                            // The tile can act on this build, but nothing here has shown the limit
+                            // actually holding — say so rather than print the reassuring access label.
+                            state.enforcement == EnforcementStatus.UNDER_TEST ->
+                                getString(R.string.tile_enforcement_testing)
                             else -> (state.access?.label ?: state.adapterName)
                                 .get(this@ChargeTileService)
                         },

--- a/app/src/main/java/eu/darken/amply/main/ui/tile/ChargeTileService.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/tile/ChargeTileService.kt
@@ -71,10 +71,10 @@ class ChargeTileService : TileService() {
                             state.isAwaitingReplug() -> getString(R.string.tile_replug_hint)
                             state.isSettling(System.currentTimeMillis()) ->
                                 getString(R.string.tile_applying)
-                            // The tile can act on this build, but nothing here has shown the limit
-                            // actually holding — say so rather than print the reassuring access label.
-                            state.enforcement == EnforcementStatus.UNDER_TEST ->
-                                getString(R.string.tile_enforcement_testing)
+                            // The tile can act on this build, but nothing observable can show the
+                            // limit holding — say so rather than print the reassuring access label.
+                            state.enforcement == EnforcementStatus.UNVERIFIED ->
+                                getString(R.string.tile_enforcement_unverified)
                             else -> (state.access?.label ?: state.adapterName)
                                 .get(this@ChargeTileService)
                         },

--- a/app/src/main/java/eu/darken/amply/main/ui/widget/AmplyWidget.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/widget/AmplyWidget.kt
@@ -302,12 +302,17 @@ internal fun statusLine(
         )
     }
     val label = widgetLabel(context, state.observation.policyOrNull() ?: requestedTarget)
-    // While a build is under verification the setting is real but its effect is not established, so
-    // the widget must not put a bare "Limited to 80%" on the home screen.
-    return if (state.enforcement == EnforcementStatus.UNDER_TEST) {
-        context.getString(R.string.widget_status_testing_suffix, label)
-    } else {
-        label
+    // The enforcement tier is resolved BEFORE the steady label, not as a special case after it: the
+    // label falls back to the last requested target, which survives a refutation and an OTA that
+    // resets a confirmed build to candidate. Only a confirmed build — or an adapter the question
+    // doesn't apply to — may put a bare "Limited to 80%" on the home screen.
+    return when (state.enforcement) {
+        // Controls are withheld on both of these, so whatever was once requested is not in force.
+        EnforcementStatus.CANDIDATE -> context.getString(R.string.widget_status_enforcement_candidate)
+        EnforcementStatus.REFUTED -> context.getString(R.string.widget_status_enforcement_refuted)
+        // Under test the setting is real but its effect is not established yet.
+        EnforcementStatus.UNDER_TEST -> context.getString(R.string.widget_status_testing_suffix, label)
+        EnforcementStatus.CONFIRMED, null -> label
     }
 }
 

--- a/app/src/main/java/eu/darken/amply/main/ui/widget/AmplyWidget.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/widget/AmplyWidget.kt
@@ -310,8 +310,8 @@ internal fun statusLine(
         // Controls are withheld on both of these, so whatever was once requested is not in force.
         EnforcementStatus.CANDIDATE -> context.getString(R.string.widget_status_enforcement_candidate)
         EnforcementStatus.REFUTED -> context.getString(R.string.widget_status_enforcement_refuted)
-        // Under test the setting is real but its effect is not established yet.
-        EnforcementStatus.UNDER_TEST -> context.getString(R.string.widget_status_testing_suffix, label)
+        // The setting is real, but nothing observable can show the hardware acting on it.
+        EnforcementStatus.UNVERIFIED -> context.getString(R.string.widget_status_unverified_suffix, label)
         EnforcementStatus.CONFIRMED, null -> label
     }
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/widget/AmplyWidget.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/widget/AmplyWidget.kt
@@ -52,6 +52,7 @@ import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.ChargingPreferences
 import eu.darken.amply.charging.core.ChargingRepository
 import eu.darken.amply.charging.core.ChargingState
+import eu.darken.amply.charging.core.enforcement.EnforcementStatus
 import eu.darken.amply.charging.core.isAwaitingReplug
 import eu.darken.amply.charging.core.isSettling
 import eu.darken.amply.charging.core.settlingTarget
@@ -269,7 +270,7 @@ internal fun widgetDisplay(state: ChargingState, sessionActive: Boolean, now: Lo
  * which is unreliable given Glance's widget-session caching). Derived from the requested target because
  * observation alone degrades to Unknown on WSS-only.
  */
-private fun statusLine(
+internal fun statusLine(
     context: Context,
     sessionActive: Boolean,
     settling: Boolean,
@@ -300,7 +301,14 @@ private fun statusLine(
             widgetLabel(context, state.settlingTarget() ?: requestedTarget),
         )
     }
-    return widgetLabel(context, state.observation.policyOrNull() ?: requestedTarget)
+    val label = widgetLabel(context, state.observation.policyOrNull() ?: requestedTarget)
+    // While a build is under verification the setting is real but its effect is not established, so
+    // the widget must not put a bare "Limited to 80%" on the home screen.
+    return if (state.enforcement == EnforcementStatus.UNDER_TEST) {
+        context.getString(R.string.widget_status_testing_suffix, label)
+    } else {
+        label
+    }
 }
 
 /** "∞ <limit>" — the adapter's protective default, e.g. ∞80% on Pixel, ∞Auto on Xiaomi. */

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="tile_active">Restore limit</string>
     <string name="tile_override_active">Temporary override active</string>
     <string name="tile_replug_hint">Replug to apply</string>
+    <string name="tile_enforcement_testing">Charge limiting not verified yet</string>
     <string name="tile_applying">Applying…</string>
     <string name="widget_description">Amply charge controls</string>
     <string name="session_channel_name">Full charge and restore</string>
@@ -379,6 +380,16 @@
     <string name="dashboard_waiting_target">Waiting for the system to switch to %1$s. This can take about 15 seconds…</string>
     <string name="dashboard_waiting_replug">Takes effect the next time you unplug and replug the charger</string>
     <string name="dashboard_hw_unconfirmed">The charging hardware hasn\'t confirmed %1$s yet. It may not be applying</string>
+
+    <!-- Enforcement verification (adapters where a setting can read back while the hardware ignores it) -->
+    <string name="dashboard_enforcement_candidate_title">Charge limiting is unverified here</string>
+    <string name="dashboard_enforcement_candidate_body">Your build accepts a charge limit, but whether the charging hardware actually honours it differs from build to build, so Amply can\'t offer the controls yet. Run a check on this device: Amply watches one charge and switches the controls on only if the battery really stops at the limit.</string>
+    <string name="dashboard_enforcement_candidate_action">Verify on this device</string>
+    <string name="dashboard_enforcement_testing_title">Verifying charge limiting</string>
+    <string name="dashboard_enforcement_testing_body">The controls are available, but nothing here proves the limit yet. Set a limit, then charge from below it and leave the charger connected: Amply confirms once the battery is observed holding at the limit, and switches the controls back off if it charges past it.</string>
+    <string name="dashboard_enforcement_testing_note">Set, but hardware enforcement is not verified on this build yet</string>
+    <string name="dashboard_enforcement_refuted_title">Charge limiting does not work on this build</string>
+    <string name="dashboard_enforcement_refuted_body">Your build accepted the limit and then charged past it, so the charging hardware is ignoring it. Amply has switched its charging controls off here rather than show a protection that isn\'t real. A report helps get this build looked at.</string>
     <string name="dashboard_settling_fallback_target">the new policy</string>
     <string name="dashboard_session_once_title" formatted="false">Charging to 100% once</string>
     <string name="dashboard_session_returns">%1$s will return automatically at 100%% or when you unplug.</string>
@@ -541,6 +552,7 @@
     <string name="widget_status_charging_replug" formatted="false">1×100% · replug to start</string>
     <string name="widget_status_waiting_suffix">%1$s · waiting for system…</string>
     <string name="widget_status_replug_suffix">%1$s · replug to apply</string>
+    <string name="widget_status_testing_suffix">%1$s · not verified yet</string>
     <string name="widget_label_limited">Limited to %1$d%%</string>
     <string name="widget_label_unlimited" formatted="false">Unlimited (100%)</string>
     <string name="widget_label_adaptive">Adaptive charging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="tile_active">Restore limit</string>
     <string name="tile_override_active">Temporary override active</string>
     <string name="tile_replug_hint">Replug to apply</string>
-    <string name="tile_enforcement_testing">Charge limiting not verified yet</string>
+    <string name="tile_enforcement_unverified">Charge limiting not confirmed on this build</string>
     <string name="tile_applying">Applying…</string>
     <string name="widget_description">Amply charge controls</string>
     <string name="session_channel_name">Full charge and restore</string>
@@ -144,7 +144,7 @@
     <string name="adapter_detail_requires_lineageos">Requires a qualified LineageOS device</string>
     <string name="adapter_detail_lineageos_no_provider">LineageOS charging control is not available on this build</string>
     <string name="adapter_detail_lineageos_ready">Charging control requires Shizuku on this device</string>
-    <string name="adapter_detail_enforcement_candidate">Charge limiting has not been verified on this build yet</string>
+    <string name="adapter_detail_enforcement_candidate">Charge limiting is not confirmed on this build</string>
     <string name="adapter_detail_enforcement_refuted">This build charged past the limit it accepted, so charging control is switched off</string>
     <string name="adapter_detail_none">No charging adapter is known for this device</string>
 
@@ -381,13 +381,13 @@
     <string name="dashboard_waiting_replug">Takes effect the next time you unplug and replug the charger</string>
     <string name="dashboard_hw_unconfirmed">The charging hardware hasn\'t confirmed %1$s yet. It may not be applying</string>
 
-    <!-- Enforcement verification (adapters where a setting can read back while the hardware ignores it) -->
-    <string name="dashboard_enforcement_candidate_title">Charge limiting is unverified here</string>
-    <string name="dashboard_enforcement_candidate_body">Your build accepts a charge limit, but whether the charging hardware actually honours it differs from build to build, so Amply can\'t offer the controls yet. Run a check on this device: Amply watches one charge and switches the controls on only if the battery really stops at the limit.</string>
-    <string name="dashboard_enforcement_candidate_action">Verify on this device</string>
-    <string name="dashboard_enforcement_testing_title">Verifying charge limiting</string>
-    <string name="dashboard_enforcement_testing_body">The controls are available, but nothing here proves the limit yet. Set a limit, then charge from below it and leave the charger connected: Amply confirms once the battery is observed holding at the limit, and switches the controls back off if it charges past it.</string>
-    <string name="dashboard_enforcement_testing_note">Set, but hardware enforcement is not verified on this build yet</string>
+    <!-- Enforcement tier (adapters where a setting can read back while the hardware ignores it) -->
+    <string name="dashboard_enforcement_candidate_title">Charge limiting is not confirmed here</string>
+    <string name="dashboard_enforcement_candidate_body">Your build accepts a charge limit, but whether the charging hardware actually honours it differs from build to build, and Amply can\'t tell from the outside: a battery resting below the limit looks the same as one paused by heat or a weak charger. You can switch the controls on anyway. Amply won\'t claim the limit is working, and it turns the controls off again if it ever sees the battery charge past the limit.</string>
+    <string name="dashboard_enforcement_candidate_action">Enable anyway</string>
+    <string name="dashboard_enforcement_unverified_title">Charge limit not confirmed</string>
+    <string name="dashboard_enforcement_unverified_body">The controls are available, but nothing Amply can see proves the limit works on this build. It keeps watching for the opposite: if the battery is observed charging past the limit, Amply switches its charging controls back off.</string>
+    <string name="dashboard_enforcement_unverified_note">Set, but not confirmed to work on this build</string>
     <string name="dashboard_enforcement_refuted_title">Charge limiting does not work on this build</string>
     <string name="dashboard_enforcement_refuted_body">Your build accepted the limit and then charged past it, so the charging hardware is ignoring it. Amply has switched its charging controls off here rather than show a protection that isn\'t real. A report helps get this build looked at.</string>
     <string name="dashboard_settling_fallback_target">the new policy</string>
@@ -552,8 +552,8 @@
     <string name="widget_status_charging_replug" formatted="false">1×100% · replug to start</string>
     <string name="widget_status_waiting_suffix">%1$s · waiting for system…</string>
     <string name="widget_status_replug_suffix">%1$s · replug to apply</string>
-    <string name="widget_status_testing_suffix">%1$s · not verified yet</string>
-    <string name="widget_status_enforcement_candidate">Charge limiting not verified</string>
+    <string name="widget_status_unverified_suffix">%1$s · not confirmed</string>
+    <string name="widget_status_enforcement_candidate">Charge limiting off (unconfirmed)</string>
     <string name="widget_status_enforcement_refuted">Charge limiting unavailable</string>
     <string name="widget_label_limited">Limited to %1$d%%</string>
     <string name="widget_label_unlimited" formatted="false">Unlimited (100%)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -390,6 +390,11 @@
     <string name="dashboard_enforcement_unverified_note">Set, but not confirmed to work on this build</string>
     <string name="dashboard_enforcement_refuted_title">Charge limiting does not work on this build</string>
     <string name="dashboard_enforcement_refuted_body">Your build accepted the limit and then charged past it, so the charging hardware is ignoring it. Amply has switched its charging controls off here rather than show a protection that isn\'t real. A report helps get this build looked at.</string>
+    <!-- Hero wording for the tiers that keep the controls off: the device is matched, so the generic
+         "unsupported device" line would contradict the card right below it. -->
+    <string name="dashboard_enforcement_candidate_hero_title">Charging control is not switched on</string>
+    <string name="dashboard_enforcement_candidate_hero_body">Amply can control charging on this build, it just can\'t confirm the limit holds. The card below switches it on anyway.</string>
+    <string name="dashboard_enforcement_refuted_hero_title">Charge limiting doesn\'t work here</string>
     <string name="dashboard_settling_fallback_target">the new policy</string>
     <string name="dashboard_session_once_title" formatted="false">Charging to 100% once</string>
     <string name="dashboard_session_returns">%1$s will return automatically at 100%% or when you unplug.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -553,6 +553,8 @@
     <string name="widget_status_waiting_suffix">%1$s · waiting for system…</string>
     <string name="widget_status_replug_suffix">%1$s · replug to apply</string>
     <string name="widget_status_testing_suffix">%1$s · not verified yet</string>
+    <string name="widget_status_enforcement_candidate">Charge limiting not verified</string>
+    <string name="widget_status_enforcement_refuted">Charge limiting unavailable</string>
     <string name="widget_label_limited">Limited to %1$d%%</string>
     <string name="widget_label_unlimited" formatted="false">Unlimited (100%)</string>
     <string name="widget_label_adaptive">Adaptive charging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,6 +143,8 @@
     <string name="adapter_detail_requires_lineageos">Requires a qualified LineageOS device</string>
     <string name="adapter_detail_lineageos_no_provider">LineageOS charging control is not available on this build</string>
     <string name="adapter_detail_lineageos_ready">Charging control requires Shizuku on this device</string>
+    <string name="adapter_detail_enforcement_candidate">Charge limiting has not been verified on this build yet</string>
+    <string name="adapter_detail_enforcement_refuted">This build charged past the limit it accepted, so charging control is switched off</string>
     <string name="adapter_detail_none">No charging adapter is known for this device</string>
 
     <!-- Access backend detail + summary labels -->

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryPersistenceTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryPersistenceTest.kt
@@ -17,6 +17,8 @@ import eu.darken.amply.charging.core.access.LineageSettingsClient
 import eu.darken.amply.charging.core.access.ShizukuSettingsBackend
 import eu.darken.amply.charging.core.access.shizuku.ShizukuController
 import eu.darken.amply.charging.core.access.shizuku.ShizukuInstallationDetector
+import eu.darken.amply.charging.core.enforcement.BuildIdentitySource
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceStore
 import eu.darken.amply.charging.core.adapter.AdapterRegistry
 import eu.darken.amply.charging.core.adapter.GrapheneOsChargingAdapter
 import eu.darken.amply.charging.core.adapter.LineageChargingAdapter
@@ -73,6 +75,12 @@ class ChargingRepositoryPersistenceTest {
     private lateinit var preferences: ChargingPreferences
     private lateinit var repository: ChargingRepository
 
+    // This test drives the Pixel adapter, which needs no enforcement evidence; a fixed identity keeps
+    // the store deterministic.
+    private val buildIdentity = object : BuildIdentitySource {
+        override fun current() = "test-build"
+    }
+
     @Before
     fun setup() {
         // Satisfy the Pixel capability gate: Google manufacturer, a supported model, telephony, and a
@@ -127,6 +135,8 @@ class ChargingRepositoryPersistenceTest {
                 override fun schedule(requestedAtMillis: Long) = Unit
             },
             batteryReader = BatteryReader(context),
+            evidenceStore = EnforcementEvidenceStore(appDataStore, buildIdentity, SerializationModule.json()),
+            buildIdentity = buildIdentity,
         )
     }
 

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryRestoreGateTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryRestoreGateTest.kt
@@ -33,6 +33,8 @@ import eu.darken.amply.charging.core.enforcement.EnforcementVerdict
 import eu.darken.amply.charging.core.enforcement.EnforcementVerdictEngine
 import eu.darken.amply.common.AppDataStore
 import eu.darken.amply.common.serialization.SerializationModule
+import eu.darken.amply.fullcharge.core.RecoveryOrigin
+import eu.darken.amply.fullcharge.core.writeRecoveryTarget
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.CoroutineScope
@@ -170,6 +172,37 @@ class ChargingRepositoryRestoreGateTest {
             .observation.shouldBeInstanceOf<ChargeObservation.Unsupported>()
 
         repository.restorePersistent(ChargePolicy.FixedLimit(80), forceNotify = true)
+            .observation.shouldBeInstanceOf<ChargeObservation.Unknown>()
+    }
+
+    /**
+     * The recovery dispatch, which is where the bypass could leak: `setPersistentPolicy` persists its
+     * target BEFORE the risky write, so a process death or a failed write leaves a *fresh user
+     * choice* as pending recovery work. Boot recovery must write that one through the gate — the
+     * build can have become a candidate (an OTA changes the composite build identity) or been refuted
+     * meanwhile — while an owed session restore keeps its bypass.
+     */
+    @Test
+    fun `a candidate build gates a pending user request but not an owed restore`() = runTest {
+        repository.writeRecoveryTarget(ChargePolicy.Unrestricted, RecoveryOrigin.USER_REQUEST).let {
+            it.success shouldBe false
+            it.observation.shouldBeInstanceOf<ChargeObservation.Unsupported>()
+        }
+
+        repository.writeRecoveryTarget(ChargePolicy.FixedLimit(80), RecoveryOrigin.SESSION_RESTORE)
+            .observation.shouldBeInstanceOf<ChargeObservation.Unknown>()
+    }
+
+    @Test
+    fun `a refuted build gates a pending user request but not an owed restore`() = runTest {
+        refute()
+
+        repository.writeRecoveryTarget(ChargePolicy.Unrestricted, RecoveryOrigin.USER_REQUEST).let {
+            it.success shouldBe false
+            it.observation.shouldBeInstanceOf<ChargeObservation.Unsupported>()
+        }
+
+        repository.writeRecoveryTarget(ChargePolicy.FixedLimit(80), RecoveryOrigin.SESSION_RESTORE)
             .observation.shouldBeInstanceOf<ChargeObservation.Unknown>()
     }
 

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryRestoreGateTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryRestoreGateTest.kt
@@ -1,0 +1,185 @@
+package eu.darken.amply.charging.core
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.content.pm.ProviderInfo
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.battery.core.BatteryReader
+import eu.darken.amply.charging.core.access.AccessResolver
+import eu.darken.amply.charging.core.access.DirectSettingsBackend
+import eu.darken.amply.charging.core.access.LineageSettingsClient
+import eu.darken.amply.charging.core.access.ShizukuSettingsBackend
+import eu.darken.amply.charging.core.access.shizuku.ShizukuController
+import eu.darken.amply.charging.core.access.shizuku.ShizukuInstallationDetector
+import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.adapter.GrapheneOsChargingAdapter
+import eu.darken.amply.charging.core.adapter.LineageChargingAdapter
+import eu.darken.amply.charging.core.adapter.LineageLabAdapter
+import eu.darken.amply.charging.core.adapter.OnePlusChargingAdapter
+import eu.darken.amply.charging.core.adapter.OnePlusLabAdapter
+import eu.darken.amply.charging.core.adapter.PixelChargingAdapter
+import eu.darken.amply.charging.core.adapter.SamsungLabAdapter
+import eu.darken.amply.charging.core.adapter.SamsungLegacyChargingAdapter
+import eu.darken.amply.charging.core.adapter.SamsungModernChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiHyperOs3ChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiLabAdapter
+import eu.darken.amply.charging.core.enforcement.BuildIdentitySource
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidence
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceStore
+import eu.darken.amply.charging.core.enforcement.EnforcementVerdict
+import eu.darken.amply.charging.core.enforcement.EnforcementVerdictEngine
+import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.serialization.SerializationModule
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * The enforcement gate withholds NEW control on a build whose hardware was never observed honouring
+ * a cap. It must never withhold the repayment of a protective policy the user already had: a
+ * confirmed LineageOS device with an open full-charge session that installs a nightly comes back
+ * with a changed build identity — a candidate again — while still owing an 80% restore. Refusing
+ * that write leaves the device configured Unrestricted, which is what the gate exists to prevent.
+ *
+ * Both paths fail here (WRITE_SECURE_SETTINGS cannot write the Lineage provider), so the assertion
+ * is on *where* they fail: the gated apply never reaches the adapter (Unsupported, the gate's
+ * reason), while the restore reaches the write and fails there (Unknown).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36])
+class ChargingRepositoryRestoreGateTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val storeScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    private val buildIdentity = object : BuildIdentitySource {
+        override fun current() = "test-build"
+    }
+
+    private lateinit var evidenceStore: EnforcementEvidenceStore
+    private lateinit var repository: ChargingRepository
+
+    @Before
+    fun setup() {
+        // A LineageOS build as the app can actually see it: the system feature (the ro.lineage.*
+        // properties are SELinux-denied) plus the private settings provider. QUALIFIED_CODENAMES
+        // ships empty, so this device is a CANDIDATE with control gated off.
+        val shadowPackageManager = shadowOf(context.packageManager)
+        shadowPackageManager.setSystemFeature(DeviceInfo.FEATURE_LINEAGE_OS, true)
+        shadowPackageManager.addOrUpdateProvider(
+            ProviderInfo().apply {
+                authority = DeviceInfo.LINEAGE_SETTINGS_AUTHORITY
+                packageName = "org.lineageos.lineagesettings"
+                name = "org.lineageos.lineagesettings.LineageSettingsProvider"
+            },
+        )
+        shadowOf(context as Application).grantPermissions(Manifest.permission.WRITE_SECURE_SETTINGS)
+
+        val appDataStore = AppDataStore(
+            PreferenceDataStoreFactory.create(scope = storeScope) {
+                File(tempFolder.root, "test.preferences_pb")
+            },
+        )
+        val json = SerializationModule.json()
+        evidenceStore = EnforcementEvidenceStore(appDataStore, buildIdentity, json)
+        val shizukuController = ShizukuController(context, ShizukuInstallationDetector(context))
+        repository = ChargingRepository(
+            context = context,
+            registry = AdapterRegistry(
+                context = context,
+                lineage = LineageChargingAdapter(LineageSettingsClient(context)),
+                lineageLab = LineageLabAdapter(),
+                grapheneOs = GrapheneOsChargingAdapter(),
+                pixel = PixelChargingAdapter(),
+                samsungModern = SamsungModernChargingAdapter(),
+                samsungLegacy = SamsungLegacyChargingAdapter(),
+                samsungLab = SamsungLabAdapter(),
+                xiaomi = XiaomiChargingAdapter(),
+                xiaomiHyperOs3 = XiaomiHyperOs3ChargingAdapter(),
+                xiaomiLab = XiaomiLabAdapter(),
+                onePlus = OnePlusChargingAdapter(),
+                onePlusLab = OnePlusLabAdapter(),
+            ),
+            accessResolver = AccessResolver(
+                direct = DirectSettingsBackend(context),
+                shizuku = ShizukuSettingsBackend(shizukuController),
+            ),
+            preferences = ChargingPreferences(appDataStore, json),
+            shizukuController = shizukuController,
+            settleScheduler = object : SettleScheduler {
+                override fun schedule(requestedAtMillis: Long) = Unit
+            },
+            batteryReader = BatteryReader(context),
+            evidenceStore = evidenceStore,
+            buildIdentity = buildIdentity,
+        )
+    }
+
+    @After
+    fun teardown() {
+        storeScope.cancel()
+    }
+
+    private suspend fun refute() = evidenceStore.record(
+        EnforcementEvidence(
+            adapterId = "lineageos-chargingcontrol-v1",
+            buildIdentity = buildIdentity.current(),
+            algorithmVersion = EnforcementVerdictEngine.ALGORITHM_VERSION,
+            verdict = EnforcementVerdict.REFUTED,
+            capPercent = 80,
+            observedPercent = 90,
+            observedAtWallMillis = 1_000L,
+        ),
+    ) shouldBe true
+
+    @Test
+    fun `a candidate build refuses a fresh user apply but still repays a restore`() = runTest {
+        val fresh = repository.applyPersistent(ChargePolicy.FixedLimit(80))
+        fresh.success shouldBe false
+        fresh.observation.shouldBeInstanceOf<ChargeObservation.Unsupported>()
+
+        // The persisted restore obligation gets past the tier and is attempted against the adapter.
+        repository.restorePersistent(ChargePolicy.FixedLimit(80))
+            .observation.shouldBeInstanceOf<ChargeObservation.Unknown>()
+    }
+
+    @Test
+    fun `a refuted build refuses a fresh user apply but still repays a restore`() = runTest {
+        refute()
+
+        repository.applyPersistent(ChargePolicy.FixedLimit(80))
+            .observation.shouldBeInstanceOf<ChargeObservation.Unsupported>()
+
+        repository.restorePersistent(ChargePolicy.FixedLimit(80), forceNotify = true)
+            .observation.shouldBeInstanceOf<ChargeObservation.Unknown>()
+    }
+
+    @Test
+    fun `the restore path still enforces the adapter's own preconditions`() = runTest {
+        // Not an evidence question: Adaptive is not in the Lineage adapter's supported policies, so
+        // the restore must refuse it exactly like an ordinary apply would.
+        repository.restorePersistent(ChargePolicy.Adaptive).let {
+            it.success shouldBe false
+            it.observation.shouldBeInstanceOf<ChargeObservation.Unsupported>()
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/amply/charging/core/DeviceInfoLineageDetectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/DeviceInfoLineageDetectionTest.kt
@@ -17,6 +17,7 @@ import eu.darken.amply.charging.core.adapter.SamsungModernChargingAdapter
 import eu.darken.amply.charging.core.adapter.XiaomiChargingAdapter
 import eu.darken.amply.charging.core.adapter.XiaomiHyperOs3ChargingAdapter
 import eu.darken.amply.charging.core.adapter.XiaomiLabAdapter
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceState
 import eu.darken.amply.common.ca.toCaString
 import io.kotest.matchers.shouldBe
 import org.junit.Test
@@ -86,7 +87,7 @@ class DeviceInfoLineageDetectionTest {
         // The whole chain the bug broke: PackageManager → DeviceInfo.current → AdapterRegistry.
         shadowOf(context.packageManager).setSystemFeature(DeviceInfo.FEATURE_LINEAGE_OS, true)
 
-        val selection = registry.select(DeviceInfo.current(context))
+        val selection = registry.select(DeviceInfo.current(context), EnforcementEvidenceState.Absent)
 
         selection.adapter?.id shouldBe "lineageos-lab"
         selection.support.contributionWanted shouldBe true
@@ -96,7 +97,7 @@ class DeviceInfoLineageDetectionTest {
     fun `without the feature the same device is not routed to a lineage adapter`() {
         shadowOf(context.packageManager).setSystemFeature(DeviceInfo.FEATURE_LINEAGE_OS, false)
 
-        val selection = registry.select(DeviceInfo.current(context))
+        val selection = registry.select(DeviceInfo.current(context), EnforcementEvidenceState.Absent)
 
         selection.adapter?.id shouldBe null
     }

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
@@ -296,10 +296,10 @@ class AdapterRegistrySelectionTest {
     }
 
     @Test
-    fun `a secondary user is never offered a verification it cannot complete`() {
-        // The probe's own gate (the keys are device-wide, sessions are per-user) is not something a
-        // verification can answer: the recorder refuses to observe off the system user and canApply
-        // stays false, so an offered check would never finish. Enforcement stays unset, and the
+    fun `a secondary user is never offered an opt-in that changes nothing`() {
+        // The probe's own gate (the keys are device-wide, sessions are per-user) is not something the
+        // opt-in can answer: the recorder refuses to observe off the system user and canApply stays
+        // false, so accepting the build would enable nothing. Enforcement stays unset, and the
         // specific probe reason survives instead of being replaced by the gate's text.
         listOf(
             EnforcementEvidenceState.Absent,
@@ -332,20 +332,20 @@ class AdapterRegistrySelectionTest {
     }
 
     @Test
-    fun `a started verification enables control without claiming enforcement`() {
+    fun `accepting an unconfirmed build enables control without claiming enforcement`() {
         val selection = select(lineage(codename = "raven"), verificationStarted = true)
         selection.support.controlEnabled shouldBe true
-        selection.support.enforcement shouldBe EnforcementStatus.UNDER_TEST
+        selection.support.enforcement shouldBe EnforcementStatus.UNVERIFIED
     }
 
     @Test
-    fun `a local confirmation enables control`() {
-        val selection = select(
-            lineage(codename = "raven"),
-            evidence = lineageEvidence(EnforcementVerdict.CONFIRMED),
-        )
-        selection.support.controlEnabled shouldBe true
-        selection.support.enforcement shouldBe EnforcementStatus.CONFIRMED
+    fun `only a maintainer qualification can reach the confirmed tier`() {
+        // Local observation cannot confirm a cap at all (see EnforcementVerdictEngine), so an
+        // unqualified codename never leaves the candidate/unverified tiers however much it is observed.
+        select(lineage(codename = "raven")).support.enforcement shouldBe EnforcementStatus.CANDIDATE
+        select(lineage(codename = "raven"), verificationStarted = true).support.enforcement shouldBe
+            EnforcementStatus.UNVERIFIED
+        select(lineage(codename = "oriole")).support.enforcement shouldBe EnforcementStatus.CONFIRMED
     }
 
     @Test
@@ -368,9 +368,11 @@ class AdapterRegistrySelectionTest {
 
     @Test
     fun `evidence recorded for a different adapter does not apply`() {
+        // A refutation of the GrapheneOS adapter says nothing about the Lineage one, so the device
+        // stays an ordinary candidate instead of being locked out by someone else's verdict.
         val selection = select(
             lineage(codename = "raven"),
-            evidence = lineageEvidence(EnforcementVerdict.CONFIRMED, adapterId = "grapheneos-chargelimit-v1"),
+            evidence = lineageEvidence(EnforcementVerdict.REFUTED, adapterId = "grapheneos-chargelimit-v1"),
         )
         selection.support.controlEnabled shouldBe false
         selection.support.enforcement shouldBe EnforcementStatus.CANDIDATE

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
@@ -1,22 +1,36 @@
 package eu.darken.amply.charging.core.adapter
 
+import android.content.Context
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.R
 import eu.darken.amply.charging.core.DeviceInfo
 import eu.darken.amply.charging.core.SettingProbe
 import eu.darken.amply.charging.core.access.LineageChargeReadout
 import eu.darken.amply.charging.core.access.LineageChargeReader
+import eu.darken.amply.charging.core.enforcement.BuildIdentitySource
 import eu.darken.amply.charging.core.enforcement.EnforcementEvidence
 import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceState
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceStore
 import eu.darken.amply.charging.core.enforcement.EnforcementStatus
 import eu.darken.amply.charging.core.enforcement.EnforcementVerdict
 import eu.darken.amply.charging.core.enforcement.EnforcementVerdictEngine
+import eu.darken.amply.common.AppDataStore
 import eu.darken.amply.common.ca.toCaString
+import eu.darken.amply.common.serialization.SerializationModule
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.io.File
 
 /**
  * Registry-level selection: the first matched adapter wins, so the Samsung adapters' matched
@@ -364,6 +378,51 @@ class AdapterRegistrySelectionTest {
             selection.support.contributionWanted shouldBe true
             selection.support.detail shouldBe R.string.adapter_detail_enforcement_refuted
         }
+    }
+
+    @Test
+    fun `a refutation recorded under the old algorithm version still disables control`() {
+        // The regression an algorithm-version bump invites: the user accepted the unconfirmed build
+        // (the opt-in is retained across updates), the device was then observed charging past its cap
+        // under version 1, and the app updated. Reading that stored refutation as "no evidence" would
+        // hand control straight back — through UNVERIFIED, silently — to the exact hardware this gate
+        // exists to keep it away from.
+        val raw = """
+            {"adapterId":"lineageos-chargingcontrol-v1","buildIdentity":"build-a","algorithmVersion":1,
+            "verdict":"REFUTED","capPercent":80,"observedPercent":84,"observedAtWallMillis":1000}
+        """.trimIndent()
+        val storeScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        val stored = try {
+            val appDataStore = AppDataStore(
+                PreferenceDataStoreFactory.create(scope = storeScope) {
+                    File(
+                        ApplicationProvider.getApplicationContext<Context>().cacheDir,
+                        "enforcement-migration-${System.nanoTime()}.preferences_pb",
+                    )
+                },
+            )
+            val store = EnforcementEvidenceStore(
+                appDataStore,
+                object : BuildIdentitySource {
+                    override fun current() = "build-a"
+                },
+                SerializationModule.json(),
+            )
+            runBlocking {
+                appDataStore.store.edit { it[stringPreferencesKey("enforcement.evidence.v1")] = raw }
+                store.currentState()
+            }
+        } finally {
+            storeScope.cancel()
+        }
+
+        val selection = select(
+            lineage(codename = "raven"),
+            evidence = stored,
+            verificationStarted = true,
+        )
+        selection.support.controlEnabled shouldBe false
+        selection.support.enforcement shouldBe EnforcementStatus.REFUTED
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
@@ -1,10 +1,16 @@
 package eu.darken.amply.charging.core.adapter
 
 import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.R
 import eu.darken.amply.charging.core.DeviceInfo
 import eu.darken.amply.charging.core.SettingProbe
 import eu.darken.amply.charging.core.access.LineageChargeReadout
 import eu.darken.amply.charging.core.access.LineageChargeReader
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidence
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceState
+import eu.darken.amply.charging.core.enforcement.EnforcementStatus
+import eu.darken.amply.charging.core.enforcement.EnforcementVerdict
+import eu.darken.amply.charging.core.enforcement.EnforcementVerdictEngine
 import eu.darken.amply.common.ca.toCaString
 import io.kotest.matchers.shouldBe
 import org.junit.Test
@@ -42,6 +48,31 @@ class AdapterRegistrySelectionTest {
         onePlusLab = OnePlusLabAdapter(),
     )
 
+    /**
+     * Every case that isn't about the enforcement gate runs with no stored evidence and no started
+     * verification — the shipped default on a fresh install.
+     */
+    private fun select(
+        device: DeviceInfo,
+        evidence: EnforcementEvidenceState = EnforcementEvidenceState.Absent,
+        verificationStarted: Boolean = false,
+    ) = registry.select(device, evidence, verificationStarted)
+
+    private fun lineageEvidence(
+        verdict: EnforcementVerdict,
+        adapterId: String = "lineageos-chargingcontrol-v1",
+    ) = EnforcementEvidenceState.Present(
+        EnforcementEvidence(
+            adapterId = adapterId,
+            buildIdentity = "build-a",
+            algorithmVersion = EnforcementVerdictEngine.ALGORITHM_VERSION,
+            verdict = verdict,
+            capPercent = 80,
+            observedPercent = 80,
+            observedAtWallMillis = 1_000L,
+        ),
+    )
+
     private fun samsung(oneUi: Int?) = DeviceInfo(
         manufacturer = "samsung",
         model = "SM-TEST",
@@ -54,21 +85,21 @@ class AdapterRegistrySelectionTest {
 
     @Test
     fun `one ui 8 selects the modern adapter with control`() {
-        val selection = registry.select(samsung(80000))
+        val selection = select(samsung(80000))
         selection.adapter?.id shouldBe "samsung-oneui8-v1"
         selection.support.controlEnabled shouldBe true
     }
 
     @Test
     fun `one ui 4 and 5 select the legacy adapter`() {
-        registry.select(samsung(40100)).adapter?.id shouldBe "samsung-legacy-v1"
-        registry.select(samsung(50100)).adapter?.id shouldBe "samsung-legacy-v1"
+        select(samsung(40100)).adapter?.id shouldBe "samsung-legacy-v1"
+        select(samsung(50100)).adapter?.id shouldBe "samsung-legacy-v1"
     }
 
     @Test
     fun `unverified one ui versions fall through to the diagnostics lab adapter`() {
         listOf(30000, 60000, 61000, 70000, 90000, null).forEach { oneUi ->
-            val selection = registry.select(samsung(oneUi))
+            val selection = select(samsung(oneUi))
             selection.adapter?.id shouldBe "samsung-lab"
             selection.support.controlEnabled shouldBe false
         }
@@ -76,7 +107,7 @@ class AdapterRegistrySelectionTest {
 
     @Test
     fun `pixel still selects the pixel adapter`() {
-        val selection = registry.select(
+        val selection = select(
             DeviceInfo("Google", "Pixel 8", 36, "test", hasChargingOptimization = true),
         )
         selection.adapter?.id shouldBe "google-pixel-lab-v1"
@@ -102,7 +133,7 @@ class AdapterRegistrySelectionTest {
     fun `grapheneos selects its live adapter ahead of the pixel adapter`() {
         // Without the ordering, the Pixel probe (any Google/Pixel*) would swallow the device as a
         // matched-but-diagnostics-only stock Pixel.
-        val selection = registry.select(graphene())
+        val selection = select(graphene())
         selection.adapter?.id shouldBe "grapheneos-chargelimit-v1"
         selection.support.controlEnabled shouldBe true
     }
@@ -111,7 +142,7 @@ class AdapterRegistrySelectionTest {
     fun `grapheneos keeps control without the key probe`() {
         // The real-device shape: @Protected denies the unprivileged probe, so the key always reads
         // absent from app context (issue-#49 beta report) — control must not gate on it.
-        val selection = registry.select(graphene(key = false))
+        val selection = select(graphene(key = false))
         selection.adapter?.id shouldBe "grapheneos-chargelimit-v1"
         selection.support.controlEnabled shouldBe true
         selection.support.contributionWanted shouldBe false
@@ -120,7 +151,7 @@ class AdapterRegistrySelectionTest {
     @Test
     fun `a stock pixel with the key present is not treated as grapheneos`() {
         // Identity is packages-only: the key alone must fall through to the Pixel adapter.
-        val selection = registry.select(
+        val selection = select(
             graphene(packages = false).copy(hasChargingOptimization = true),
         )
         selection.adapter?.id shouldBe "google-pixel-lab-v1"
@@ -131,40 +162,40 @@ class AdapterRegistrySelectionTest {
         // Both are ROM-identity adapters; a LineageOS Pixel carries the Lineage feature and no
         // graphene packages, so ordering only matters for hypothetical both-signal devices — the
         // Lineage pair stays first.
-        registry.select(lineageWithDeniedProperty("komodo", "Google")).adapter?.id shouldBe "lineageos-lab"
+        select(lineageWithDeniedProperty("komodo", "Google")).adapter?.id shouldBe "lineageos-chargingcontrol-v1"
     }
 
     @Test
     fun `any HyperOS 2 xiaomi selects the live adapter`() {
-        val selection = registry.select(
+        val selection = select(
             DeviceInfo("Xiaomi", "2306EPN60G", 35, "test", hyperOsVersion = 2, isSystemUser = true),
         )
         selection.adapter?.id shouldBe "xiaomi-hyperos2-v1"
         selection.support.controlEnabled shouldBe true
 
         // A different HyperOS 2 model selects the live adapter too (ROM-version gate, not model).
-        registry.select(
+        select(
             DeviceInfo("Xiaomi", "23078PND5G", 35, "test", hyperOsVersion = 2, isSystemUser = true),
         ).adapter?.id shouldBe "xiaomi-hyperos2-v1"
     }
 
     @Test
     fun `non-HyperOS-2 xiaomi devices fall through to the xiaomi lab adapter`() {
-        registry.select(
+        select(
             DeviceInfo("Xiaomi", "2306EPN60G", 35, "test", hyperOsVersion = 1),
         ).adapter?.id shouldBe "xiaomi-lab"
         // HyperOS 3 without a qualified codename falls through via the hyperos3 allowlist.
-        registry.select(
+        select(
             DeviceInfo("Xiaomi", "2306EPN60G", 35, "test", hyperOsVersion = 3),
         ).adapter?.id shouldBe "xiaomi-lab"
-        registry.select(
+        select(
             DeviceInfo("Xiaomi", "M2101K6G", 33, "test"),
         ).adapter?.id shouldBe "xiaomi-lab"
     }
 
     @Test
     fun `a qualified HyperOS 3 codename selects the hyperos3 adapter with control`() {
-        val selection = registry.select(
+        val selection = select(
             DeviceInfo("Xiaomi", "24117RN76G", 36, "test", codename = "tanzanite", hyperOsVersion = 3, isSystemUser = true),
         )
         selection.adapter?.id shouldBe "xiaomi-hyperos3-v1"
@@ -175,11 +206,11 @@ class AdapterRegistrySelectionTest {
     fun `an unqualified HyperOS 3 codename falls through to the xiaomi lab adapter`() {
         // marblein (HyperOS 3.0.2) carries only the two HyperOS-2-style modes — the reason the
         // hyperos3 gate is a codename allowlist and not version-only.
-        registry.select(
+        select(
             DeviceInfo("Xiaomi", "23049PCD8I", 35, "test", codename = "marblein", hyperOsVersion = 3, isSystemUser = true),
         ).adapter?.id shouldBe "xiaomi-lab"
         // A future HyperOS major falls through too, even on a qualified codename.
-        registry.select(
+        select(
             DeviceInfo("Xiaomi", "24117RN76G", 37, "test", codename = "tanzanite", hyperOsVersion = 4, isSystemUser = true),
         ).adapter?.id shouldBe "xiaomi-lab"
     }
@@ -187,7 +218,7 @@ class AdapterRegistrySelectionTest {
     @Test
     fun `ColorOS 15 oplus devices select the live adapter across the family`() {
         listOf("OnePlus", "OPPO", "realme").forEach { manufacturer ->
-            val selection = registry.select(
+            val selection = select(
                 DeviceInfo(manufacturer, "CPH2621", 35, "test", oplusRomVersion = 15, isSystemUser = true),
             )
             selection.adapter?.id shouldBe "oplus-coloros15-v1"
@@ -197,14 +228,14 @@ class AdapterRegistrySelectionTest {
 
     @Test
     fun `unqualified oplus devices fall through to the oneplus lab adapter`() {
-        registry.select(
+        select(
             DeviceInfo("OnePlus", "CPH2621", 35, "test", oplusRomVersion = 14),
         ).adapter?.id shouldBe "oneplus-lab"
         // No oplus ROM property (older device / non-Oplus that still reports the brand) → lab.
-        registry.select(
+        select(
             DeviceInfo("OnePlus", "CPH2621", 34, "test"),
         ).adapter?.id shouldBe "oneplus-lab"
-        registry.select(
+        select(
             DeviceInfo("realme", "RMX3999", 34, "test"),
         ).adapter?.id shouldBe "oneplus-lab"
     }
@@ -240,84 +271,178 @@ class AdapterRegistrySelectionTest {
     ) = lineage(codename = codename, manufacturer = manufacturer, version = null, feature = true)
 
     @Test
-    fun `a qualified lineageos codename selects the live adapter with control`() {
-        val selection = registry.select(lineage(codename = "oriole"))
+    fun `a maintainer-qualified lineageos codename keeps control without local evidence`() {
+        val selection = select(lineage(codename = "oriole"))
         selection.adapter?.id shouldBe "lineageos-chargingcontrol-v1"
         selection.support.controlEnabled shouldBe true
+        selection.support.enforcement shouldBe EnforcementStatus.CONFIRMED
     }
 
     @Test
-    fun `a qualified lineageos device without the provider matches but disables control`() {
-        val selection = registry.select(lineage(codename = "oriole", provider = false))
-        selection.adapter?.id shouldBe "lineageos-chargingcontrol-v1"
+    fun `a lineageos device without the provider falls through to the lab adapter`() {
+        // There is nothing to write without the provider, so the live adapter no longer matches at all —
+        // those devices get the generic lab diagnostics text instead of the old provider-specific note.
+        val selection = select(lineage(codename = "oriole", provider = false))
+        selection.adapter?.id shouldBe "lineageos-lab"
         selection.support.controlEnabled shouldBe false
+        selection.support.enforcement shouldBe null
     }
 
     @Test
     fun `a secondary user on a qualified lineageos device disables control`() {
-        val selection = registry.select(lineage(codename = "oriole", systemUser = false))
+        val selection = select(lineage(codename = "oriole", systemUser = false))
         selection.adapter?.id shouldBe "lineageos-chargingcontrol-v1"
         selection.support.controlEnabled shouldBe false
     }
 
     @Test
-    fun `an unqualified lineageos codename falls through to the lineage lab adapter`() {
-        val selection = registry.select(lineage(codename = "raven")) // Pixel 6 Pro, not yet qualified
-        selection.adapter?.id shouldBe "lineageos-lab"
+    fun `an unqualified lineageos device is a candidate with control off`() {
+        // The device is now reachable by the live adapter (that is the point of the widening), but until
+        // enforcement is observed it must not be handed controls that present as protection.
+        val selection = select(lineage(codename = "raven")) // Pixel 6 Pro, never qualified
+        selection.adapter?.id shouldBe "lineageos-chargingcontrol-v1"
         selection.support.controlEnabled shouldBe false
+        selection.support.enforcement shouldBe EnforcementStatus.CANDIDATE
+        selection.support.detail shouldBe R.string.adapter_detail_enforcement_candidate
+    }
+
+    @Test
+    fun `a started verification enables control without claiming enforcement`() {
+        val selection = select(lineage(codename = "raven"), verificationStarted = true)
+        selection.support.controlEnabled shouldBe true
+        selection.support.enforcement shouldBe EnforcementStatus.UNDER_TEST
+    }
+
+    @Test
+    fun `a local confirmation enables control`() {
+        val selection = select(
+            lineage(codename = "raven"),
+            evidence = lineageEvidence(EnforcementVerdict.CONFIRMED),
+        )
+        selection.support.controlEnabled shouldBe true
+        selection.support.enforcement shouldBe EnforcementStatus.CONFIRMED
+    }
+
+    @Test
+    fun `a refutation disables control and beats everything else`() {
+        // Even with the verification opt-in still set, and even on a maintainer-qualified codename:
+        // this build was observed charging past the cap it accepted.
+        listOf("raven", "oriole").forEach { codename ->
+            val selection = select(
+                lineage(codename = codename),
+                evidence = lineageEvidence(EnforcementVerdict.REFUTED),
+                verificationStarted = true,
+            )
+            selection.adapter?.id shouldBe "lineageos-chargingcontrol-v1"
+            selection.support.controlEnabled shouldBe false
+            selection.support.enforcement shouldBe EnforcementStatus.REFUTED
+            selection.support.contributionWanted shouldBe true
+            selection.support.detail shouldBe R.string.adapter_detail_enforcement_refuted
+        }
+    }
+
+    @Test
+    fun `evidence recorded for a different adapter does not apply`() {
+        val selection = select(
+            lineage(codename = "raven"),
+            evidence = lineageEvidence(EnforcementVerdict.CONFIRMED, adapterId = "grapheneos-chargelimit-v1"),
+        )
+        selection.support.controlEnabled shouldBe false
+        selection.support.enforcement shouldBe EnforcementStatus.CANDIDATE
+    }
+
+    @Test
+    fun `loading and corrupt evidence both fail closed`() {
+        // Loading is "not read yet" and must never be mistaken for "nothing stored"…
+        select(lineage(codename = "raven"), evidence = EnforcementEvidenceState.Loading).support.let {
+            it.controlEnabled shouldBe false
+            it.enforcement shouldBe EnforcementStatus.CANDIDATE
+        }
+        // …and an undecodable record may be a refutation, so it is treated as one.
+        select(
+            lineage(codename = "raven"),
+            evidence = EnforcementEvidenceState.Corrupt,
+            verificationStarted = true,
+        ).support.let {
+            it.controlEnabled shouldBe false
+            it.enforcement shouldBe EnforcementStatus.REFUTED
+        }
+    }
+
+    @Test
+    fun `adapters that need no evidence are untouched by the gate`() {
+        listOf(
+            EnforcementEvidenceState.Loading,
+            EnforcementEvidenceState.Corrupt,
+            lineageEvidence(EnforcementVerdict.REFUTED, adapterId = "samsung-oneui8-v1"),
+        ).forEach { evidence ->
+            val selection = select(samsung(80000), evidence = evidence)
+            selection.adapter?.id shouldBe "samsung-oneui8-v1"
+            selection.support.controlEnabled shouldBe true
+            selection.support.enforcement shouldBe null
+        }
     }
 
     @Test
     fun `a lineageos build on OEM hardware is handled by lineage, never the OEM lab adapter`() {
         // The Lineage adapters precede all OEM adapters, so a custom-ROM build on Samsung/Xiaomi/OnePlus
         // hardware is never swallowed by a manufacturer-based lab adapter.
-        registry.select(lineage(codename = "gts9", manufacturer = "samsung")).adapter?.id shouldBe "lineageos-lab"
-        registry.select(lineage(codename = "munch", manufacturer = "Xiaomi")).adapter?.id shouldBe "lineageos-lab"
-        registry.select(lineage(codename = "salami", manufacturer = "OnePlus")).adapter?.id shouldBe "lineageos-lab"
+        select(lineage(codename = "gts9", manufacturer = "samsung")).adapter?.id shouldBe
+            "lineageos-chargingcontrol-v1"
+        select(lineage(codename = "munch", manufacturer = "Xiaomi")).adapter?.id shouldBe
+            "lineageos-chargingcontrol-v1"
+        select(lineage(codename = "salami", manufacturer = "OnePlus")).adapter?.id shouldBe
+            "lineageos-chargingcontrol-v1"
+        // A provider-less derivative still lands on the Lineage lab adapter, not the OEM one.
+        select(lineage(codename = "gts9", manufacturer = "samsung", provider = false)).adapter?.id shouldBe
+            "lineageos-lab"
     }
 
     @Test
     fun `a stock device is unaffected by the lineage adapters`() {
         // Neither signal set → both Lineage adapters skip, OEM matching proceeds as before.
-        registry.select(samsung(80000)).adapter?.id shouldBe "samsung-oneui8-v1"
+        select(samsung(80000)).adapter?.id shouldBe "samsung-oneui8-v1"
     }
 
     @Test
     fun `a qualified lineageos device is selected when only the system feature is readable`() {
-        val selection = registry.select(lineageWithDeniedProperty(codename = "oriole"))
+        val selection = select(lineageWithDeniedProperty(codename = "oriole"))
         selection.adapter?.id shouldBe "lineageos-chargingcontrol-v1"
         selection.support.controlEnabled shouldBe true
     }
 
     @Test
-    fun `an unqualified lineageos device falls to the lineage lab adapter without the version property`() {
+    fun `an unqualified lineageos device is still routed to lineage without the version property`() {
         // The Pixel 6 / LineageOS 23.2 case: previously selected google-pixel-lab-v1, which hid the
         // contribution wizard (contributionWanted defaults false on the Pixel adapter) and pointed
         // "open battery settings" at Battery Saver instead of Battery.
-        val selection = registry.select(lineageWithDeniedProperty(codename = "raven"))
-        selection.adapter?.id shouldBe "lineageos-lab"
-        selection.support.contributionWanted shouldBe true
+        val selection = select(lineageWithDeniedProperty(codename = "raven"))
+        selection.adapter?.id shouldBe "lineageos-chargingcontrol-v1"
+        selection.support.enforcement shouldBe EnforcementStatus.CANDIDATE
     }
 
     @Test
     fun `the guided capture wizard is withheld on lineageos but still offered to OEM lab devices`() {
         // On LineageOS the keys are already mapped and live outside the wizard's capture set, so a guided run
         // always diffs to empty and cannot be delivered — the contribution goes through the direct report.
-        val lineage = registry.select(lineageWithDeniedProperty(codename = "raven")).support
+        val lineage = select(
+            lineageWithDeniedProperty(codename = "raven"),
+            evidence = lineageEvidence(EnforcementVerdict.REFUTED),
+        ).support
         lineage.contributionWanted shouldBe true
         lineage.guidedCaptureUseful shouldBe false
 
         // An unmapped OEM is the case the wizard exists for; it must be unaffected.
-        val samsung = registry.select(samsung(oneUi = null)).support
+        val samsung = select(samsung(oneUi = null)).support
         samsung.contributionWanted shouldBe true
         samsung.guidedCaptureUseful shouldBe true
     }
 
     @Test
     fun `lineageos on OEM hardware is never swallowed by an OEM adapter without the version property`() {
-        registry.select(lineageWithDeniedProperty("gts9", "samsung")).adapter?.id shouldBe "lineageos-lab"
-        registry.select(lineageWithDeniedProperty("munch", "Xiaomi")).adapter?.id shouldBe "lineageos-lab"
-        registry.select(lineageWithDeniedProperty("salami", "OnePlus")).adapter?.id shouldBe "lineageos-lab"
-        registry.select(lineageWithDeniedProperty("bluejay", "Google")).adapter?.id shouldBe "lineageos-lab"
+        select(lineageWithDeniedProperty("gts9", "samsung")).adapter?.id shouldBe "lineageos-chargingcontrol-v1"
+        select(lineageWithDeniedProperty("munch", "Xiaomi")).adapter?.id shouldBe "lineageos-chargingcontrol-v1"
+        select(lineageWithDeniedProperty("salami", "OnePlus")).adapter?.id shouldBe "lineageos-chargingcontrol-v1"
+        select(lineageWithDeniedProperty("bluejay", "Google")).adapter?.id shouldBe "lineageos-chargingcontrol-v1"
     }
 }

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/AdapterRegistrySelectionTest.kt
@@ -296,6 +296,31 @@ class AdapterRegistrySelectionTest {
     }
 
     @Test
+    fun `a secondary user is never offered a verification it cannot complete`() {
+        // The probe's own gate (the keys are device-wide, sessions are per-user) is not something a
+        // verification can answer: the recorder refuses to observe off the system user and canApply
+        // stays false, so an offered check would never finish. Enforcement stays unset, and the
+        // specific probe reason survives instead of being replaced by the gate's text.
+        listOf(
+            EnforcementEvidenceState.Absent,
+            EnforcementEvidenceState.Loading,
+            EnforcementEvidenceState.Corrupt,
+            lineageEvidence(EnforcementVerdict.REFUTED),
+        ).forEach { evidence ->
+            listOf(false, true).forEach { started ->
+                val support = select(
+                    lineage(codename = "raven", systemUser = false),
+                    evidence = evidence,
+                    verificationStarted = started,
+                ).support
+                support.controlEnabled shouldBe false
+                support.enforcement shouldBe null
+                support.detail shouldBe R.string.adapter_detail_secondary_user
+            }
+        }
+    }
+
+    @Test
     fun `an unqualified lineageos device is a candidate with control off`() {
         // The device is now reachable by the live adapter (that is the point of the widening), but until
         // enforcement is observed it must not be handed controls that present as protection.

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/ContributionEligibilityTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/ContributionEligibilityTest.kt
@@ -6,6 +6,10 @@ import eu.darken.amply.charging.core.DeviceInfo
 import eu.darken.amply.charging.core.SettingProbe
 import eu.darken.amply.charging.core.access.LineageChargeReadout
 import eu.darken.amply.charging.core.access.LineageChargeReader
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidence
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceState
+import eu.darken.amply.charging.core.enforcement.EnforcementVerdict
+import eu.darken.amply.charging.core.enforcement.EnforcementVerdictEngine
 import eu.darken.amply.common.ca.toCaString
 import io.kotest.matchers.shouldBe
 import org.junit.Test
@@ -35,6 +39,13 @@ class ContributionEligibilityTest {
         onePlusLab = OnePlusLabAdapter(),
     )
 
+    /** Nothing here is about the enforcement gate, so every case runs with the fresh-install default. */
+    private fun select(
+        device: DeviceInfo,
+        evidence: EnforcementEvidenceState = EnforcementEvidenceState.Absent,
+        verificationStarted: Boolean = false,
+    ) = registry.select(device, evidence, verificationStarted)
+
     private fun device(manufacturer: String, model: String = "X", sdk: Int = 35) = DeviceInfo(
         manufacturer = manufacturer,
         model = model,
@@ -46,14 +57,14 @@ class ContributionEligibilityTest {
 
     @Test
     fun `unknown OEM is a wanted contribution`() {
-        val support = registry.select(device("Sony")).support
+        val support = select(device("Sony")).support
         support.matched shouldBe false
         support.contributionWanted shouldBe true
     }
 
     @Test
     fun `unqualified xiaomi is matched by the lab adapter and wants contributions`() {
-        val support = registry.select(device("Xiaomi")).support
+        val support = select(device("Xiaomi")).support
         support.matched shouldBe true
         support.contributionWanted shouldBe true
     }
@@ -61,15 +72,15 @@ class ContributionEligibilityTest {
     @Test
     fun `samsung and oplus family diagnostics-only adapters want contributions`() {
         // No version signal → the live adapters don't match; the lab adapters handle these.
-        registry.select(device("Samsung")).support.contributionWanted shouldBe true
-        registry.select(device("OnePlus")).support.contributionWanted shouldBe true
-        registry.select(device("Oppo")).support.contributionWanted shouldBe true
-        registry.select(device("realme")).support.contributionWanted shouldBe true
+        select(device("Samsung")).support.contributionWanted shouldBe true
+        select(device("OnePlus")).support.contributionWanted shouldBe true
+        select(device("Oppo")).support.contributionWanted shouldBe true
+        select(device("realme")).support.contributionWanted shouldBe true
     }
 
     @Test
     fun `supported pixel does not solicit a contribution`() {
-        val support = registry.select(device("Google", model = "Pixel 8")).support
+        val support = select(device("Google", model = "Pixel 8")).support
         support.matched shouldBe true
         support.contributionWanted shouldBe false
     }
@@ -84,16 +95,41 @@ class ContributionEligibilityTest {
                 hasGrapheneOsPackages = true,
                 batteryChargeLimitProbe = SettingProbe.PRESENT,
             )
-        registry.select(ready).support.contributionWanted shouldBe false
-        registry.select(ready.copy(batteryChargeLimitProbe = SettingProbe.ABSENT))
+        select(ready).support.contributionWanted shouldBe false
+        select(ready.copy(batteryChargeLimitProbe = SettingProbe.ABSENT))
             .support.contributionWanted shouldBe false
+    }
+
+    @Test
+    fun `an unverified lineageos device is not a contribution target, a refuted one is`() {
+        val device = device("Google", model = "Pixel 6").copy(
+            codename = "raven",
+            hasLineageFeature = true,
+            hasLineageSettingsProvider = true,
+        )
+        // Nothing to report yet: the device just hasn't been verified, and the dashboard asks the user
+        // to run the verification instead.
+        select(device).support.contributionWanted shouldBe false
+        // A build that accepted the limit and charged past it anyway is exactly what a maintainer wants.
+        val refuted = EnforcementEvidenceState.Present(
+            EnforcementEvidence(
+                adapterId = "lineageos-chargingcontrol-v1",
+                buildIdentity = "build-a",
+                algorithmVersion = EnforcementVerdictEngine.ALGORITHM_VERSION,
+                verdict = EnforcementVerdict.REFUTED,
+                capPercent = 80,
+                observedPercent = 86,
+                observedAtWallMillis = 1_000L,
+            ),
+        )
+        select(device, evidence = refuted).support.contributionWanted shouldBe true
     }
 
     @Test
     fun `gated pixel is still not a contribution target`() {
         // Old Pixel model: matched by the Pixel adapter but control-gated — a known limitation,
         // not a new device to add support for.
-        val support = registry.select(device("Google", model = "Pixel 4", sdk = 33)).support
+        val support = select(device("Google", model = "Pixel 4", sdk = 33)).support
         support.contributionWanted shouldBe false
     }
 }

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapterTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapterTest.kt
@@ -37,36 +37,49 @@ class LineageChargingAdapterTest {
         isSystemUser = systemUser,
     )
 
-    // Gate logic is exercised through the test seam; production ships an empty allowlist (asserted below).
+    // The maintainer fast path is exercised through the test seam; production ships an empty allowlist
+    // (asserted below).
     private fun gated(vararg codenames: String) = LineageChargingAdapter(FakeLineage(), codenames.toSet())
 
     @Test
-    fun `production adapter ships lab-only with an empty qualified allowlist`() {
+    fun `the maintainer allowlist ships empty and no longer decides whether the adapter matches`() {
         LineageChargingAdapter.QUALIFIED_CODENAMES shouldBe emptySet()
-        // Even a fully-provisioned oriole is not live until a codename is qualified.
-        LineageChargingAdapter(FakeLineage()).probe(device()).matched shouldBe false
+        val production = LineageChargingAdapter(FakeLineage())
+        // Every provider-carrying LineageOS build is now handled here; enforcement evidence — not the
+        // allowlist — is what decides whether control is actually offered (see AdapterRegistry).
+        production.probe(device()).matched shouldBe true
+        production.enforcementEvidenceRequired shouldBe true
+        production.maintainerQualified(device()) shouldBe false
+        gated("oriole").maintainerQualified(device(codename = "oriole")) shouldBe true
+        gated("oriole").maintainerQualified(device(codename = "raven")) shouldBe false
     }
 
     @Test
-    fun `probe gates on qualified codename, provider, and system user`() {
-        gated("oriole").probe(device()).let {
+    fun `probe gates on lineageos identity, the provider, and the system user`() {
+        val adapter = LineageChargingAdapter(FakeLineage())
+        adapter.probe(device()).let {
             it.controlEnabled shouldBe true
             it.detail shouldBe R.string.adapter_detail_lineageos_ready
         }
-        gated("oriole").probe(device(version = null)).matched shouldBe false // not LineageOS
-        gated("oriole").probe(device(codename = "raven")).let {
-            it.matched shouldBe false // codename not in the qualified allowlist
+        // An unqualified codename is no longer a match condition.
+        adapter.probe(device(codename = "raven")).controlEnabled shouldBe true
+        adapter.probe(device(version = null)).matched shouldBe false // not LineageOS
+        adapter.probe(device(provider = false)).let {
+            // No provider means nothing to write, so this falls through to LineageLabAdapter entirely.
+            it.matched shouldBe false
             it.detail shouldBe R.string.adapter_detail_requires_lineageos
         }
-        gated("oriole").probe(device(provider = false)).let {
-            it.matched shouldBe true
-            it.controlEnabled shouldBe false
-            it.detail shouldBe R.string.adapter_detail_lineageos_no_provider
-        }
-        gated("oriole").probe(device(systemUser = false)).let {
+        adapter.probe(device(systemUser = false)).let {
             it.controlEnabled shouldBe false
             it.detail shouldBe R.string.adapter_detail_secondary_user
         }
+    }
+
+    @Test
+    fun `the guided capture wizard is never offered here`() {
+        // The three keys are already mapped and live in a provider the wizard doesn't capture, so a
+        // guided run always diffs to empty; a refuted device contributes via the direct report.
+        LineageChargingAdapter(FakeLineage()).probe(device()).guidedCaptureUseful shouldBe false
     }
 
     private suspend fun observed(enabled: String?, mode: String? = null, limit: String? = null): ChargeObservation {

--- a/app/src/test/java/eu/darken/amply/charging/core/enforcement/BuildIdentityTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/enforcement/BuildIdentityTest.kt
@@ -1,0 +1,37 @@
+package eu.darken.amply.charging.core.enforcement
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldMatch
+import org.junit.jupiter.api.Test
+
+class BuildIdentityTest {
+
+    private val stockFingerprint = "google/oriole/oriole:16/BP3A.250905.014/13640300:user/release-keys"
+
+    private fun identity(
+        fingerprint: String = stockFingerprint,
+        incremental: String = "13640300",
+        buildTime: Long = 1_762_000_000_000L,
+        providerVersion: Long = 16_000L,
+    ) = composeBuildIdentity(fingerprint, incremental, buildTime, providerVersion)
+
+    @Test
+    fun `the same build composes the same identity`() {
+        identity() shouldBe identity()
+    }
+
+    @Test
+    fun `identical fingerprints still differ per build`() {
+        // LineageOS spoofs Build.FINGERPRINT to stock, so two nightlies share it while the charging
+        // service underneath differs. Fingerprint-only scoping would keep trusting the old verdict.
+        identity() shouldNotBe identity(incremental = "13640301")
+        identity() shouldNotBe identity(buildTime = 1_763_000_000_000L)
+        identity() shouldNotBe identity(providerVersion = 16_001L)
+    }
+
+    @Test
+    fun `the identity is an opaque fixed-length token`() {
+        identity() shouldMatch Regex("[0-9a-f]{16}")
+    }
+}

--- a/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStoreTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStoreTest.kt
@@ -39,17 +39,18 @@ class EnforcementEvidenceStoreTest {
     }
 
     private fun evidence(
-        verdict: EnforcementVerdict = EnforcementVerdict.CONFIRMED,
+        verdict: EnforcementVerdict = EnforcementVerdict.REFUTED,
         buildIdentity: String = "build-a",
         algorithmVersion: Int = EnforcementVerdictEngine.ALGORITHM_VERSION,
         adapterId: String = "lineageos-chargingcontrol-v1",
+        observedPercent: Int = 80,
     ) = EnforcementEvidence(
         adapterId = adapterId,
         buildIdentity = buildIdentity,
         algorithmVersion = algorithmVersion,
         verdict = verdict,
         capPercent = 80,
-        observedPercent = 80,
+        observedPercent = observedPercent,
         observedAtWallMillis = 1_000L,
     )
 
@@ -90,43 +91,28 @@ class EnforcementEvidenceStoreTest {
     }
 
     @Test
-    fun `a confirmation never replaces a corrupt record`() = runTest {
-        // The unreadable record could be a refutation; overwriting it would reopen control.
-        writeRaw("{not json")
-        store.record(evidence(verdict = EnforcementVerdict.CONFIRMED)) shouldBe false
-        store.currentState() shouldBe EnforcementEvidenceState.Corrupt
-    }
-
-    @Test
     fun `a refutation replaces a corrupt record`() = runTest {
+        // Both fail closed, and the refutation is the more informative of the two.
         writeRaw("{not json")
-        store.record(evidence(verdict = EnforcementVerdict.REFUTED)) shouldBe true
-        store.currentState() shouldBe
-            EnforcementEvidenceState.Present(evidence(verdict = EnforcementVerdict.REFUTED))
+        store.record(evidence()) shouldBe true
+        store.currentState() shouldBe EnforcementEvidenceState.Present(evidence())
     }
 
     @Test
-    fun `a refutation overwrites a confirmation`() = runTest {
-        store.record(evidence(verdict = EnforcementVerdict.CONFIRMED)) shouldBe true
-        store.record(evidence(verdict = EnforcementVerdict.REFUTED)) shouldBe true
+    fun `a refutation is terminal and is never overwritten for the same scope`() = runTest {
+        store.record(evidence(observedPercent = 84)) shouldBe true
+        // Nothing observable can redeem the build, so a later record for the same scope is not news.
+        store.record(evidence(observedPercent = 91)) shouldBe false
         val state = store.currentState().shouldBeInstanceOf<EnforcementEvidenceState.Present>()
-        state.evidence.verdict shouldBe EnforcementVerdict.REFUTED
+        state.evidence.observedPercent shouldBe 84
     }
 
     @Test
-    fun `a confirmation does not overwrite a refutation for the same scope`() = runTest {
-        store.record(evidence(verdict = EnforcementVerdict.REFUTED)) shouldBe true
-        store.record(evidence(verdict = EnforcementVerdict.CONFIRMED)) shouldBe false
-        val state = store.currentState().shouldBeInstanceOf<EnforcementEvidenceState.Present>()
-        state.evidence.verdict shouldBe EnforcementVerdict.REFUTED
-    }
-
-    @Test
-    fun `a confirmation replaces a refutation from a different build`() = runTest {
+    fun `a refutation from a different build does not block this one`() = runTest {
         // A new ROM build is a new question; the old build's refutation says nothing about it.
-        store.record(evidence(verdict = EnforcementVerdict.REFUTED, buildIdentity = "build-b")) shouldBe true
-        store.record(evidence(verdict = EnforcementVerdict.CONFIRMED)) shouldBe true
+        store.record(evidence(buildIdentity = "build-b")) shouldBe true
+        store.record(evidence(observedPercent = 91)) shouldBe true
         val state = store.currentState().shouldBeInstanceOf<EnforcementEvidenceState.Present>()
-        state.evidence.verdict shouldBe EnforcementVerdict.CONFIRMED
+        state.evidence.observedPercent shouldBe 91
     }
 }

--- a/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStoreTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStoreTest.kt
@@ -77,21 +77,60 @@ class EnforcementEvidenceStoreTest {
     }
 
     @Test
-    fun `a record from an older algorithm version reads absent`() = runTest {
-        store.record(
-            evidence(algorithmVersion = EnforcementVerdictEngine.ALGORITHM_VERSION - 1),
-        ) shouldBe true
+    fun `a version 1 refutation survives the version bump and stays terminal`() = runTest {
+        // Version 1's heuristic also weighed a hardware signal that turned out to be session-scoped —
+        // but only its confirmation arm rested on that signal. Discarding its refutations too would
+        // fail OPEN: with the opt-in preference retained, an app update would silently re-enable
+        // control on a build already observed charging past its cap. Pinned to the literal 1 rather
+        // than ALGORITHM_VERSION - 1: the point is the specific superseded heuristic.
+        EnforcementVerdictEngine.ALGORITHM_VERSION shouldBe 2
+        writeRaw(
+            json.encodeToString(
+                EnforcementEvidence.serializer(),
+                evidence(algorithmVersion = 1, observedPercent = 84),
+            ),
+        )
+
+        // Restamped to the current version, so it still applies to this build…
+        store.currentState() shouldBe
+            EnforcementEvidenceState.Present(evidence(observedPercent = 84))
+        // …and is still terminal: a later observation must not record over it.
+        store.record(evidence(observedPercent = 91)) shouldBe false
+        val state = store.currentState().shouldBeInstanceOf<EnforcementEvidenceState.Present>()
+        state.evidence.observedPercent shouldBe 84
+    }
+
+    @Test
+    fun `a version 1 confirmation reads absent, not corrupt`() = runTest {
+        // The literal wire form a version-1 build wrote: the CONFIRMED constant no longer exists, so
+        // typed deserialization would fail and read Corrupt — which the gate treats as a refutation
+        // and would lock the device out permanently. It is worth nothing, not less than nothing.
+        writeRaw(
+            """
+            {"adapterId":"lineageos-chargingcontrol-v1","buildIdentity":"build-a","algorithmVersion":1,
+            "verdict":"CONFIRMED","capPercent":80,"observedPercent":80,"observedAtWallMillis":1000}
+            """.trimIndent(),
+        )
+
         store.currentState() shouldBe EnforcementEvidenceState.Absent
     }
 
     @Test
-    fun `a version 1 record does not count under version 2`() = runTest {
-        // Version 1's heuristic also weighed a hardware signal that turned out to be session-scoped,
-        // so its verdicts are not this version's. Pinned to the literal 1 rather than
-        // ALGORITHM_VERSION - 1: the point is the specific superseded heuristic, not "one behind".
-        EnforcementVerdictEngine.ALGORITHM_VERSION shouldBe 2
-        writeRaw(json.encodeToString(EnforcementEvidence.serializer(), evidence(algorithmVersion = 1)))
+    fun `a version 1 record with an unknown verdict reads corrupt`() = runTest {
+        writeRaw(
+            """{"buildIdentity":"build-a","algorithmVersion":1,"verdict":"SOMETHING_ELSE"}""",
+        )
 
+        store.currentState() shouldBe EnforcementEvidenceState.Corrupt
+    }
+
+    @Test
+    fun `a record from an unknown future algorithm version reads absent`() = runTest {
+        // A downgrade after a newer build wrote its own verdict: that heuristic is not this one's, and
+        // nothing here can translate it.
+        store.record(
+            evidence(algorithmVersion = EnforcementVerdictEngine.ALGORITHM_VERSION + 1),
+        ) shouldBe true
         store.currentState() shouldBe EnforcementEvidenceState.Absent
     }
 

--- a/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStoreTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStoreTest.kt
@@ -85,6 +85,17 @@ class EnforcementEvidenceStoreTest {
     }
 
     @Test
+    fun `a version 1 record does not count under version 2`() = runTest {
+        // Version 1's heuristic also weighed a hardware signal that turned out to be session-scoped,
+        // so its verdicts are not this version's. Pinned to the literal 1 rather than
+        // ALGORITHM_VERSION - 1: the point is the specific superseded heuristic, not "one behind".
+        EnforcementVerdictEngine.ALGORITHM_VERSION shouldBe 2
+        writeRaw(json.encodeToString(EnforcementEvidence.serializer(), evidence(algorithmVersion = 1)))
+
+        store.currentState() shouldBe EnforcementEvidenceState.Absent
+    }
+
+    @Test
     fun `a corrupt record reads corrupt, never absent`() = runTest {
         writeRaw("{not json")
         store.currentState() shouldBe EnforcementEvidenceState.Corrupt

--- a/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStoreTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementEvidenceStoreTest.kt
@@ -1,0 +1,132 @@
+package eu.darken.amply.charging.core.enforcement
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.serialization.SerializationModule
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class EnforcementEvidenceStoreTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    private val storeScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val json = SerializationModule.json()
+    private val appDataStore by lazy {
+        AppDataStore(
+            PreferenceDataStoreFactory.create(scope = storeScope) { File(tempDir, "test.preferences_pb") },
+        )
+    }
+    private val identity = object : BuildIdentitySource {
+        override fun current() = "build-a"
+    }
+    private val store by lazy { EnforcementEvidenceStore(appDataStore, identity, json) }
+
+    @AfterEach
+    fun teardown() {
+        storeScope.cancel()
+    }
+
+    private fun evidence(
+        verdict: EnforcementVerdict = EnforcementVerdict.CONFIRMED,
+        buildIdentity: String = "build-a",
+        algorithmVersion: Int = EnforcementVerdictEngine.ALGORITHM_VERSION,
+        adapterId: String = "lineageos-chargingcontrol-v1",
+    ) = EnforcementEvidence(
+        adapterId = adapterId,
+        buildIdentity = buildIdentity,
+        algorithmVersion = algorithmVersion,
+        verdict = verdict,
+        capPercent = 80,
+        observedPercent = 80,
+        observedAtWallMillis = 1_000L,
+    )
+
+    private suspend fun writeRaw(value: String) {
+        appDataStore.store.edit { it[stringPreferencesKey("enforcement.evidence.v1")] = value }
+    }
+
+    @Test
+    fun `nothing stored reads absent`() = runTest {
+        store.currentState() shouldBe EnforcementEvidenceState.Absent
+    }
+
+    @Test
+    fun `a recorded verdict round-trips`() = runTest {
+        store.record(evidence()) shouldBe true
+        store.currentState() shouldBe EnforcementEvidenceState.Present(evidence())
+    }
+
+    @Test
+    fun `a record from another build reads absent`() = runTest {
+        // HAL capability is build-scoped: an update can drop the LIMIT mode on identical hardware.
+        store.record(evidence(buildIdentity = "build-b")) shouldBe true
+        store.currentState() shouldBe EnforcementEvidenceState.Absent
+    }
+
+    @Test
+    fun `a record from an older algorithm version reads absent`() = runTest {
+        store.record(
+            evidence(algorithmVersion = EnforcementVerdictEngine.ALGORITHM_VERSION - 1),
+        ) shouldBe true
+        store.currentState() shouldBe EnforcementEvidenceState.Absent
+    }
+
+    @Test
+    fun `a corrupt record reads corrupt, never absent`() = runTest {
+        writeRaw("{not json")
+        store.currentState() shouldBe EnforcementEvidenceState.Corrupt
+    }
+
+    @Test
+    fun `a confirmation never replaces a corrupt record`() = runTest {
+        // The unreadable record could be a refutation; overwriting it would reopen control.
+        writeRaw("{not json")
+        store.record(evidence(verdict = EnforcementVerdict.CONFIRMED)) shouldBe false
+        store.currentState() shouldBe EnforcementEvidenceState.Corrupt
+    }
+
+    @Test
+    fun `a refutation replaces a corrupt record`() = runTest {
+        writeRaw("{not json")
+        store.record(evidence(verdict = EnforcementVerdict.REFUTED)) shouldBe true
+        store.currentState() shouldBe
+            EnforcementEvidenceState.Present(evidence(verdict = EnforcementVerdict.REFUTED))
+    }
+
+    @Test
+    fun `a refutation overwrites a confirmation`() = runTest {
+        store.record(evidence(verdict = EnforcementVerdict.CONFIRMED)) shouldBe true
+        store.record(evidence(verdict = EnforcementVerdict.REFUTED)) shouldBe true
+        val state = store.currentState().shouldBeInstanceOf<EnforcementEvidenceState.Present>()
+        state.evidence.verdict shouldBe EnforcementVerdict.REFUTED
+    }
+
+    @Test
+    fun `a confirmation does not overwrite a refutation for the same scope`() = runTest {
+        store.record(evidence(verdict = EnforcementVerdict.REFUTED)) shouldBe true
+        store.record(evidence(verdict = EnforcementVerdict.CONFIRMED)) shouldBe false
+        val state = store.currentState().shouldBeInstanceOf<EnforcementEvidenceState.Present>()
+        state.evidence.verdict shouldBe EnforcementVerdict.REFUTED
+    }
+
+    @Test
+    fun `a confirmation replaces a refutation from a different build`() = runTest {
+        // A new ROM build is a new question; the old build's refutation says nothing about it.
+        store.record(evidence(verdict = EnforcementVerdict.REFUTED, buildIdentity = "build-b")) shouldBe true
+        store.record(evidence(verdict = EnforcementVerdict.CONFIRMED)) shouldBe true
+        val state = store.currentState().shouldBeInstanceOf<EnforcementEvidenceState.Present>()
+        state.evidence.verdict shouldBe EnforcementVerdict.CONFIRMED
+    }
+}

--- a/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorderTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorderTest.kt
@@ -37,10 +37,9 @@ class EnforcementRecorderTest {
     )
 
     @Test
-    fun `a started verification with a configured cap observes`() {
+    fun `an accepted build with a configured cap observes`() {
+        // Nothing stored yet: the refutation watch is exactly what there is left to observe.
         observe() shouldBe true
-        // A confirmed device keeps observing: a build that held the cap once can still be refuted later.
-        observe(evidence = evidence(EnforcementVerdict.CONFIRMED)) shouldBe true
     }
 
     @Test
@@ -66,7 +65,7 @@ class EnforcementRecorderTest {
     }
 
     @Test
-    fun `nothing is observed before the user starts verification`() {
+    fun `nothing is observed before the user accepts the build`() {
         observe(verificationStarted = false) shouldBe false
     }
 

--- a/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorderTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementRecorderTest.kt
@@ -1,0 +1,77 @@
+package eu.darken.amply.charging.core.enforcement
+
+import eu.darken.amply.charging.core.ChargePolicy
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * The keep-alive gate behind `EnforcementWatcher.isEnabled()`. It decides whether a foreground
+ * service and its persistent notification are held up, so every "no" here matters.
+ */
+class EnforcementRecorderTest {
+
+    private fun observe(
+        evidence: EnforcementEvidenceState = EnforcementEvidenceState.Absent,
+        isSystemUser: Boolean = true,
+        adapterRequiresEvidence: Boolean = true,
+        verificationStarted: Boolean = true,
+        persistentPolicy: ChargePolicy? = ChargePolicy.FixedLimit(80),
+    ) = shouldObserveEnforcement(
+        evidence = evidence,
+        isSystemUser = isSystemUser,
+        adapterRequiresEvidence = adapterRequiresEvidence,
+        verificationStarted = verificationStarted,
+        persistentPolicy = persistentPolicy,
+    )
+
+    private fun evidence(verdict: EnforcementVerdict) = EnforcementEvidenceState.Present(
+        EnforcementEvidence(
+            adapterId = "lineageos-chargingcontrol-v1",
+            buildIdentity = "build-a",
+            algorithmVersion = EnforcementVerdictEngine.ALGORITHM_VERSION,
+            verdict = verdict,
+            capPercent = 80,
+            observedPercent = 80,
+            observedAtWallMillis = 1_000L,
+        ),
+    )
+
+    @Test
+    fun `a started verification with a configured cap observes`() {
+        observe() shouldBe true
+        // A confirmed device keeps observing: a build that held the cap once can still be refuted later.
+        observe(evidence = evidence(EnforcementVerdict.CONFIRMED)) shouldBe true
+    }
+
+    @Test
+    fun `no cap configured does not hold the service up`() {
+        // The state at boot before the user has ever applied a limit through Amply.
+        observe(persistentPolicy = null) shouldBe false
+        observe(persistentPolicy = ChargePolicy.Unrestricted) shouldBe false
+        observe(persistentPolicy = ChargePolicy.Adaptive) shouldBe false
+        // A "100% limit" caps nothing, so there is nothing to observe holding.
+        observe(persistentPolicy = ChargePolicy.FixedLimit(100)) shouldBe false
+    }
+
+    @Test
+    fun `a secondary user never observes`() {
+        observe(isSystemUser = false) shouldBe false
+    }
+
+    @Test
+    fun `a refuted or corrupt record ends observation`() {
+        // Terminal: the answer for this build is in, and an undecodable record may be that answer.
+        observe(evidence = evidence(EnforcementVerdict.REFUTED)) shouldBe false
+        observe(evidence = EnforcementEvidenceState.Corrupt) shouldBe false
+    }
+
+    @Test
+    fun `nothing is observed before the user starts verification`() {
+        observe(verificationStarted = false) shouldBe false
+    }
+
+    @Test
+    fun `adapters that need no evidence never observe`() {
+        observe(adapterRequiresEvidence = false) shouldBe false
+    }
+}

--- a/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngineTest.kt
@@ -23,6 +23,9 @@ class EnforcementVerdictEngineTest {
         policyGeneration: Long = 1L,
         plugSessionId: Long = 1L,
         batteryStatus: Int? = null,
+        // The adapter's hardware hold signal. Defaults to the behavioural `held` flag, i.e. the
+        // honest device shape: the ROM reports the hold state exactly while it is holding.
+        hardwareHold: Boolean? = held,
     ) = EnforcementSample(
         adapterId = "lineageos-chargingcontrol-v1",
         buildIdentity = "build-a",
@@ -33,6 +36,7 @@ class EnforcementVerdictEngineTest {
         batteryStatus = batteryStatus
             ?: if (held) BatteryManager.BATTERY_STATUS_NOT_CHARGING else BatteryManager.BATTERY_STATUS_CHARGING,
         chargingStatus = null,
+        hardwareHold = hardwareHold,
         currentNowMicroamps = null,
         policyGeneration = policyGeneration,
         plugSessionId = plugSessionId,
@@ -71,6 +75,36 @@ class EnforcementVerdictEngineTest {
     @Test
     fun `a rise followed by a sustained plateau confirms`() {
         run(riseThenHold(holdMinutes = 6)) shouldBe EnforcementVerdict.CONFIRMED
+    }
+
+    @Test
+    fun `a plateau without a hardware hold signal never confirms`() {
+        // The false-CONFIRM this gate exists for: a hot phone (or a weak charger) parks the battery
+        // at 75-80% under an 80% cap and reports NOT_CHARGING for well over five minutes. Behaviourally
+        // identical to a cap hold; only the hardware signal tells them apart.
+        listOf(false, null).forEach { signal ->
+            run(riseThenHold(holdMinutes = 20).map { it.copy(hardwareHold = signal) }) shouldBe null
+        }
+        // The same plateau WITH the signal is the real thing.
+        run(riseThenHold(holdMinutes = 20)) shouldBe EnforcementVerdict.CONFIRMED
+    }
+
+    @Test
+    fun `a declining level breaks the hold`() {
+        val rise = (70..cap).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
+        val hold = (0 until 6).map { sample(percent = cap, elapsed = 330_000L + it * 30_000L, held = true) }
+        // The battery starts LOSING charge while plugged, with the hold signal still set. A plateau
+        // test that only required "not increasing" would keep counting this as a hold.
+        val decline = (0 until 40).map { sample(percent = cap - 1, elapsed = 510_000L + it * 30_000L, held = true) }
+        run(rise + hold + decline) shouldBe null
+    }
+
+    @Test
+    fun `a drop clears the rise, so the plateau after it cannot confirm on its own`() {
+        val rise = (70..(cap - 1)).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
+        val drop = sample(percent = cap - 2, elapsed = 300_000L)
+        val plateau = (0 until 40).map { sample(percent = cap - 2, elapsed = 330_000L + it * 30_000L, held = true) }
+        run(rise + listOf(drop) + plateau) shouldBe null
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngineTest.kt
@@ -199,19 +199,30 @@ class EnforcementVerdictEngineTest {
     }
 
     @Test
-    fun `a device already above the cap does not refute`() {
-        // Plugged in at 95% with an 80% cap: the level was never observed climbing from inside the cap.
-        val samples = (95..99).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
-        run(samples) shouldBe null
+    fun `a resting level above the cap does not refute`() {
+        // Plugged in at 95% with an 80% cap and staying there: the device stopped charging, which is
+        // no evidence against it. Only a climb from that level is.
+        run((0 until 20).map { sample(95, it * 30_000L) }) shouldBe null
+    }
+
+    @Test
+    fun `an epoch that opens above the cap still refutes once the level climbs`() {
+        // The gap this closes: an 80% cap restored early from a full-charge session at 84% (or a
+        // process death at 82%). The old in-cap-only climb base stayed null forever, so a build that
+        // ignores the cap charged all the way to 100% without ever being refuted.
+        run(listOf(sample(84, 0L), sample(85, 30_000L))) shouldBe EnforcementVerdict.REFUTED
+        run(listOf(sample(82, 0L), sample(83, 30_000L), sample(84, 60_000L))) shouldBe
+            EnforcementVerdict.REFUTED
     }
 
     @Test
     fun `a cap change mid-epoch resets instead of refuting`() {
         // Sitting at 78% under an 80% cap, the user switches to 70%: a bare watermark would read the
-        // very next sample as "charging past 70" and refute a good device.
+        // very next sample as "charging past 70" and refute a good device. The new epoch opens above
+        // its cap, and a device that honours it simply stops charging there.
         val below = (70..78).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
-        val afterSwitch = (78..85).mapIndexed { index, percent ->
-            sample(percent, 300_000L + index * 30_000L, policyGeneration = 2L)
+        val afterSwitch = (0 until 10).map { tick ->
+            sample(78, 300_000L + tick * 30_000L, policyGeneration = 2L)
                 .copy(configured = ChargeObservation.Verified(ChargePolicy.FixedLimit(70), BackendKind.SHIZUKU))
         }
         run(below + afterSwitch) shouldBe null
@@ -219,10 +230,11 @@ class EnforcementVerdictEngineTest {
 
     @Test
     fun `a new plug session restarts the window`() {
+        // A climb of 78 → 84 inside ONE epoch refutes; split across a replug it must not, because the
+        // fresh epoch has seen no climb of its own yet.
         val first = (70..78).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
-        // Replugged already above the cap: the fresh epoch has no in-cap climb base.
-        val second = (84..90).mapIndexed { index, percent ->
-            sample(percent, 600_000L + index * 30_000L, plugSessionId = 2L)
+        val second = (0 until 10).map { tick ->
+            sample(84, 600_000L + tick * 30_000L, plugSessionId = 2L)
         }
         run(first + second) shouldBe null
     }

--- a/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngineTest.kt
@@ -1,0 +1,215 @@
+package eu.darken.amply.charging.core.enforcement
+
+import android.os.BatteryManager
+import eu.darken.amply.charging.core.BackendKind
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.common.ca.toCaString
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class EnforcementVerdictEngineTest {
+
+    private val cap = 80
+
+    private fun sample(
+        percent: Int,
+        elapsed: Long,
+        held: Boolean = false,
+        plugged: Boolean = true,
+        sessionActive: Boolean = false,
+        configured: ChargeObservation? = ChargeObservation.Verified(ChargePolicy.FixedLimit(cap), BackendKind.SHIZUKU),
+        policyGeneration: Long = 1L,
+        plugSessionId: Long = 1L,
+        batteryStatus: Int? = null,
+    ) = EnforcementSample(
+        adapterId = "lineageos-chargingcontrol-v1",
+        buildIdentity = "build-a",
+        configured = configured,
+        sessionActive = sessionActive,
+        plugged = plugged,
+        percent = percent,
+        batteryStatus = batteryStatus
+            ?: if (held) BatteryManager.BATTERY_STATUS_NOT_CHARGING else BatteryManager.BATTERY_STATUS_CHARGING,
+        chargingStatus = null,
+        currentNowMicroamps = null,
+        policyGeneration = policyGeneration,
+        plugSessionId = plugSessionId,
+        elapsedRealtimeMillis = elapsed,
+        wallMillis = 1_000L + elapsed,
+    )
+
+    /**
+     * Feed a sequence and return the FIRST verdict the engine reached, or null. The engine keeps
+     * emitting while the condition holds (the recorder is what dedupes against the store), so only
+     * the first one is meaningful here.
+     */
+    private fun run(samples: List<EnforcementSample>): EnforcementVerdict? {
+        var progress: EnforcementProgress? = null
+        var first: EnforcementVerdict? = null
+        samples.forEach {
+            val outcome = EnforcementVerdictEngine.evaluate(progress, it)
+            progress = outcome.progress
+            if (first == null) first = outcome.verdict
+        }
+        return first
+    }
+
+    /** Climb from 70% to the cap, then sit held at the cap for [holdMinutes]. */
+    private fun riseThenHold(holdMinutes: Int, holdPercent: Int = cap): List<EnforcementSample> {
+        val rise = (70..holdPercent).mapIndexed { index, percent ->
+            sample(percent = percent, elapsed = index * 30_000L)
+        }
+        val holdStart = rise.size * 30_000L
+        val hold = (0 until holdMinutes * 2).map { tick ->
+            sample(percent = holdPercent, elapsed = holdStart + tick * 30_000L, held = true)
+        }
+        return rise + hold
+    }
+
+    @Test
+    fun `a rise followed by a sustained plateau confirms`() {
+        run(riseThenHold(holdMinutes = 6)) shouldBe EnforcementVerdict.CONFIRMED
+    }
+
+    @Test
+    fun `a single held tick does not confirm`() {
+        val samples = (70..cap).mapIndexed { index, percent -> sample(percent, index * 30_000L) } +
+            sample(percent = cap, elapsed = 1_000_000L, held = true)
+        run(samples) shouldBe null
+    }
+
+    @Test
+    fun `a hold shorter than the minimum window does not confirm`() {
+        run(riseThenHold(holdMinutes = 2)) shouldBe null
+    }
+
+    @Test
+    fun `a thermal pause far below the cap does not confirm`() {
+        // Charging stalls at 60% for half an hour: heldNow is true the whole time, but the level is
+        // nowhere near the configured cap.
+        val samples = (50..60).mapIndexed { index, percent -> sample(percent, index * 30_000L) } +
+            (0 until 60).map { sample(percent = 60, elapsed = 400_000L + it * 30_000L, held = true) }
+        run(samples) shouldBe null
+    }
+
+    @Test
+    fun `a plateau without an observed rise does not confirm`() {
+        // Plugged in already sitting at the cap: nothing was observed climbing into the hold.
+        val samples = (0 until 40).map { sample(percent = cap, elapsed = it * 30_000L, held = true) }
+        run(samples) shouldBe null
+    }
+
+    @Test
+    fun `unplugged samples produce no verdict`() {
+        run(riseThenHold(holdMinutes = 6).map { it.copy(plugged = false) }) shouldBe null
+        // Charging past the cap while "unplugged" is nonsense data, not a refutation.
+        run(listOf(sample(70, 0L), sample(90, 60_000L)).map { it.copy(plugged = false) }) shouldBe null
+    }
+
+    @Test
+    fun `an active full-charge session produces no verdict`() {
+        // The session deliberately lifts the cap; charging past it proves nothing about the hardware.
+        run(listOf(sample(70, 0L), sample(90, 60_000L)).map { it.copy(sessionActive = true) }) shouldBe null
+    }
+
+    @Test
+    fun `only a verified fixed limit is evaluated`() {
+        val unevaluable = listOf(
+            ChargeObservation.Verified(ChargePolicy.Adaptive, BackendKind.SHIZUKU),
+            ChargeObservation.Verified(ChargePolicy.Unrestricted, BackendKind.SHIZUKU),
+            ChargeObservation.Verified(ChargePolicy.FixedLimit(100), BackendKind.SHIZUKU),
+            ChargeObservation.LastRequested(ChargePolicy.FixedLimit(80)),
+            ChargeObservation.Unknown("unreadable".toCaString()),
+            null,
+        )
+        unevaluable.forEach { configured ->
+            run(riseThenHold(holdMinutes = 6).map { it.copy(configured = configured) }) shouldBe null
+            run(listOf(sample(70, 0L), sample(90, 60_000L)).map { it.copy(configured = configured) }) shouldBe null
+        }
+    }
+
+    @Test
+    fun `an unknown level moves nothing`() {
+        val samples = riseThenHold(holdMinutes = 6).flatMap { listOf(it.copy(percent = -1), it) }
+        // The interleaved unknown readings neither break the climb nor advance the hold.
+        run(samples) shouldBe EnforcementVerdict.CONFIRMED
+        // And on their own they decide nothing at all.
+        run(List(50) { sample(percent = -1, elapsed = it * 30_000L, held = true) }) shouldBe null
+    }
+
+    @Test
+    fun `charging past the cap refutes`() {
+        val samples = (70..(cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)).mapIndexed { index, percent ->
+            sample(percent, index * 30_000L)
+        }
+        run(samples) shouldBe EnforcementVerdict.REFUTED
+    }
+
+    @Test
+    fun `refutation ignores the reported battery status`() {
+        // A ROM can carry the level past the cap while reporting NOT_CHARGING / FULL / UNKNOWN;
+        // gating on BATTERY_STATUS_CHARGING would leave such a build trusted indefinitely.
+        listOf(
+            BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+            BatteryManager.BATTERY_STATUS_FULL,
+            BatteryManager.BATTERY_STATUS_UNKNOWN,
+            BatteryManager.BATTERY_STATUS_DISCHARGING,
+        ).forEach { status ->
+            val samples = (70..(cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)).mapIndexed { index, percent ->
+                sample(percent, index * 30_000L, batteryStatus = status)
+            }
+            run(samples) shouldBe EnforcementVerdict.REFUTED
+        }
+    }
+
+    @Test
+    fun `a device already above the cap does not refute`() {
+        // Plugged in at 95% with an 80% cap: the level was never observed climbing from inside the cap.
+        val samples = (95..99).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
+        run(samples) shouldBe null
+    }
+
+    @Test
+    fun `a cap change mid-epoch resets instead of refuting`() {
+        // Sitting at 78% under an 80% cap, the user switches to 70%: a bare watermark would read the
+        // very next sample as "charging past 70" and refute a good device.
+        val below = (70..78).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
+        val afterSwitch = (78..85).mapIndexed { index, percent ->
+            sample(percent, 300_000L + index * 30_000L, policyGeneration = 2L)
+                .copy(configured = ChargeObservation.Verified(ChargePolicy.FixedLimit(70), BackendKind.SHIZUKU))
+        }
+        run(below + afterSwitch) shouldBe null
+    }
+
+    @Test
+    fun `a new plug session restarts the window`() {
+        val first = (70..78).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
+        // Replugged already above the cap: the fresh epoch has no in-cap climb base.
+        val second = (84..90).mapIndexed { index, percent ->
+            sample(percent, 600_000L + index * 30_000L, plugSessionId = 2L)
+        }
+        run(first + second) shouldBe null
+    }
+
+    @Test
+    fun `a cut and resumed charge still confirms`() {
+        // Charging pauses (level drops a point), resumes, then holds: the interruption must not
+        // disqualify the plateau that follows.
+        val rise = (70..78).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
+        val dip = listOf(sample(77, 300_000L), sample(78, 330_000L), sample(79, 360_000L), sample(80, 390_000L))
+        val hold = (0 until 14).map { sample(percent = cap, elapsed = 420_000L + it * 30_000L, held = true) }
+        run(rise + dip + hold) shouldBe EnforcementVerdict.CONFIRMED
+    }
+
+    @Test
+    fun `the confirm and refute bands are disjoint`() {
+        // The bands are asymmetric on purpose (hysteresis below the cap, a small allowance above it);
+        // what must never happen is one level qualifying for both verdicts.
+        val confirmBand = (cap - EnforcementVerdictEngine.HOLD_BAND)..cap
+        val refuteBand = (cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)..100
+        confirmBand.none { it in refuteBand } shouldBe true
+        refuteBand.first shouldBeGreaterThan confirmBand.last
+    }
+}

--- a/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngineTest.kt
@@ -5,9 +5,9 @@ import eu.darken.amply.charging.core.BackendKind
 import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.common.ca.toCaString
-import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
+import kotlin.random.Random
 
 class EnforcementVerdictEngineTest {
 
@@ -16,16 +16,14 @@ class EnforcementVerdictEngineTest {
     private fun sample(
         percent: Int,
         elapsed: Long,
-        held: Boolean = false,
         plugged: Boolean = true,
         sessionActive: Boolean = false,
         configured: ChargeObservation? = ChargeObservation.Verified(ChargePolicy.FixedLimit(cap), BackendKind.SHIZUKU),
         policyGeneration: Long = 1L,
         plugSessionId: Long = 1L,
-        batteryStatus: Int? = null,
-        // The adapter's hardware hold signal. Defaults to the behavioural `held` flag, i.e. the
-        // honest device shape: the ROM reports the hold state exactly while it is holding.
-        hardwareHold: Boolean? = held,
+        batteryStatus: Int? = BatteryManager.BATTERY_STATUS_CHARGING,
+        chargingStatus: Int? = null,
+        currentNowMicroamps: Int? = null,
     ) = EnforcementSample(
         adapterId = "lineageos-chargingcontrol-v1",
         buildIdentity = "build-a",
@@ -33,11 +31,9 @@ class EnforcementVerdictEngineTest {
         sessionActive = sessionActive,
         plugged = plugged,
         percent = percent,
-        batteryStatus = batteryStatus
-            ?: if (held) BatteryManager.BATTERY_STATUS_NOT_CHARGING else BatteryManager.BATTERY_STATUS_CHARGING,
-        chargingStatus = null,
-        hardwareHold = hardwareHold,
-        currentNowMicroamps = null,
+        batteryStatus = batteryStatus,
+        chargingStatus = chargingStatus,
+        currentNowMicroamps = currentNowMicroamps,
         policyGeneration = policyGeneration,
         plugSessionId = plugSessionId,
         elapsedRealtimeMillis = elapsed,
@@ -60,84 +56,135 @@ class EnforcementVerdictEngineTest {
         return first
     }
 
-    /** Climb from 70% to the cap, then sit held at the cap for [holdMinutes]. */
+    /** Climb from 70% to [holdPercent], then sit there for [holdMinutes]. */
     private fun riseThenHold(holdMinutes: Int, holdPercent: Int = cap): List<EnforcementSample> {
         val rise = (70..holdPercent).mapIndexed { index, percent ->
             sample(percent = percent, elapsed = index * 30_000L)
         }
         val holdStart = rise.size * 30_000L
         val hold = (0 until holdMinutes * 2).map { tick ->
-            sample(percent = holdPercent, elapsed = holdStart + tick * 30_000L, held = true)
+            sample(
+                percent = holdPercent,
+                elapsed = holdStart + tick * 30_000L,
+                batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+            )
         }
         return rise + hold
     }
 
     @Test
-    fun `a rise followed by a sustained plateau confirms`() {
-        run(riseThenHold(holdMinutes = 6)) shouldBe EnforcementVerdict.CONFIRMED
+    fun `a rise followed by a sustained plateau at the cap decides nothing`() {
+        // The plateau is the shape a working cap produces, and also the shape a thermal pause or a
+        // weak charger produces. Nothing observable separates them, so it stays undecided forever.
+        run(riseThenHold(holdMinutes = 6)) shouldBe null
+        run(riseThenHold(holdMinutes = 120)) shouldBe null
     }
 
     @Test
-    fun `a plateau without a hardware hold signal never confirms`() {
-        // The false-CONFIRM this gate exists for: a hot phone (or a weak charger) parks the battery
-        // at 75-80% under an 80% cap and reports NOT_CHARGING for well over five minutes. Behaviourally
-        // identical to a cap hold; only the hardware signal tells them apart.
-        listOf(false, null).forEach { signal ->
-            run(riseThenHold(holdMinutes = 20).map { it.copy(hardwareHold = signal) }) shouldBe null
+    fun `the session-scoped hardware state cannot decide anything either`() {
+        // Measured on a Pixel 6 / LineageOS 23.2: `Charging state: 4` was reported while the device
+        // was actively charging at level 70 under an 80% cap. It says "limit mode enabled for this
+        // plug session", not "charging stopped", so the engine must not read it at all.
+        val holdState = 4
+        run(riseThenHold(holdMinutes = 60).map { it.copy(chargingStatus = holdState) }) shouldBe null
+        // And it does not suppress a refutation either.
+        val climb = (70..(cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)).mapIndexed { index, percent ->
+            sample(percent, index * 30_000L, chargingStatus = holdState)
         }
-        // The same plateau WITH the signal is the real thing.
-        run(riseThenHold(holdMinutes = 20)) shouldBe EnforcementVerdict.CONFIRMED
+        run(climb) shouldBe EnforcementVerdict.REFUTED
     }
 
     @Test
-    fun `a declining level breaks the hold`() {
-        val rise = (70..cap).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
-        val hold = (0 until 6).map { sample(percent = cap, elapsed = 330_000L + it * 30_000L, held = true) }
-        // The battery starts LOSING charge while plugged, with the hold signal still set. A plateau
-        // test that only required "not increasing" would keep counting this as a hold.
-        val decline = (0 until 40).map { sample(percent = cap - 1, elapsed = 510_000L + it * 30_000L, held = true) }
-        run(rise + hold + decline) shouldBe null
+    fun `no input sequence can produce a confirmation`() {
+        // The engine has exactly one verdict, and nothing may reach a second one. Sweeps the whole
+        // input space that moves state: levels, plug state, both status fields, sessions, epochs.
+        EnforcementVerdict.entries.toList() shouldBe listOf(EnforcementVerdict.REFUTED)
+
+        val random = Random(20260816)
+        val statuses = listOf(
+            null,
+            BatteryManager.BATTERY_STATUS_CHARGING,
+            BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+            BatteryManager.BATTERY_STATUS_FULL,
+            BatteryManager.BATTERY_STATUS_DISCHARGING,
+            BatteryManager.BATTERY_STATUS_UNKNOWN,
+        )
+        val chargingStatuses = listOf(null, 1, 4, 5)
+        repeat(2_000) {
+            var progress: EnforcementProgress? = null
+            repeat(40) { tick ->
+                val candidate = sample(
+                    percent = random.nextInt(-1, 101),
+                    elapsed = tick * 30_000L,
+                    plugged = random.nextBoolean(),
+                    sessionActive = random.nextInt(10) == 0,
+                    policyGeneration = random.nextLong(1, 3),
+                    plugSessionId = random.nextLong(1, 3),
+                    batteryStatus = statuses.random(random),
+                    chargingStatus = chargingStatuses.random(random),
+                    currentNowMicroamps = random.nextInt(-2_000_000, 2_000_000),
+                )
+                val outcome = EnforcementVerdictEngine.evaluate(progress, candidate)
+                progress = outcome.progress
+                // A non-null verdict is REFUTED by construction (single-value enum); what this
+                // asserts is that every one of them is actually justified by a climb past the cap.
+                outcome.verdict?.let {
+                    it shouldBe EnforcementVerdict.REFUTED
+                    (candidate.percent >= cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE) shouldBe true
+                }
+            }
+        }
     }
 
     @Test
-    fun `a drop clears the rise, so the plateau after it cannot confirm on its own`() {
-        val rise = (70..(cap - 1)).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
-        val drop = sample(percent = cap - 2, elapsed = 300_000L)
-        val plateau = (0 until 40).map { sample(percent = cap - 2, elapsed = 330_000L + it * 30_000L, held = true) }
-        run(rise + listOf(drop) + plateau) shouldBe null
+    fun `charging past the cap refutes`() {
+        val samples = (70..(cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)).mapIndexed { index, percent ->
+            sample(percent, index * 30_000L)
+        }
+        run(samples) shouldBe EnforcementVerdict.REFUTED
     }
 
     @Test
-    fun `a single held tick does not confirm`() {
-        val samples = (70..cap).mapIndexed { index, percent -> sample(percent, index * 30_000L) } +
-            sample(percent = cap, elapsed = 1_000_000L, held = true)
+    fun `a climb that stops inside the allowance does not refute`() {
+        val samples = (70 until (cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)).mapIndexed { index, percent ->
+            sample(percent, index * 30_000L)
+        }
         run(samples) shouldBe null
     }
 
     @Test
-    fun `a hold shorter than the minimum window does not confirm`() {
-        run(riseThenHold(holdMinutes = 2)) shouldBe null
+    fun `refutation ignores the reported battery status`() {
+        // A ROM can carry the level past the cap while reporting NOT_CHARGING / FULL / UNKNOWN;
+        // gating on BATTERY_STATUS_CHARGING would leave such a build trusted indefinitely.
+        listOf(
+            BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+            BatteryManager.BATTERY_STATUS_FULL,
+            BatteryManager.BATTERY_STATUS_UNKNOWN,
+            BatteryManager.BATTERY_STATUS_DISCHARGING,
+        ).forEach { status ->
+            val samples = (70..(cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)).mapIndexed { index, percent ->
+                sample(percent, index * 30_000L, batteryStatus = status)
+            }
+            run(samples) shouldBe EnforcementVerdict.REFUTED
+        }
     }
 
     @Test
-    fun `a thermal pause far below the cap does not confirm`() {
-        // Charging stalls at 60% for half an hour: heldNow is true the whole time, but the level is
-        // nowhere near the configured cap.
-        val samples = (50..60).mapIndexed { index, percent -> sample(percent, index * 30_000L) } +
-            (0 until 60).map { sample(percent = 60, elapsed = 400_000L + it * 30_000L, held = true) }
-        run(samples) shouldBe null
-    }
-
-    @Test
-    fun `a plateau without an observed rise does not confirm`() {
-        // Plugged in already sitting at the cap: nothing was observed climbing into the hold.
-        val samples = (0 until 40).map { sample(percent = cap, elapsed = it * 30_000L, held = true) }
-        run(samples) shouldBe null
+    fun `a drop clears the rise, so the climb has to re-establish itself`() {
+        // Charging pauses and the level slips a point: the rise that follows must be observed again
+        // before anything past the cap counts as the device ignoring it.
+        val rise = (70..(cap + 1)).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
+        val drop = listOf(sample(cap, 300_000L))
+        run(rise + drop) shouldBe null
+        // Resuming from the drop and climbing on does refute.
+        val resumed = (cap..(cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)).mapIndexed { index, percent ->
+            sample(percent, 330_000L + index * 30_000L)
+        }
+        run(rise + drop + resumed) shouldBe EnforcementVerdict.REFUTED
     }
 
     @Test
     fun `unplugged samples produce no verdict`() {
-        run(riseThenHold(holdMinutes = 6).map { it.copy(plugged = false) }) shouldBe null
         // Charging past the cap while "unplugged" is nonsense data, not a refutation.
         run(listOf(sample(70, 0L), sample(90, 60_000L)).map { it.copy(plugged = false) }) shouldBe null
     }
@@ -159,43 +206,19 @@ class EnforcementVerdictEngineTest {
             null,
         )
         unevaluable.forEach { configured ->
-            run(riseThenHold(holdMinutes = 6).map { it.copy(configured = configured) }) shouldBe null
             run(listOf(sample(70, 0L), sample(90, 60_000L)).map { it.copy(configured = configured) }) shouldBe null
         }
     }
 
     @Test
     fun `an unknown level moves nothing`() {
-        val samples = riseThenHold(holdMinutes = 6).flatMap { listOf(it.copy(percent = -1), it) }
-        // The interleaved unknown readings neither break the climb nor advance the hold.
-        run(samples) shouldBe EnforcementVerdict.CONFIRMED
-        // And on their own they decide nothing at all.
-        run(List(50) { sample(percent = -1, elapsed = it * 30_000L, held = true) }) shouldBe null
-    }
-
-    @Test
-    fun `charging past the cap refutes`() {
-        val samples = (70..(cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)).mapIndexed { index, percent ->
+        val climb = (70..(cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)).mapIndexed { index, percent ->
             sample(percent, index * 30_000L)
         }
-        run(samples) shouldBe EnforcementVerdict.REFUTED
-    }
-
-    @Test
-    fun `refutation ignores the reported battery status`() {
-        // A ROM can carry the level past the cap while reporting NOT_CHARGING / FULL / UNKNOWN;
-        // gating on BATTERY_STATUS_CHARGING would leave such a build trusted indefinitely.
-        listOf(
-            BatteryManager.BATTERY_STATUS_NOT_CHARGING,
-            BatteryManager.BATTERY_STATUS_FULL,
-            BatteryManager.BATTERY_STATUS_UNKNOWN,
-            BatteryManager.BATTERY_STATUS_DISCHARGING,
-        ).forEach { status ->
-            val samples = (70..(cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)).mapIndexed { index, percent ->
-                sample(percent, index * 30_000L, batteryStatus = status)
-            }
-            run(samples) shouldBe EnforcementVerdict.REFUTED
-        }
+        // Interleaved unknown readings neither break nor advance the climb.
+        run(climb.flatMap { listOf(it.copy(percent = -1), it) }) shouldBe EnforcementVerdict.REFUTED
+        // And on their own they decide nothing at all.
+        run(List(50) { sample(percent = -1, elapsed = it * 30_000L) }) shouldBe null
     }
 
     @Test
@@ -208,8 +231,8 @@ class EnforcementVerdictEngineTest {
     @Test
     fun `an epoch that opens above the cap still refutes once the level climbs`() {
         // The gap this closes: an 80% cap restored early from a full-charge session at 84% (or a
-        // process death at 82%). The old in-cap-only climb base stayed null forever, so a build that
-        // ignores the cap charged all the way to 100% without ever being refuted.
+        // process death at 82%). An in-cap-only climb base stays null forever, so a build that
+        // ignores the cap charges all the way to 100% without ever being refuted.
         run(listOf(sample(84, 0L), sample(85, 30_000L))) shouldBe EnforcementVerdict.REFUTED
         run(listOf(sample(82, 0L), sample(83, 30_000L), sample(84, 60_000L))) shouldBe
             EnforcementVerdict.REFUTED
@@ -237,25 +260,5 @@ class EnforcementVerdictEngineTest {
             sample(84, 600_000L + tick * 30_000L, plugSessionId = 2L)
         }
         run(first + second) shouldBe null
-    }
-
-    @Test
-    fun `a cut and resumed charge still confirms`() {
-        // Charging pauses (level drops a point), resumes, then holds: the interruption must not
-        // disqualify the plateau that follows.
-        val rise = (70..78).mapIndexed { index, percent -> sample(percent, index * 30_000L) }
-        val dip = listOf(sample(77, 300_000L), sample(78, 330_000L), sample(79, 360_000L), sample(80, 390_000L))
-        val hold = (0 until 14).map { sample(percent = cap, elapsed = 420_000L + it * 30_000L, held = true) }
-        run(rise + dip + hold) shouldBe EnforcementVerdict.CONFIRMED
-    }
-
-    @Test
-    fun `the confirm and refute bands are disjoint`() {
-        // The bands are asymmetric on purpose (hysteresis below the cap, a small allowance above it);
-        // what must never happen is one level qualifying for both verdicts.
-        val confirmBand = (cap - EnforcementVerdictEngine.HOLD_BAND)..cap
-        val refuteBand = (cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)..100
-        confirmBand.none { it in refuteBand } shouldBe true
-        refuteBand.first shouldBeGreaterThan confirmBand.last
     }
 }

--- a/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngineTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/enforcement/EnforcementVerdictEngineTest.kt
@@ -1,6 +1,5 @@
 package eu.darken.amply.charging.core.enforcement
 
-import android.os.BatteryManager
 import eu.darken.amply.charging.core.BackendKind
 import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
@@ -21,9 +20,6 @@ class EnforcementVerdictEngineTest {
         configured: ChargeObservation? = ChargeObservation.Verified(ChargePolicy.FixedLimit(cap), BackendKind.SHIZUKU),
         policyGeneration: Long = 1L,
         plugSessionId: Long = 1L,
-        batteryStatus: Int? = BatteryManager.BATTERY_STATUS_CHARGING,
-        chargingStatus: Int? = null,
-        currentNowMicroamps: Int? = null,
     ) = EnforcementSample(
         adapterId = "lineageos-chargingcontrol-v1",
         buildIdentity = "build-a",
@@ -31,12 +27,8 @@ class EnforcementVerdictEngineTest {
         sessionActive = sessionActive,
         plugged = plugged,
         percent = percent,
-        batteryStatus = batteryStatus,
-        chargingStatus = chargingStatus,
-        currentNowMicroamps = currentNowMicroamps,
         policyGeneration = policyGeneration,
         plugSessionId = plugSessionId,
-        elapsedRealtimeMillis = elapsed,
         wallMillis = 1_000L + elapsed,
     )
 
@@ -63,11 +55,7 @@ class EnforcementVerdictEngineTest {
         }
         val holdStart = rise.size * 30_000L
         val hold = (0 until holdMinutes * 2).map { tick ->
-            sample(
-                percent = holdPercent,
-                elapsed = holdStart + tick * 30_000L,
-                batteryStatus = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
-            )
+            sample(percent = holdPercent, elapsed = holdStart + tick * 30_000L)
         }
         return rise + hold
     }
@@ -75,41 +63,21 @@ class EnforcementVerdictEngineTest {
     @Test
     fun `a rise followed by a sustained plateau at the cap decides nothing`() {
         // The plateau is the shape a working cap produces, and also the shape a thermal pause or a
-        // weak charger produces. Nothing observable separates them, so it stays undecided forever.
+        // weak charger produces. Nothing observable separates them, so it stays undecided forever —
+        // including the hardware charging state, which the sample deliberately no longer carries:
+        // measured on a Pixel 6 / LineageOS 23.2, `Charging state: 4` was reported while the device
+        // was actively charging at level 70 under an 80% cap.
         run(riseThenHold(holdMinutes = 6)) shouldBe null
         run(riseThenHold(holdMinutes = 120)) shouldBe null
     }
 
     @Test
-    fun `the session-scoped hardware state cannot decide anything either`() {
-        // Measured on a Pixel 6 / LineageOS 23.2: `Charging state: 4` was reported while the device
-        // was actively charging at level 70 under an 80% cap. It says "limit mode enabled for this
-        // plug session", not "charging stopped", so the engine must not read it at all.
-        val holdState = 4
-        run(riseThenHold(holdMinutes = 60).map { it.copy(chargingStatus = holdState) }) shouldBe null
-        // And it does not suppress a refutation either.
-        val climb = (70..(cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)).mapIndexed { index, percent ->
-            sample(percent, index * 30_000L, chargingStatus = holdState)
-        }
-        run(climb) shouldBe EnforcementVerdict.REFUTED
-    }
-
-    @Test
     fun `no input sequence can produce a confirmation`() {
         // The engine has exactly one verdict, and nothing may reach a second one. Sweeps the whole
-        // input space that moves state: levels, plug state, both status fields, sessions, epochs.
+        // input space that moves state: levels, plug state, sessions, epochs.
         EnforcementVerdict.entries.toList() shouldBe listOf(EnforcementVerdict.REFUTED)
 
         val random = Random(20260816)
-        val statuses = listOf(
-            null,
-            BatteryManager.BATTERY_STATUS_CHARGING,
-            BatteryManager.BATTERY_STATUS_NOT_CHARGING,
-            BatteryManager.BATTERY_STATUS_FULL,
-            BatteryManager.BATTERY_STATUS_DISCHARGING,
-            BatteryManager.BATTERY_STATUS_UNKNOWN,
-        )
-        val chargingStatuses = listOf(null, 1, 4, 5)
         repeat(2_000) {
             var progress: EnforcementProgress? = null
             repeat(40) { tick ->
@@ -120,9 +88,6 @@ class EnforcementVerdictEngineTest {
                     sessionActive = random.nextInt(10) == 0,
                     policyGeneration = random.nextLong(1, 3),
                     plugSessionId = random.nextLong(1, 3),
-                    batteryStatus = statuses.random(random),
-                    chargingStatus = chargingStatuses.random(random),
-                    currentNowMicroamps = random.nextInt(-2_000_000, 2_000_000),
                 )
                 val outcome = EnforcementVerdictEngine.evaluate(progress, candidate)
                 progress = outcome.progress
@@ -150,23 +115,6 @@ class EnforcementVerdictEngineTest {
             sample(percent, index * 30_000L)
         }
         run(samples) shouldBe null
-    }
-
-    @Test
-    fun `refutation ignores the reported battery status`() {
-        // A ROM can carry the level past the cap while reporting NOT_CHARGING / FULL / UNKNOWN;
-        // gating on BATTERY_STATUS_CHARGING would leave such a build trusted indefinitely.
-        listOf(
-            BatteryManager.BATTERY_STATUS_NOT_CHARGING,
-            BatteryManager.BATTERY_STATUS_FULL,
-            BatteryManager.BATTERY_STATUS_UNKNOWN,
-            BatteryManager.BATTERY_STATUS_DISCHARGING,
-        ).forEach { status ->
-            val samples = (70..(cap + EnforcementVerdictEngine.OVERSHOOT_ALLOWANCE)).mapIndexed { index, percent ->
-                sample(percent, index * 30_000L, batteryStatus = status)
-            }
-            run(samples) shouldBe EnforcementVerdict.REFUTED
-        }
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
+++ b/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
@@ -171,7 +171,7 @@ class StoredRecordFormatTest {
             adapterId = "lineageos-chargingcontrol-v1",
             buildIdentity = "0123456789abcdef",
             algorithmVersion = 1,
-            verdict = EnforcementVerdict.CONFIRMED,
+            verdict = EnforcementVerdict.REFUTED,
             capPercent = 80,
             observedPercent = 79,
             observedAtWallMillis = 1_700_000_000_000L,
@@ -179,7 +179,7 @@ class StoredRecordFormatTest {
 
         json.encodeToString(EnforcementEvidence.serializer(), evidence) shouldBe
             """{"adapterId":"lineageos-chargingcontrol-v1","buildIdentity":"0123456789abcdef",""" +
-            """"algorithmVersion":1,"verdict":"CONFIRMED","capPercent":80,"observedPercent":79,""" +
+            """"algorithmVersion":1,"verdict":"REFUTED","capPercent":80,"observedPercent":79,""" +
             """"observedAtWallMillis":1700000000000}"""
     }
 

--- a/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
+++ b/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
@@ -13,6 +13,7 @@ import eu.darken.amply.fullcharge.core.ChargeSessionRecord
 import eu.darken.amply.fullcharge.core.InterruptionEvent
 import eu.darken.amply.fullcharge.core.InterruptionOutcome
 import eu.darken.amply.fullcharge.core.InterruptionReason
+import eu.darken.amply.fullcharge.core.RecoveryOrigin
 import eu.darken.amply.fullcharge.core.RecoveryRecord
 import eu.darken.amply.fullcharge.core.WorkProvenance
 import eu.darken.amply.main.core.QuickAccessState
@@ -98,7 +99,8 @@ class StoredRecordFormatTest {
         // green through a @SerialName rename that would orphan every already-stored record.
         json.encodeToString(RecoveryRecord.serializer(), record) shouldBe
             """{"target":"unrestricted","workId":"wid-r",""" +
-            """"provenance":{"token":"tok-a","pid":42,"createdAtMillis":1000}}"""
+            """"provenance":{"token":"tok-a","pid":42,"createdAtMillis":1000},""" +
+            """"origin":"USER_REQUEST"}"""
     }
 
     @Test
@@ -109,7 +111,20 @@ class StoredRecordFormatTest {
             target = ChargePolicy.FixedLimit(90),
             workId = "wid-r",
             provenance = null,
+            origin = RecoveryOrigin.USER_REQUEST,
         )
+    }
+
+    /**
+     * A record written before the origin field existed must decode to the GATED path. The other
+     * default would let a fresh user write — persisted by an older build and resumed by this one —
+     * reach the ungated restore path on a build the enforcement gate refuses.
+     */
+    @Test
+    fun `a recovery record without an origin decodes as a gated user request`() {
+        json.decodeFromString(RecoveryRecord.serializer(), """{"target":"unrestricted"}""")
+            .origin shouldBe RecoveryOrigin.USER_REQUEST
+        RecoveryRecord(target = ChargePolicy.Unrestricted).origin shouldBe RecoveryOrigin.USER_REQUEST
     }
 
     @Test
@@ -125,7 +140,7 @@ class StoredRecordFormatTest {
 
         expected.forEach { (policy, wire) ->
             json.encodeToString(RecoveryRecord.serializer(), RecoveryRecord(target = policy)) shouldBe
-                """{"target":"$wire"}"""
+                """{"target":"$wire","origin":"USER_REQUEST"}"""
             json.decodeFromString(RecoveryRecord.serializer(), """{"target":"$wire"}""").target shouldBe policy
         }
     }

--- a/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
+++ b/app/src/test/java/eu/darken/amply/common/datastore/StoredRecordFormatTest.kt
@@ -2,6 +2,8 @@ package eu.darken.amply.common.datastore
 
 import eu.darken.amply.alarm.core.ChargeAlarmConfig
 import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidence
+import eu.darken.amply.charging.core.enforcement.EnforcementVerdict
 import eu.darken.amply.common.serialization.SerializationModule
 import eu.darken.amply.common.theming.ThemeColor
 import eu.darken.amply.common.theming.ThemeMode
@@ -161,6 +163,34 @@ class StoredRecordFormatTest {
 
         json.encodeToString(InterruptionEvent.serializer(), event) shouldBe
             """{"occurredAtMillis":10,"reason":"USER_STOPPED","outcome":"RESTORED_LATE","workId":"wid-1"}"""
+    }
+
+    @Test
+    fun `enforcement evidence encodes to the pinned shape`() {
+        val evidence = EnforcementEvidence(
+            adapterId = "lineageos-chargingcontrol-v1",
+            buildIdentity = "0123456789abcdef",
+            algorithmVersion = 1,
+            verdict = EnforcementVerdict.CONFIRMED,
+            capPercent = 80,
+            observedPercent = 79,
+            observedAtWallMillis = 1_700_000_000_000L,
+        )
+
+        json.encodeToString(EnforcementEvidence.serializer(), evidence) shouldBe
+            """{"adapterId":"lineageos-chargingcontrol-v1","buildIdentity":"0123456789abcdef",""" +
+            """"algorithmVersion":1,"verdict":"CONFIRMED","capPercent":80,"observedPercent":79,""" +
+            """"observedAtWallMillis":1700000000000}"""
+    }
+
+    /**
+     * A record that lost fields must never read as a claim of enforcement, so the verdict default is
+     * the refutation — the only direction that can't hand control to an unproven device.
+     */
+    @Test
+    fun `enforcement evidence defaults to the refuting verdict`() {
+        json.decodeFromString(EnforcementEvidence.serializer(), "{}") shouldBe EnforcementEvidence()
+        EnforcementEvidence().verdict shouldBe EnforcementVerdict.REFUTED
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/BootRecoveryFlowTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/BootRecoveryFlowTest.kt
@@ -6,6 +6,7 @@ import eu.darken.amply.charging.core.ChargePolicy
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
@@ -204,9 +205,51 @@ class BootRecoveryFlowTest {
         hooks.pending shouldBe null
     }
 
+    @Test
+    fun `a session-seeded target is rewritten as an owed restore`() = runTest {
+        val hooks = FakeHooks()
+
+        BootRecoveryFlow(hooks).run()
+
+        hooks.rewrites.shouldNotBeEmpty()
+        hooks.rewriteOrigins.toSet() shouldBe setOf(RecoveryOrigin.SESSION_RESTORE)
+    }
+
+    @Test
+    fun `a pending user request is rewritten as a user request, not as a restore`() = runTest {
+        // setPersistentPolicy persists its target BEFORE the write, so a process death (or a failed
+        // write) leaves a fresh user choice — Unrestricted here — as pending recovery work. Sending it
+        // down the ungated restore path would land it on a build the enforcement gate refuses.
+        val hooks = FakeHooks(
+            sessionTarget = null,
+            pending = ChargePolicy.Unrestricted,
+            pendingOrigin = RecoveryOrigin.USER_REQUEST,
+        )
+
+        BootRecoveryFlow(hooks).run()
+
+        hooks.rewrites shouldBe listOf(ChargePolicy.Unrestricted)
+        hooks.rewriteOrigins shouldBe listOf(RecoveryOrigin.USER_REQUEST)
+    }
+
+    @Test
+    fun `a pending session restore keeps the restore origin`() = runTest {
+        val hooks = FakeHooks(
+            sessionTarget = null,
+            pending = fixedLimit,
+            pendingOrigin = RecoveryOrigin.SESSION_RESTORE,
+        )
+
+        BootRecoveryFlow(hooks).run()
+
+        hooks.rewrites.shouldNotBeEmpty()
+        hooks.rewriteOrigins.toSet() shouldBe setOf(RecoveryOrigin.SESSION_RESTORE)
+    }
+
     private inner class FakeHooks(
         var sessionTarget: ChargePolicy? = fixedLimit,
         var pending: ChargePolicy? = null,
+        var pendingOrigin: RecoveryOrigin = RecoveryOrigin.USER_REQUEST,
         val restoreResult: Boolean = true,
         val rewriteResult: Boolean = true,
         var snapshot: BatterySnapshot? = BatterySnapshot(plugged = true, percent = 80, chargingState = 1),
@@ -217,12 +260,17 @@ class BootRecoveryFlowTest {
         var restoreCalls = 0
         var staleSessionDrops = 0
         val rewrites = mutableListOf<ChargePolicy>()
+        val rewriteOrigins = mutableListOf<RecoveryOrigin>()
         val failures = mutableListOf<Boolean>()
 
         override suspend fun currentSessionTarget() = sessionTarget
-        override suspend fun pendingTarget() = pending
+        override suspend fun pendingTarget() =
+            pending?.let { BootRecoveryFlow.PendingRecovery(target = it, origin = pendingOrigin) }
+
         override suspend fun setPendingTarget(policy: ChargePolicy) {
             pending = policy
+            // Mirrors the service: a target seeded from the session is an owed restore.
+            pendingOrigin = RecoveryOrigin.SESSION_RESTORE
         }
 
         override suspend fun clearPendingTarget() {
@@ -240,8 +288,9 @@ class BootRecoveryFlowTest {
             sessionTarget = null
         }
 
-        override suspend fun rewrite(policy: ChargePolicy): Boolean {
+        override suspend fun rewrite(policy: ChargePolicy, origin: RecoveryOrigin): Boolean {
             rewrites += policy
+            rewriteOrigins += origin
             return rewriteResult
         }
 

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/FullChargeStoreTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/FullChargeStoreTest.kt
@@ -112,7 +112,11 @@ class FullChargeStoreTest {
     @Test
     fun `recovery provenance round-trips including a null boot count`() = runTest {
         val provenance = WorkProvenance(token = "tok-r", pid = 99, bootCount = null, createdAtMillis = 2_500L)
-        store.setPendingRecoveryTarget(ChargePolicy.Unrestricted, provenance = provenance)
+        store.setPendingRecoveryTarget(
+            ChargePolicy.Unrestricted,
+            provenance = provenance,
+            origin = RecoveryOrigin.SESSION_RESTORE,
+        )
 
         store.pendingRecoveryProvenance() shouldBe provenance
     }
@@ -122,6 +126,7 @@ class FullChargeStoreTest {
         store.setPendingRecoveryTarget(
             ChargePolicy.Unrestricted,
             provenance = WorkProvenance("tok-r", 99, 3, 2_500L),
+            origin = RecoveryOrigin.SESSION_RESTORE,
         )
         store.clearPendingRecoveryTarget()
 
@@ -150,6 +155,7 @@ class FullChargeStoreTest {
         store.setPendingRecoveryTarget(
             ChargePolicy.Unrestricted,
             provenance = WorkProvenance("old", 1, 1, 5L),
+            origin = RecoveryOrigin.SESSION_RESTORE,
         )
         val adopted = WorkProvenance(token = "new", pid = 2, bootCount = 4, createdAtMillis = 9L)
         store.adoptRecoveryOwner(adopted)
@@ -209,7 +215,11 @@ class FullChargeStoreTest {
 
     @Test
     fun `recovery work id is written at creation and cleared with the target`() = runTest {
-        store.setPendingRecoveryTarget(ChargePolicy.Unrestricted, workId = "wid-r")
+        store.setPendingRecoveryTarget(
+            ChargePolicy.Unrestricted,
+            workId = "wid-r",
+            origin = RecoveryOrigin.SESSION_RESTORE,
+        )
         store.pendingRecoveryWorkId() shouldBe "wid-r"
 
         store.clearPendingRecoveryTarget()
@@ -234,6 +244,7 @@ class FullChargeStoreTest {
             ChargePolicy.FixedLimit(90),
             workId = "wid-r",
             provenance = WorkProvenance("tok-r", 43, 7, 1_100L),
+            origin = RecoveryOrigin.SESSION_RESTORE,
         )
         store.setLastSeenBootCount(7)
 
@@ -250,6 +261,7 @@ class FullChargeStoreTest {
             target = ChargePolicy.FixedLimit(90),
             workId = "wid-r",
             provenance = WorkProvenance("tok-r", 43, 7, 1_100L),
+            origin = RecoveryOrigin.SESSION_RESTORE,
         )
         restarted.lastSeenBootCount() shouldBe 7
     }
@@ -305,6 +317,7 @@ class FullChargeStoreTest {
             ChargePolicy.Unrestricted,
             workId = "wid-r",
             provenance = WorkProvenance("old", 1, 1, 5L),
+            origin = RecoveryOrigin.SESSION_RESTORE,
         )
         store.adoptRecoveryOwner(WorkProvenance("new", 2, 1, 9L))
 

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/InterruptionAssessorTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/InterruptionAssessorTest.kt
@@ -203,6 +203,7 @@ class InterruptionAssessorTest {
             ChargePolicy.Unrestricted,
             workId = "wid-r",
             provenance = deadProvenance(boot = 5),
+            origin = RecoveryOrigin.SESSION_RESTORE,
         )
         val pickup = assessor.captureRecoveryPickup()
         pickup.assessment.shouldNotBeNull()
@@ -223,7 +224,11 @@ class InterruptionAssessorTest {
     @Test
     fun `a recovery pickup without provenance is adopted with no assessment`() = runTest {
         bootCount = 5
-        fullChargeStore.setPendingRecoveryTarget(ChargePolicy.Unrestricted, provenance = null)
+        fullChargeStore.setPendingRecoveryTarget(
+            ChargePolicy.Unrestricted,
+            provenance = null,
+            origin = RecoveryOrigin.SESSION_RESTORE,
+        )
 
         assessor.captureRecoveryPickup().assessment shouldBe null
         fullChargeStore.pendingRecoveryProvenance()!!.token shouldBe identity.token
@@ -236,6 +241,7 @@ class InterruptionAssessorTest {
             ChargePolicy.Unrestricted,
             workId = "wid-r",
             provenance = deadProvenance(boot = 5),
+            origin = RecoveryOrigin.SESSION_RESTORE,
         )
         val pickup = assessor.captureRecoveryPickup()
 
@@ -264,6 +270,7 @@ class InterruptionAssessorTest {
             ChargePolicy.Unrestricted,
             workId = "wid-r",
             provenance = WorkProvenance(identity.token, identity.pid, 5, 5L),
+            origin = RecoveryOrigin.SESSION_RESTORE,
         )
         val pickup = assessor.captureRecoveryPickup()
         pickup.assessment shouldBe null

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardEnforcementCardTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardEnforcementCardTest.kt
@@ -102,6 +102,19 @@ class DashboardEnforcementCardTest {
     }
 
     @Test
+    fun `a secondary user is offered no verification`() {
+        // The registry leaves enforcement unset when the probe itself refused control (here: the
+        // Lineage keys are device-wide, so control is main-user only). Offering the check would start
+        // a verification the recorder never observes and that can therefore never complete.
+        var started = false
+        render(state(status = null, controlEnabled = false)) { started = true }
+
+        compose.onNodeWithTag(ENFORCEMENT_CARD_TEST_TAG).assertDoesNotExist()
+        compose.onNodeWithText(string(R.string.dashboard_enforcement_candidate_action)).assertDoesNotExist()
+        started shouldBe false
+    }
+
+    @Test
     fun `an adapter the question does not apply to shows no card at all`() {
         render(state(status = null, controlEnabled = true))
 

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardEnforcementCardTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardEnforcementCardTest.kt
@@ -63,7 +63,7 @@ class DashboardEnforcementCardTest {
     }
 
     @Test
-    fun `an unverified device explains itself and offers the check`() {
+    fun `a candidate device explains itself and offers the opt-in`() {
         var started = false
         render(state(EnforcementStatus.CANDIDATE, controlEnabled = false)) { started = true }
 
@@ -74,15 +74,15 @@ class DashboardEnforcementCardTest {
     }
 
     @Test
-    fun `a device under verification is not shown as confirmed`() {
-        render(state(EnforcementStatus.UNDER_TEST, controlEnabled = true))
+    fun `an unconfirmed device is not shown as confirmed`() {
+        render(state(EnforcementStatus.UNVERIFIED, controlEnabled = true))
 
         // The card is present…
         scrollToCard()
-        compose.onNodeWithText(string(R.string.dashboard_enforcement_testing_title)).assertExists()
+        compose.onNodeWithText(string(R.string.dashboard_enforcement_unverified_title)).assertExists()
         // …and the hero qualifies the verified read-back instead of leaving it to stand alone.
         compose.onNode(hasScrollAction()).performScrollToNode(hasTestTag(HERO_CARD_TEST_TAG))
-        compose.onNodeWithText(string(R.string.dashboard_enforcement_testing_note)).assertExists()
+        compose.onNodeWithText(string(R.string.dashboard_enforcement_unverified_note)).assertExists()
     }
 
     @Test
@@ -98,14 +98,14 @@ class DashboardEnforcementCardTest {
         render(state(EnforcementStatus.CONFIRMED, controlEnabled = true))
 
         compose.onNodeWithTag(ENFORCEMENT_CARD_TEST_TAG).assertDoesNotExist()
-        compose.onNodeWithText(string(R.string.dashboard_enforcement_testing_note)).assertDoesNotExist()
+        compose.onNodeWithText(string(R.string.dashboard_enforcement_unverified_note)).assertDoesNotExist()
     }
 
     @Test
-    fun `a secondary user is offered no verification`() {
+    fun `a secondary user is offered no opt-in`() {
         // The registry leaves enforcement unset when the probe itself refused control (here: the
-        // Lineage keys are device-wide, so control is main-user only). Offering the check would start
-        // a verification the recorder never observes and that can therefore never complete.
+        // Lineage keys are device-wide, so control is main-user only). Offering the opt-in there
+        // would enable controls that cannot write anything.
         var started = false
         render(state(status = null, controlEnabled = false)) { started = true }
 
@@ -119,6 +119,6 @@ class DashboardEnforcementCardTest {
         render(state(status = null, controlEnabled = true))
 
         compose.onNodeWithTag(ENFORCEMENT_CARD_TEST_TAG).assertDoesNotExist()
-        compose.onNodeWithText(string(R.string.dashboard_enforcement_testing_note)).assertDoesNotExist()
+        compose.onNodeWithText(string(R.string.dashboard_enforcement_unverified_note)).assertDoesNotExist()
     }
 }

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardEnforcementCardTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardEnforcementCardTest.kt
@@ -1,8 +1,10 @@
 package eu.darken.amply.main.ui.dashboard
 
 import android.app.Application
+import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -62,6 +64,11 @@ class DashboardEnforcementCardTest {
         compose.onNode(hasScrollAction()).performScrollToNode(hasTestTag(ENFORCEMENT_CARD_TEST_TAG))
     }
 
+    /** Scoped to the hero, so a string that also appears on a card further down can't satisfy it. */
+    private fun heroText(res: Int) = compose.onNode(
+        hasText(string(res)) and hasAnyAncestor(hasTestTag(HERO_CARD_TEST_TAG)),
+    )
+
     @Test
     fun `a candidate device explains itself and offers the opt-in`() {
         var started = false
@@ -71,6 +78,38 @@ class DashboardEnforcementCardTest {
         compose.onNodeWithText(string(R.string.dashboard_enforcement_candidate_title)).assertExists()
         compose.onNodeWithText(string(R.string.dashboard_enforcement_candidate_action)).performClick()
         started shouldBe true
+    }
+
+    @Test
+    fun `a candidate device is not announced as unsupported`() {
+        // The adapter matched — control is merely switched off until the user accepts it unconfirmed.
+        // The generic unsupported copy here would contradict the card directly below the hero.
+        render(state(EnforcementStatus.CANDIDATE, controlEnabled = false))
+
+        compose.onNode(hasScrollAction()).performScrollToNode(hasTestTag(HERO_CARD_TEST_TAG))
+        heroText(R.string.dashboard_status_unsupported).assertDoesNotExist()
+        heroText(R.string.dashboard_enforcement_candidate_hero_title).assertExists()
+        heroText(R.string.dashboard_enforcement_candidate_hero_body).assertExists()
+    }
+
+    @Test
+    fun `a refuted device names the refutation instead of calling itself unsupported`() {
+        render(state(EnforcementStatus.REFUTED, controlEnabled = false))
+
+        compose.onNode(hasScrollAction()).performScrollToNode(hasTestTag(HERO_CARD_TEST_TAG))
+        heroText(R.string.dashboard_status_unsupported).assertDoesNotExist()
+        heroText(R.string.dashboard_enforcement_refuted_hero_title).assertExists()
+        // The card below owns the explanation; the hero must not repeat its paragraph.
+        heroText(R.string.dashboard_enforcement_refuted_body).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a probe refusal keeps the generic unsupported wording`() {
+        // No tier at all (secondary user): nothing licenses the tier-specific copy here.
+        render(state(status = null, controlEnabled = false))
+
+        compose.onNode(hasScrollAction()).performScrollToNode(hasTestTag(HERO_CARD_TEST_TAG))
+        heroText(R.string.dashboard_status_unsupported).assertExists()
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardEnforcementCardTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardEnforcementCardTest.kt
@@ -1,0 +1,111 @@
+package eu.darken.amply.main.ui.dashboard
+
+import android.app.Application
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.R
+import eu.darken.amply.charging.core.BackendKind
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.ChargingState
+import eu.darken.amply.charging.core.enforcement.EnforcementStatus
+import eu.darken.amply.common.ca.toCaString
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The dashboard's side of the enforcement gate: a device may not present a settings read-back as
+ * protection, and a device whose controls are withheld must say why and offer the way out.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class DashboardEnforcementCardTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    private fun string(res: Int): String = context.getString(res)
+
+    private fun state(status: EnforcementStatus?, controlEnabled: Boolean) = DashboardUiState(
+        onboardingComplete = true,
+        charging = ChargingState(
+            adapterId = "lineageos-chargingcontrol-v1",
+            controlEnabled = controlEnabled,
+            enforcement = status,
+            syncVerification = true,
+            observation = if (controlEnabled) {
+                ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.SHIZUKU)
+            } else {
+                ChargeObservation.Unsupported("not verified".toCaString())
+            },
+        ),
+    )
+
+    private fun render(state: DashboardUiState, onStartVerification: () -> Unit = {}) {
+        compose.setContent {
+            DashboardScreenUnderTest(state = state, onStartVerification = onStartVerification)
+        }
+    }
+
+    private fun scrollToCard() {
+        compose.onNode(hasScrollAction()).performScrollToNode(hasTestTag(ENFORCEMENT_CARD_TEST_TAG))
+    }
+
+    @Test
+    fun `an unverified device explains itself and offers the check`() {
+        var started = false
+        render(state(EnforcementStatus.CANDIDATE, controlEnabled = false)) { started = true }
+
+        scrollToCard()
+        compose.onNodeWithText(string(R.string.dashboard_enforcement_candidate_title)).assertExists()
+        compose.onNodeWithText(string(R.string.dashboard_enforcement_candidate_action)).performClick()
+        started shouldBe true
+    }
+
+    @Test
+    fun `a device under verification is not shown as confirmed`() {
+        render(state(EnforcementStatus.UNDER_TEST, controlEnabled = true))
+
+        // The card is present…
+        scrollToCard()
+        compose.onNodeWithText(string(R.string.dashboard_enforcement_testing_title)).assertExists()
+        // …and the hero qualifies the verified read-back instead of leaving it to stand alone.
+        compose.onNode(hasScrollAction()).performScrollToNode(hasTestTag(HERO_CARD_TEST_TAG))
+        compose.onNodeWithText(string(R.string.dashboard_enforcement_testing_note)).assertExists()
+    }
+
+    @Test
+    fun `a refuted device is warned about`() {
+        render(state(EnforcementStatus.REFUTED, controlEnabled = false))
+
+        scrollToCard()
+        compose.onNodeWithText(string(R.string.dashboard_enforcement_refuted_title)).assertExists()
+    }
+
+    @Test
+    fun `a confirmed device shows no card at all`() {
+        render(state(EnforcementStatus.CONFIRMED, controlEnabled = true))
+
+        compose.onNodeWithTag(ENFORCEMENT_CARD_TEST_TAG).assertDoesNotExist()
+        compose.onNodeWithText(string(R.string.dashboard_enforcement_testing_note)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `an adapter the question does not apply to shows no card at all`() {
+        render(state(status = null, controlEnabled = true))
+
+        compose.onNodeWithTag(ENFORCEMENT_CARD_TEST_TAG).assertDoesNotExist()
+        compose.onNodeWithText(string(R.string.dashboard_enforcement_testing_note)).assertDoesNotExist()
+    }
+}

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardInterruptionCardTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardInterruptionCardTest.kt
@@ -66,6 +66,7 @@ class DashboardInterruptionCardTest {
                 onFixNotifications = {},
                 onOpenBatteryHub = {},
                 onRetryCapture = {},
+                onStartVerification = {},
                 onPinWidget = {},
                 onAddTile = {},
                 onDismissQuickAccess = {},

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenGestureTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenGestureTest.kt
@@ -379,6 +379,7 @@ private fun DashboardScreenForTest(state: DashboardUiState) {
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = {},
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenUnderTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenUnderTest.kt
@@ -12,6 +12,7 @@ internal fun DashboardScreenUnderTest(
     onOpenShizuku: () -> Unit = {},
     onAllowShizuku: () -> Unit = {},
     onUpgrade: () -> Unit = {},
+    onStartVerification: () -> Unit = {},
 ) {
     DashboardScreen(
         state = state,
@@ -27,6 +28,7 @@ internal fun DashboardScreenUnderTest(
         onFixNotifications = {},
         onOpenBatteryHub = {},
         onRetryCapture = {},
+        onStartVerification = onStartVerification,
         onPinWidget = {},
         onAddTile = {},
         onDismissQuickAccess = {},

--- a/app/src/test/java/eu/darken/amply/main/ui/widget/AmplyWidgetLabelTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/widget/AmplyWidgetLabelTest.kt
@@ -2,7 +2,11 @@ package eu.darken.amply.main.ui.widget
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.charging.core.BackendKind
+import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
+import eu.darken.amply.charging.core.ChargingState
+import eu.darken.amply.charging.core.enforcement.EnforcementStatus
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,5 +26,36 @@ class AmplyWidgetLabelTest {
         // Xiaomi: the protective default is heuristic adaptive, not a fixed cap — the label
         // must not claim a permanent 80% limit.
         protectButtonLabel(context, ChargePolicy.Adaptive) shouldBe "∞Auto"
+    }
+
+    private fun state(enforcement: EnforcementStatus?) = ChargingState(
+        controlEnabled = true,
+        enforcement = enforcement,
+        observation = ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.SHIZUKU),
+    )
+
+    @Test
+    fun `the widget does not claim a limit while enforcement is unverified`() {
+        // The setting reads back verified, which on these builds proves only that the ROM stored it.
+        statusLine(
+            context = context,
+            sessionActive = false,
+            settling = false,
+            awaitingReplug = false,
+            state = state(EnforcementStatus.UNDER_TEST),
+            requestedTarget = null,
+        ) shouldBe "Limited to 80% · not verified yet"
+
+        // Confirmed, or an adapter the question doesn't apply to: the plain claim, as before.
+        listOf(EnforcementStatus.CONFIRMED, null).forEach { enforcement ->
+            statusLine(
+                context = context,
+                sessionActive = false,
+                settling = false,
+                awaitingReplug = false,
+                state = state(enforcement),
+                requestedTarget = null,
+            ) shouldBe "Limited to 80%"
+        }
     }
 }

--- a/app/src/test/java/eu/darken/amply/main/ui/widget/AmplyWidgetLabelTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/widget/AmplyWidgetLabelTest.kt
@@ -43,16 +43,16 @@ class AmplyWidgetLabelTest {
     )
 
     @Test
-    fun `the widget does not claim a limit while enforcement is unverified`() {
+    fun `the widget does not claim a limit on an unconfirmed build`() {
         // The setting reads back verified, which on these builds proves only that the ROM stored it.
         statusLine(
             context = context,
             sessionActive = false,
             settling = false,
             awaitingReplug = false,
-            state = state(EnforcementStatus.UNDER_TEST),
+            state = state(EnforcementStatus.UNVERIFIED),
             requestedTarget = null,
-        ) shouldBe "Limited to 80% · not verified yet"
+        ) shouldBe "Limited to 80% · not confirmed"
 
         // Confirmed, or an adapter the question doesn't apply to: the plain claim, as before.
         listOf(EnforcementStatus.CONFIRMED, null).forEach { enforcement ->
@@ -68,7 +68,7 @@ class AmplyWidgetLabelTest {
     }
 
     @Test
-    fun `the widget claims no limit on an unverified or refuted build`() {
+    fun `the widget claims no limit on a candidate or refuted build`() {
         // …and the last requested target outlives the tier change: a build refuted after the user
         // asked for 80%, or a confirmed build reset to candidate by an OTA, still carries
         // FixedLimit(80) as the last request. Rendering that would claim a protection that is off.
@@ -79,7 +79,7 @@ class AmplyWidgetLabelTest {
             awaitingReplug = false,
             state = gatedState(EnforcementStatus.CANDIDATE),
             requestedTarget = ChargePolicy.FixedLimit(80),
-        ) shouldBe "Charge limiting not verified"
+        ) shouldBe "Charge limiting off (unconfirmed)"
 
         statusLine(
             context = context,

--- a/app/src/test/java/eu/darken/amply/main/ui/widget/AmplyWidgetLabelTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/widget/AmplyWidgetLabelTest.kt
@@ -7,6 +7,7 @@ import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.ChargingState
 import eu.darken.amply.charging.core.enforcement.EnforcementStatus
+import eu.darken.amply.common.ca.toCaString
 import io.kotest.matchers.shouldBe
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,6 +35,13 @@ class AmplyWidgetLabelTest {
         observation = ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.SHIZUKU),
     )
 
+    /** The gated shape: control is off, so the repository publishes Unsupported… */
+    private fun gatedState(enforcement: EnforcementStatus) = ChargingState(
+        controlEnabled = false,
+        enforcement = enforcement,
+        observation = ChargeObservation.Unsupported("gate".toCaString()),
+    )
+
     @Test
     fun `the widget does not claim a limit while enforcement is unverified`() {
         // The setting reads back verified, which on these builds proves only that the ROM stored it.
@@ -57,5 +65,29 @@ class AmplyWidgetLabelTest {
                 requestedTarget = null,
             ) shouldBe "Limited to 80%"
         }
+    }
+
+    @Test
+    fun `the widget claims no limit on an unverified or refuted build`() {
+        // …and the last requested target outlives the tier change: a build refuted after the user
+        // asked for 80%, or a confirmed build reset to candidate by an OTA, still carries
+        // FixedLimit(80) as the last request. Rendering that would claim a protection that is off.
+        statusLine(
+            context = context,
+            sessionActive = false,
+            settling = false,
+            awaitingReplug = false,
+            state = gatedState(EnforcementStatus.CANDIDATE),
+            requestedTarget = ChargePolicy.FixedLimit(80),
+        ) shouldBe "Charge limiting not verified"
+
+        statusLine(
+            context = context,
+            sessionActive = false,
+            settling = false,
+            awaitingReplug = false,
+            state = gatedState(EnforcementStatus.REFUTED),
+            requestedTarget = ChargePolicy.FixedLimit(80),
+        ) shouldBe "Charge limiting unavailable"
     }
 }

--- a/app/src/test/java/eu/darken/amply/monitor/core/ChargeMonitorWatcherGraphTest.kt
+++ b/app/src/test/java/eu/darken/amply/monitor/core/ChargeMonitorWatcherGraphTest.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import dagger.hilt.components.SingletonComponent
 import eu.darken.amply.alarm.core.ChargeAlarmWatcher
+import eu.darken.amply.charging.core.enforcement.EnforcementWatcher
 import eu.darken.amply.stats.core.ChargeStatsWatcher
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
@@ -60,5 +61,17 @@ class ChargeMonitorWatcherGraphTest {
 
         watchers.map { it.id } shouldContain "battery_stats"
         watchers.any { it is ChargeStatsWatcher } shouldBe true
+    }
+
+    @Test
+    fun `the enforcement watcher is bound into the monitor watcher set`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val watchers = EntryPointAccessors.fromApplication(
+            context,
+            WatcherEntryPoint::class.java,
+        ).watchers()
+
+        watchers.map { it.id } shouldContain "enforcement_evidence"
+        watchers.any { it is EnforcementWatcher } shouldBe true
     }
 }


### PR DESCRIPTION
## What changed

Amply can now control charging on LineageOS devices. Until now it couldn't on any of them: support was gated on a list of physically-qualified device codenames that shipped empty, so every LineageOS phone fell through to diagnostics-only and never got controls.

Any LineageOS build that ships the charging-control settings provider is now recognised. Controls start switched **off**, with a card explaining that nothing Amply can see proves the limit actually works on that build, and an option to enable them anyway. Once enabled, Amply watches real charging: if the battery is ever seen charging past the configured limit, it switches its controls back off for that build and says so, rather than showing a protection that isn't real.

Amply never claims a limit is "verified" from watching. No signal it can observe tells a charge limit holding apart from the phone pausing for heat or a weak charger, so observation can only ever disprove a limit, never confirm one. Devices that have been physically qualified skip the opt-in entirely.

Also fixed along the way: a temporary full-charge session's restore is no longer refused when a system update changes the build mid-session, which previously could leave the phone with its protection never restored.

## Technical Context

- **Why the HAL capability probe doesn't gate this.** Upstream picks the charging provider by *configured mode* before capability, so a device sitting in AUTO reports `Deadline` whether or not it supports LIMIT, and the mechanism enum has no negative case by design. The necessary condition is the existing write-readback instead — which is what established oriole's original NO-GO. The probe stays informational.

- **Why confirmation was removed rather than tightened.** `EXTRA_CHARGING_STATUS` was measured on a Pixel 6 / LineageOS 23.2 still reading `4` while the phone actively charged *ten points below* its cap — it marks the long-life session, not an active hold. Combined with a thermal or weak-supply pause being indistinguishable from a cap hold in every other observable field, no passive rule can confirm. A guided two-cap cut/resume/cut challenge is the known way to earn real confirmation and is deliberately not implemented here.

- **Evidence is keyed on a composite build identity, not a codename or fingerprint.** HAL capability is build-scoped: the same oriole exposed the LIMIT mode bit on one build and dropped it on another of the same Lineage version. `Build.FINGERPRINT` alone can't carry it either, because LineageOS spoofs it to stock.

- **The gate deliberately does not apply to repaying a persisted restore** — an OTA changes the build identity mid-session, and withholding the restore would strand the phone unrestricted, which is the opposite of what the gate is for. Recovery targets therefore carry an origin so a pending *user*-initiated write still goes through the gate, defaulting to the gated origin for records written by older builds. **Worth close review**, as is the fail-closed handling in the evidence store: a corrupt or undecodable record must never read as "no evidence".

- **On-device testing covered what CI cannot**: refutation was exercised end-to-end on a Pixel 6 running LineageOS 23.2 — an 80% limit applied and read back, the battery driven past it, and control observed being withdrawn with the explanatory card shown. The qualification ledger is updated in the same change: that device's earlier "HAL dropped LIMIT mode" NO-GO no longer holds on its current build, recorded as build-scoped evidence and explicitly **not** as a pass, so it is not added to the qualified allowlist.
