### PR TITLE
Keep Google from refunding purchases when the app is closed too soon

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -204,6 +204,7 @@ tasks.withType<KotlinCompile>().configureEach {
 dependencies {
     addBaseKotlin()
     addBaseAndroid()
+    addWorkManager()
 
     addDagger()
 

--- a/app/src/gplay/java/eu/darken/amply/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/core/UpgradeRepoGplay.kt
@@ -19,6 +19,7 @@ import eu.darken.amply.upgrade.core.billing.Sku
 import eu.darken.amply.upgrade.core.billing.SkuDetails
 import eu.darken.amply.upgrade.core.billing.UserCanceledBillingException
 import eu.darken.amply.upgrade.core.billing.client.redacted
+import eu.darken.amply.upgrade.core.billing.work.PurchaseAckScheduler
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -53,6 +54,7 @@ import javax.inject.Singleton
 class UpgradeRepoGplay @Inject constructor(
     private val billingManager: BillingManager,
     private val billingCache: BillingCache,
+    private val ackScheduler: PurchaseAckScheduler,
 ) : UpgradeRepo {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -244,6 +246,18 @@ class UpgradeRepoGplay @Inject constructor(
             return
         }
         try {
+            // Persistent ack safety net, launch trigger: armed and AWAITED before the Play sheet can
+            // open, so the WorkManager DB transaction lands even if the process dies around the
+            // sheet — the exact window behind Play's unacknowledged-purchase auto-refunds. Failure
+            // to arm never blocks the purchase; the foreground ack path still exists.
+            try {
+                ackScheduler.armForBillingFlowLaunch()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to arm ack safety net for launch: ${e.asLog()}" }
+            }
+
             // Bounded, like every other Play path. useConnection waits for a healthy connection
             // indefinitely, so a Play outage between rendering the offers and this tap would park the
             // launch forever — with launchBusySku still held, which leaves every purchase button busy

--- a/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/BillingManager.kt
@@ -15,6 +15,7 @@ import eu.darken.amply.upgrade.core.billing.client.BillingClientException
 import eu.darken.amply.upgrade.core.billing.client.BillingConnection
 import eu.darken.amply.upgrade.core.billing.client.BillingConnectionProvider
 import eu.darken.amply.upgrade.core.billing.client.redacted
+import eu.darken.amply.upgrade.core.billing.work.PurchaseAckScheduler
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -43,6 +44,8 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -55,6 +58,7 @@ import javax.inject.Singleton
 @Singleton
 open class BillingManager @Inject constructor(
     connectionProvider: BillingConnectionProvider,
+    private val ackScheduler: PurchaseAckScheduler,
 ) {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -284,12 +288,17 @@ open class BillingManager @Inject constructor(
     // below. The immutable Purchase snapshot keeps reporting isAcknowledged=false until a fresh Play
     // query supersedes it, so the ack re-fires every emission until then; re-acking is a documented
     // no-op on Play's side, whereas skipping a needed ack gets the purchase auto-refunded after 3
-    // days. Single sequential collector (the ack pass below), no locking needed.
+    // days. Confined by [ackMutex] (the collector's pass and explicit sweeps both run under it).
     private val loggedAckTokens = mutableSetOf<String>()
 
     // Tokens whose PERMANENT ack failure was already reported. Play will keep rejecting these, so the
-    // error fires once per token instead of once per pass.
+    // error fires once per token instead of once per pass. Same [ackMutex] confinement.
     private val reportedAckFailures = mutableSetOf<String>()
+
+    // Serializes acknowledgement work between the reactive ack collector and explicit
+    // [ensureAllAcknowledged] sweeps (PurchaseAckWorker): both paths mutate the token bookkeeping
+    // sets above and both must never double-drive the same purchase's inline retry sequence.
+    private val ackMutex = Mutex()
 
     // At most one reschedule timer in flight: repeated failures must not stack timers.
     private val ackRetryPending = MutableStateFlow(false)
@@ -323,17 +332,36 @@ open class BillingManager @Inject constructor(
     // whose immutable snapshot stays false until a fresh Play query.
     private enum class AckOutcome { SUCCESS, TRANSIENT, PERMANENT }
 
+    /** Aggregate outcome of one ack pass; [ensureAllAcknowledged] maps it to a sweep result. */
+    data class AckPassOutcome(val transient: Int, val permanent: Int)
+
     // One acknowledgement pass over the canonical purchase list. Never throws except cancellation:
     // transient failures schedule a re-drive, permanent ones are reported and left to organic
     // fresh-data signals.
-    private suspend fun runAckPass(purchases: Collection<Purchase>) {
+    private suspend fun runAckPass(purchases: Collection<Purchase>): AckPassOutcome = ackMutex.withLock {
         val needAck = purchases.filter {
             val needsAck = !it.isAcknowledged
             if (needsAck) log(TAG) { "Needs ACK: ${it.redacted()}" } else log(TAG) { "Already ACK'ed: ${it.redacted()}" }
             needsAck
         }
 
+        if (needAck.isNotEmpty()) {
+            // Arm the persistent safety net BEFORE attempting anything, and AWAIT the enqueue (the
+            // scheduler bounds it): the inline retries below can span minutes, and a process death
+            // inside them must not strand the purchase until Play's 3-day auto-refund. A deferred
+            // signal (channel + collector) would reintroduce exactly that window. Fail-open: the net
+            // is an extra layer, never a reason to skip the acks themselves.
+            try {
+                ackScheduler.armForUnackedPurchases(needAck.maxOf { it.purchaseTime } + ACK_SAFETY_NET_DEADLINE_MS)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Failed to arm ack safety net: ${e.asLog()}" }
+            }
+        }
+
         var transientFailures = 0
+        var permanentFailures = 0
 
         for (purchase in needAck) {
             // First ack of a token is INFO; idempotent repeats drop to DEBUG. This never gates the
@@ -396,6 +424,7 @@ open class BillingManager @Inject constructor(
             }
 
             if (outcome == AckOutcome.TRANSIENT) transientFailures++
+            if (outcome == AckOutcome.PERMANENT) permanentFailures++
             if (abortPass) break
         }
 
@@ -405,6 +434,43 @@ open class BillingManager @Inject constructor(
                 "$transientFailures purchase(s) left unacknowledged, re-driving in ${ackRescheduleMs}ms"
             }
             scheduleAckRetry()
+        }
+
+        AckPassOutcome(transient = transientFailures, permanent = permanentFailures)
+    }
+
+    /** Outcome of an explicit safety-net sweep, see [ensureAllAcknowledged]. */
+    enum class AckSweepResult { COMPLETE, RETRY, PERMANENT_FAILURE }
+
+    /**
+     * One self-contained acknowledgement sweep for the persistent safety net (PurchaseAckWorker):
+     * refresh from Play, then acknowledge everything unacknowledged IN THIS COROUTINE. The reactive
+     * ack collector consumes purchase state asynchronously, so a caller that needs proof the acks
+     * actually happened before it reports success (a worker deciding success vs retry) cannot rely
+     * on it. Never throws except cancellation.
+     */
+    open suspend fun ensureAllAcknowledged(): AckSweepResult {
+        log(TAG) { "ensureAllAcknowledged()" }
+        val fresh = try {
+            useConnection { refreshPurchases() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "ensureAllAcknowledged(): refresh failed: ${e.asLog()}" }
+            return AckSweepResult.RETRY
+        }
+        // Same bookkeeping every other refresh exit owes: grace episode clock + dead-binder teardown.
+        processReconciliation(fresh)
+        // Pending payments are filtered here, exactly like the reactive collector does: acknowledging
+        // one is a protocol error Play rejects permanently.
+        val outcome = runAckPass(fresh.purchases.purchased())
+        return when {
+            // An incomplete refresh may be hiding an unacknowledged purchase of the failed type, and
+            // a transient ack failure is retriable by definition.
+            outcome.transient > 0 || !fresh.isComplete -> AckSweepResult.RETRY
+            // Play will keep rejecting these no matter how often the worker comes back.
+            outcome.permanent > 0 -> AckSweepResult.PERMANENT_FAILURE
+            else -> AckSweepResult.COMPLETE
         }
     }
 
@@ -580,6 +646,10 @@ open class BillingManager @Inject constructor(
             BillingResponseCode.FEATURE_NOT_SUPPORTED,
             BillingResponseCode.ITEM_NOT_OWNED,
         )
+
+        // Play auto-refunds purchases not acknowledged within 3 days; every safety-net deadline
+        // derives from this.
+        const val ACK_SAFETY_NET_DEADLINE_MS = 3 * 24 * 60 * 60 * 1000L
 
         private const val INITIAL_REFRESH_TIMEOUT_MS = 30_000L
         private const val MAX_BACKOFF_MS = 300_000L

--- a/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/work/PurchaseAckScheduler.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/work/PurchaseAckScheduler.kt
@@ -1,0 +1,118 @@
+package eu.darken.amply.upgrade.core.billing.work
+
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.await
+import androidx.work.workDataOf
+import eu.darken.amply.BuildConfig
+import eu.darken.amply.common.debug.logging.Logging.Priority.WARN
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import eu.darken.amply.upgrade.core.billing.BillingManager
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+/**
+ * Arms the [PurchaseAckWorker] safety net. Two triggers:
+ * - a billing flow is about to launch (armed and awaited BEFORE the Play sheet, so the WorkManager
+ *   DB transaction lands even if the process dies around the sheet),
+ * - an ack pass discovered unacknowledged purchases (called directly, pre-attempt, from
+ *   [BillingManager]'s ack pass).
+ *
+ * `open` for the same reason [BillingManager] is: the billing tests substitute it to assert the
+ * arming contract without standing up WorkManager.
+ */
+@Singleton
+open class PurchaseAckScheduler @Inject constructor(
+    // Resolved on the first arm, not at construction: AmplyApp eagerly injects UpgradeSurfaceSync
+    // (and with it the whole billing stack) during Application field injection, and resolving
+    // WorkManager there triggers its on-demand initialization before the Application's worker
+    // factory field is set.
+    private val workManager: Provider<WorkManager>,
+) {
+
+    // A genuinely new flow refreshes the watch window: REPLACE the previous LAUNCH watch. The
+    // worker sweeps ALL unacknowledged purchases, so replacing an older watch loses nothing — and a
+    // pending rescue for an already-discovered purchase has its own identity, so starting another
+    // purchase can never displace it. The long delay keeps the worker out of the window where the
+    // user may still be in the Play sheet.
+    open suspend fun armForBillingFlowLaunch() = arm(
+        name = WORK_NAME_LAUNCH,
+        policy = ExistingWorkPolicy.REPLACE,
+        expiresAt = System.currentTimeMillis() + BillingManager.ACK_SAFETY_NET_DEADLINE_MS,
+        initialDelayMs = LAUNCH_DELAY_MS,
+    )
+
+    // Any pending rescue already covers every unacknowledged purchase: KEEP it. Once completed work
+    // exists, KEEP inserts a fresh request. Short delay — the purchase already EXISTS (unlike the
+    // launch trigger), possibly for days, so waiting 30min could waste real deadline time.
+    // Accepted edge of KEEP, within the rescue lane only: a pending request keeps its original
+    // (possibly earlier) expiry; a newer purchase with a later deadline is only re-covered once a
+    // later pass re-arms after the old work completed. Bounded residual, only reachable via
+    // out-of-band purchases.
+    open suspend fun armForUnackedPurchases(expiresAt: Long) = arm(
+        name = WORK_NAME_RESCUE,
+        policy = ExistingWorkPolicy.KEEP,
+        expiresAt = expiresAt,
+        initialDelayMs = DISCOVERY_DELAY_MS,
+    )
+
+    private suspend fun arm(
+        name: String,
+        policy: ExistingWorkPolicy,
+        expiresAt: Long,
+        initialDelayMs: Long,
+    ) {
+        if (expiresAt <= System.currentTimeMillis()) {
+            // Play has already voided (or is about to void) such a purchase; a sweep can't help.
+            log(TAG, WARN) { "arm($policy): deadline $expiresAt already passed, not scheduling" }
+            return
+        }
+        val request = OneTimeWorkRequestBuilder<PurchaseAckWorker>().apply {
+            setConstraints(
+                Constraints.Builder().apply {
+                    setRequiredNetworkType(NetworkType.CONNECTED)
+                }.build(),
+            )
+            // Launch trigger: the worker must not run while the user may still be in the Play sheet
+            // — an immediate sweep would find nothing unacknowledged, report success, and complete
+            // the net before the purchase it exists for even happened.
+            setInitialDelay(initialDelayMs, TimeUnit.MILLISECONDS)
+            setBackoffCriteria(BackoffPolicy.EXPONENTIAL, BACKOFF_DELAY_MS, TimeUnit.MILLISECONDS)
+            setInputData(workDataOf(PurchaseAckWorker.KEY_EXPIRES_AT to expiresAt))
+        }.build()
+
+        // Await the enqueue: the caller arms this because the process may die at any moment — a
+        // fire-and-forget enqueue could be lost with it. Cancellable and BOUNDED: every caller needs
+        // a durable enqueue without an unbounded stall — a WorkManager that never settles must
+        // become an exception (handled fail-open by every caller) instead of a hang (which on the
+        // launch lane would park the purchase and its busy guard forever).
+        val operation = workManager.get().enqueueUniqueWork(name, policy, request)
+        withTimeoutOrNull(ENQUEUE_TIMEOUT_MS) { operation.await() }
+            ?: throw IllegalStateException("WorkManager enqueue did not settle within ${ENQUEUE_TIMEOUT_MS}ms")
+        log(TAG) { "arm($policy): safety net armed, expiresAt=$expiresAt" }
+    }
+
+    companion object {
+        // WorkManager persists these names AND the worker's class name in its DB across app updates:
+        // keep all of them stable while old work may exist (hence the version suffix for future
+        // changes). Separate identities per trigger: the launch watch's REPLACE must not be able to
+        // displace a pending rescue for a purchase that already exists.
+        private val WORK_NAME_LAUNCH = "${BuildConfig.APPLICATION_ID}.gplay.purchase-ack.launch.v1"
+        private val WORK_NAME_RESCUE = "${BuildConfig.APPLICATION_ID}.gplay.purchase-ack.rescue.v1"
+
+        private const val LAUNCH_DELAY_MS = 30 * 60 * 1000L
+        private const val DISCOVERY_DELAY_MS = 60 * 1000L
+        private const val BACKOFF_DELAY_MS = 30 * 60 * 1000L
+        private const val ENQUEUE_TIMEOUT_MS = 10 * 1000L
+
+        val TAG: String = logTag("Upgrade", "Gplay", "Billing", "AckScheduler")
+    }
+}

--- a/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/work/PurchaseAckWorker.kt
+++ b/app/src/gplay/java/eu/darken/amply/upgrade/core/billing/work/PurchaseAckWorker.kt
@@ -1,0 +1,85 @@
+package eu.darken.amply.upgrade.core.billing.work
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ListenableWorker.Result
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import eu.darken.amply.common.debug.logging.Logging.Priority.INFO
+import eu.darken.amply.common.debug.logging.Logging.Priority.WARN
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import eu.darken.amply.upgrade.core.billing.BillingManager
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Persistent acknowledgement safety net, armed by [PurchaseAckScheduler].
+ *
+ * Play auto-refunds (and revokes) any purchase not acknowledged within 3 days. The in-process ack
+ * machinery in [BillingManager] handles every case where the process lives long enough — this
+ * worker covers the case it can't: the process dies around the Play purchase sheet (OEM task
+ * killers) and the user doesn't reopen the app before the deadline. Play voids such purchases and
+ * revokes the entitlement, so the user loses what they paid for.
+ *
+ * Self-completing by design: nothing cancels this work from the foreground ack path (an ack pass can
+ * legitimately see zero unacknowledged purchases while the Play sheet is still open, which must not
+ * tear down the net). The redundant sweep after a successful foreground ack is one purchase query.
+ */
+@HiltWorker
+class PurchaseAckWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted private val params: WorkerParameters,
+    private val billingManager: BillingManager,
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val expiresAt = inputData.getLong(KEY_EXPIRES_AT, 0L)
+        log(TAG) { "doWork(): attempt=$runAttemptCount, expiresAt=$expiresAt" }
+
+        if (!isWorthSweeping(System.currentTimeMillis(), expiresAt)) {
+            // Past Play's refund deadline (or malformed input): retrying can't achieve anything.
+            // failure() is deliberate over success() — it is visible in WorkManager diagnostics, and
+            // a completed state lets a later KEEP enqueue insert fresh work.
+            log(TAG, WARN) { "doWork(): deadline passed, giving up" }
+            return Result.failure()
+        }
+
+        // Bounded well below WorkManager's 10-minute execution limit, but generous enough for the
+        // connection wait plus the per-purchase inline retries. A sweep that ran out of time is a
+        // transient outcome, not a verdict. External cancellation propagates out of doWork — it must
+        // never be converted into success.
+        val sweep = withTimeoutOrNull(SWEEP_TIMEOUT_MS) {
+            billingManager.ensureAllAcknowledged()
+        }
+        log(TAG, INFO) { "doWork(): sweep=$sweep" }
+
+        return mapSweep(sweep, System.currentTimeMillis(), expiresAt)
+    }
+
+    companion object {
+        // Persisted in WorkManager's request data — keep the key stable while old work may exist.
+        const val KEY_EXPIRES_AT = "purchase.ack.expiresAt"
+
+        private const val SWEEP_TIMEOUT_MS = 4 * 60 * 1000L
+
+        // Pure so the retry/expiry decision is unit-testable without a WorkManager test harness.
+        internal fun isWorthSweeping(now: Long, expiresAt: Long): Boolean =
+            expiresAt > 0L && now < expiresAt
+
+        internal fun mapSweep(
+            sweep: BillingManager.AckSweepResult?,
+            now: Long,
+            expiresAt: Long,
+        ): Result = when (sweep) {
+            BillingManager.AckSweepResult.COMPLETE -> Result.success()
+            BillingManager.AckSweepResult.PERMANENT_FAILURE -> Result.failure()
+            // RETRY or timeout (null): keep trying until the deadline. WorkManager's exponential
+            // backoff caps at 5h, so the 3-day window still yields many attempts.
+            else -> if (now < expiresAt) Result.retry() else Result.failure()
+        }
+
+        val TAG: String = logTag("Upgrade", "Gplay", "Billing", "AckWorker")
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,6 +68,20 @@
                 android:resource="@xml/file_paths" />
         </provider>
 
+        <!-- WorkManager resolves its configuration from AmplyApp (Configuration.Provider) so the
+             HiltWorkerFactory is in place; that on-demand initialization only happens when the
+             androidx.startup initializer is removed. -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
+
         <activity
             android:name=".main.ui.MainActivity"
             android:exported="true">

--- a/app/src/main/java/eu/darken/amply/AmplyApp.kt
+++ b/app/src/main/java/eu/darken/amply/AmplyApp.kt
@@ -1,6 +1,9 @@
 package eu.darken.amply
 
 import android.app.Application
+import android.util.Log
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
 import eu.darken.amply.charging.core.access.AutoWssGrantCoordinator
 import eu.darken.amply.common.debug.logging.LogCatLogger
@@ -11,10 +14,11 @@ import eu.darken.amply.upgrade.core.UpgradeSurfaceSync
 import javax.inject.Inject
 
 @HiltAndroidApp
-class AmplyApp : Application() {
+class AmplyApp : Application(), Configuration.Provider {
 
     @Inject lateinit var autoWssGrantCoordinator: AutoWssGrantCoordinator
     @Inject lateinit var upgradeSurfaceSync: UpgradeSurfaceSync
+    @Inject lateinit var workerFactory: HiltWorkerFactory
 
     override fun onCreate() {
         super.onCreate()
@@ -27,6 +31,15 @@ class AmplyApp : Application() {
         // entitlement lands or lapses.
         upgradeSurfaceSync.start()
     }
+
+    // Read lazily by WorkManager's on-demand initialization (the androidx.startup initializer is
+    // removed in the manifest), so the injected factory is always set by the time it is asked for.
+    // Workers this factory doesn't know fall back to WorkManager's default reflective factory.
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setMinimumLoggingLevel(if (BuildConfig.DEBUG) Log.DEBUG else Log.WARN)
+            .setWorkerFactory(workerFactory)
+            .build()
 
     private companion object {
         val TAG = logTag("App")

--- a/app/src/main/java/eu/darken/amply/common/worker/WorkManagerModule.kt
+++ b/app/src/main/java/eu/darken/amply/common/worker/WorkManagerModule.kt
@@ -1,0 +1,25 @@
+package eu.darken.amply.common.worker
+
+import android.content.Context
+import androidx.work.WorkManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Injectable [WorkManager]. Consumers that are constructed during Application field injection must
+ * take a `Provider<WorkManager>`, not the instance: resolving it here calls
+ * [WorkManager.getInstance], which triggers WorkManager's on-demand initialization — and that reads
+ * the Application's worker factory, which isn't injected yet at that point.
+ */
+@InstallIn(SingletonComponent::class)
+@Module
+class WorkManagerModule {
+
+    @Provides
+    @Singleton
+    fun workManager(@ApplicationContext context: Context): WorkManager = WorkManager.getInstance(context)
+}

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/UpgradeRepoGplayFlowTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/UpgradeRepoGplayFlowTest.kt
@@ -16,6 +16,7 @@ import eu.darken.amply.upgrade.core.billing.TestPurchases
 import eu.darken.amply.upgrade.core.billing.client.BillingConnection
 import eu.darken.amply.upgrade.core.billing.client.BillingConnectionProvider
 import eu.darken.amply.upgrade.core.billing.toBillingData
+import eu.darken.amply.upgrade.core.billing.work.FakePurchaseAckScheduler
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -80,6 +81,7 @@ class UpgradeRepoGplayFlowTest {
         object : BillingConnectionProvider(ApplicationProvider.getApplicationContext()) {
             override val connection: Flow<BillingConnection> = emptyFlow()
         },
+        FakePurchaseAckScheduler(),
     ) {
         override val freshBillingData: Flow<FreshData> = emptyFlow()
         override val purchaseFailures: Flow<BillingResult> = emptyFlow()
@@ -97,6 +99,12 @@ class UpgradeRepoGplayFlowTest {
             launchAnswer()
     }
 
+    private val ackScheduler = FakePurchaseAckScheduler()
+
+    // Every repo in this class goes through here so the ack safety net stays one shared recorder.
+    private fun gplayRepo(manager: BillingManager, cache: BillingCache) =
+        UpgradeRepoGplay(manager, cache, ackScheduler)
+
     private fun manager(
         billingData: Flow<BillingData>,
         failureSettled: Flow<Boolean> = MutableStateFlow(false),
@@ -108,7 +116,7 @@ class UpgradeRepoGplayFlowTest {
     private fun activity(): Activity = Robolectric.buildActivity(Activity::class.java).get()
 
     @Test fun `an owned purchase settles as pro`(): Unit = runBlocking {
-        val repo = UpgradeRepoGplay(
+        val repo = gplayRepo(
             manager(MutableStateFlow(listOf(TestPurchases.purchase(iapId)).toBillingData())),
             cache(),
         )
@@ -122,7 +130,7 @@ class UpgradeRepoGplayFlowTest {
     }
 
     @Test fun `an empty answer from play settles as not pro`(): Unit = runBlocking {
-        val repo = UpgradeRepoGplay(manager(MutableStateFlow(BillingData(emptyList()))), cache())
+        val repo = gplayRepo(manager(MutableStateFlow(BillingData(emptyList()))), cache())
 
         withTimeout(TIMEOUT_MS) {
             repo.upgradeInfo.first { it.isSettled }.isPro shouldBe false
@@ -132,7 +140,7 @@ class UpgradeRepoGplayFlowTest {
     @Test fun `a recent confirmation keeps the upgrade through an empty answer`(): Unit = runBlocking {
         val cache = cache()
         cache.stampLastProState(iapId, System.currentTimeMillis())
-        val repo = UpgradeRepoGplay(manager(MutableStateFlow(BillingData(emptyList()))), cache)
+        val repo = gplayRepo(manager(MutableStateFlow(BillingData(emptyList()))), cache)
 
         withTimeout(TIMEOUT_MS) {
             // Play returning nothing during a hiccup must not revoke a purchase we confirmed minutes
@@ -147,7 +155,7 @@ class UpgradeRepoGplayFlowTest {
             OurSku.Sub.PRO_UPGRADE.id,
             System.currentTimeMillis() - UpgradeRepoGplay.GRACE_PERIOD_MS - 1,
         )
-        val repo = UpgradeRepoGplay(manager(MutableStateFlow(BillingData(emptyList()))), cache)
+        val repo = gplayRepo(manager(MutableStateFlow(BillingData(emptyList()))), cache)
 
         withTimeout(TIMEOUT_MS) {
             repo.upgradeInfo.first { it.isSettled }.isPro shouldBe false
@@ -158,7 +166,7 @@ class UpgradeRepoGplayFlowTest {
         // The cache says the window is long gone; the purchase still wins.
         val cache = cache()
         cache.stampLastProState(iapId, 1L)
-        val repo = UpgradeRepoGplay(
+        val repo = gplayRepo(
             manager(MutableStateFlow(listOf(TestPurchases.purchase(iapId)).toBillingData())),
             cache,
         )
@@ -174,7 +182,7 @@ class UpgradeRepoGplayFlowTest {
     @Test fun `an unreachable play settles the seed instead of waiting forever`(): Unit = runBlocking {
         // No billing data will ever arrive; only the failure signal can settle this, and it must —
         // otherwise every UI gate would sit on its timeout during a Play outage.
-        val repo = UpgradeRepoGplay(
+        val repo = gplayRepo(
             manager(billingData = emptyFlow(), failureSettled = MutableStateFlow(true)),
             cache(),
         )
@@ -188,7 +196,7 @@ class UpgradeRepoGplayFlowTest {
     }
 
     @Test fun `a pending payment is reported without granting the upgrade`(): Unit = runBlocking {
-        val repo = UpgradeRepoGplay(
+        val repo = gplayRepo(
             manager(MutableStateFlow(listOf(TestPurchases.purchase(iapId, pending = true)).toBillingData())),
             cache(),
         )
@@ -204,7 +212,7 @@ class UpgradeRepoGplayFlowTest {
         // The billing flow can resubscribe and re-emit its unsettled seed; a gate that saw "settled"
         // must not be told to wait again.
         val data = MutableStateFlow<BillingData?>(null)
-        val repo = UpgradeRepoGplay(
+        val repo = gplayRepo(
             manager(data.filterNotNull(), failureSettled = MutableStateFlow(true)),
             cache(),
         )
@@ -222,7 +230,7 @@ class UpgradeRepoGplayFlowTest {
         // with a silent screen.
         val cache = cache()
         cache.stampLastProState(iapId, System.currentTimeMillis())
-        val repo = UpgradeRepoGplay(
+        val repo = gplayRepo(
             manager(MutableStateFlow(listOf(TestPurchases.purchase(iapId, pending = true)).toBillingData())),
             cache,
         )
@@ -242,7 +250,7 @@ class UpgradeRepoGplayFlowTest {
         val manager = freeManager().apply {
             strictAnswer = { throw GplayServiceUnavailableException(RuntimeException("one product type failed")) }
         }
-        val repo = UpgradeRepoGplay(manager, cache)
+        val repo = gplayRepo(manager, cache)
 
         // Even a recent owner gets the error: a gate that can't verify must not let a purchase
         // through on the strength of a grace window.
@@ -258,7 +266,7 @@ class UpgradeRepoGplayFlowTest {
                 ).toBillingData()
             }
         }
-        val repo = UpgradeRepoGplay(manager, cache())
+        val repo = gplayRepo(manager, cache())
 
         val info = repo.verifyPurchaseStateNow()
 
@@ -274,7 +282,7 @@ class UpgradeRepoGplayFlowTest {
             launchAnswer = { throw ItemAlreadyOwnedBillingException(RuntimeException("launch result")) }
             refreshAnswer = { listOf(TestPurchases.purchase(iapId, pending = true)).toBillingData() }
         }
-        val repo = UpgradeRepoGplay(manager, cache())
+        val repo = gplayRepo(manager, cache())
 
         val errors = mutableListOf<Throwable>()
         withTimeout(TIMEOUT_MS) {
@@ -288,7 +296,7 @@ class UpgradeRepoGplayFlowTest {
 
     @Test fun `wasEverPro tracks whether this install ever confirmed a purchase`(): Unit = runBlocking {
         val cache = cache()
-        val repo = UpgradeRepoGplay(manager(MutableStateFlow(BillingData(emptyList()))), cache)
+        val repo = gplayRepo(manager(MutableStateFlow(BillingData(emptyList()))), cache)
 
         withTimeout(TIMEOUT_MS) {
             repo.wasEverPro.first() shouldBe false
@@ -297,7 +305,46 @@ class UpgradeRepoGplayFlowTest {
         }
     }
 
+    // region the persistent ack safety net
+
+    @Test fun `launching a billing flow arms the persistent ack safety net first`(): Unit = runBlocking {
+        val order = mutableListOf<String>()
+        val scheduler = FakePurchaseAckScheduler(order)
+        val manager = freeManager().apply { launchAnswer = { order.add(LAUNCH) } }
+        val repo = UpgradeRepoGplay(manager, cache(), scheduler)
+
+        withTimeout(TIMEOUT_MS) {
+            repo.launchBillingFlowNow(activity(), OurSku.Iap.PRO_UPGRADE, null) { }
+        }
+
+        // Armed (and awaited) BEFORE the Play sheet can open: the process may die around the sheet,
+        // and the WorkManager transaction has to land first to be worth anything.
+        order shouldBe listOf(FakePurchaseAckScheduler.LAUNCH, LAUNCH)
+    }
+
+    @Test fun `a failing safety net arm never blocks the purchase flow`(): Unit = runBlocking {
+        val scheduler = FakePurchaseAckScheduler().apply {
+            failure = { RuntimeException("workmanager broken") }
+        }
+        val launches = mutableListOf<Sku>()
+        val manager = freeManager().apply { launchAnswer = { launches.add(OurSku.Iap.PRO_UPGRADE) } }
+        val repo = UpgradeRepoGplay(manager, cache(), scheduler)
+
+        val errors = mutableListOf<Throwable>()
+        withTimeout(TIMEOUT_MS) {
+            repo.launchBillingFlowNow(activity(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+        }
+
+        // The net is best-effort: the foreground ack path still exists, the purchase must proceed.
+        errors shouldBe emptyList()
+        launches shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+    }
+
+    // endregion
+
     private companion object {
         const val TIMEOUT_MS = 10_000L
+        // Recorded by the fake manager when a launch actually reached Play.
+        const val LAUNCH = "launch"
     }
 }

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/BillingManagerTest.kt
@@ -8,7 +8,9 @@ import eu.darken.amply.upgrade.core.OurSku
 import eu.darken.amply.upgrade.core.billing.client.BillingConnection
 import eu.darken.amply.upgrade.core.billing.client.BillingConnectionProvider
 import eu.darken.amply.upgrade.core.billing.client.FakeBillingClient
+import eu.darken.amply.upgrade.core.billing.work.FakePurchaseAckScheduler
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -49,6 +51,10 @@ class BillingManagerTest {
     private val iapId = OurSku.Iap.PRO_UPGRADE.id
     private val subId = OurSku.Sub.PRO_UPGRADE.id
 
+    // The safety net is fail-open plumbing around the ack pass; only the dedicated tests below
+    // assert on it, everything else just needs it to record and return.
+    private val ackScheduler = FakePurchaseAckScheduler()
+
     @After fun teardown() {
         testScope.cancel()
     }
@@ -68,6 +74,7 @@ class BillingManagerTest {
 
     private fun manager(attempts: Channel<Unit>): BillingManager = BillingManager(
         FakeProvider(ApplicationProvider.getApplicationContext(), attempts),
+        ackScheduler,
     )
 
     /**
@@ -94,6 +101,7 @@ class BillingManagerTest {
         attempts: Channel<Unit> = Channel(Channel.UNLIMITED),
     ): BillingManager = BillingManager(
         ConnectingProvider(ApplicationProvider.getApplicationContext(), clients.toList(), attempts),
+        ackScheduler,
     )
 
     private fun client(
@@ -338,6 +346,145 @@ class BillingManagerTest {
 
     // endregion
 
+    // region the persistent ack safety net
+
+    @Test fun `a sweep acknowledges what its own refresh returned and reports COMPLETE`(): Unit = runBlocking {
+        val unacked = TestPurchases.purchase(iapId, acknowledged = false)
+        val playClient = client(iap = FakeBillingClient.Answer(purchases = listOf(unacked)))
+        val manager = connectedManager(playClient)
+        withTimeout(TIMEOUT_MS) { manager.billingData.first() }
+
+        // The ack happens IN this call, not via the async collector: the worker needs the
+        // happens-before to report success instead of retrying.
+        withTimeout(TIMEOUT_MS) { manager.ensureAllAcknowledged() } shouldBe
+            BillingManager.AckSweepResult.COMPLETE
+        playClient.acknowledged.distinct() shouldBe listOf(unacked.purchaseToken)
+    }
+
+    @Test fun `a sweep with nothing to acknowledge reports COMPLETE`(): Unit = runBlocking {
+        val playClient = client(iap = FakeBillingClient.Answer(purchases = listOf(TestPurchases.purchase(iapId))))
+        val manager = connectedManager(playClient)
+        withTimeout(TIMEOUT_MS) { manager.billingData.first() }
+
+        withTimeout(TIMEOUT_MS) { manager.ensureAllAcknowledged() } shouldBe
+            BillingManager.AckSweepResult.COMPLETE
+    }
+
+    @Test fun `a sweep reports RETRY when the ack fails transiently`(): Unit = runBlocking {
+        val unacked = TestPurchases.purchase(iapId, acknowledged = false)
+        // BILLING_UNAVAILABLE is the connection-level transient: the pass aborts after one attempt
+        // instead of burning the inline retry backoff, and the outcome is still "come back later".
+        val playClient = client(iap = FakeBillingClient.Answer(purchases = listOf(unacked))).apply {
+            acknowledgeResponseCode = BillingResponseCode.BILLING_UNAVAILABLE
+        }
+        val manager = connectedManager(playClient)
+        withTimeout(TIMEOUT_MS) { manager.billingData.first() }
+
+        withTimeout(TIMEOUT_MS) { manager.ensureAllAcknowledged() } shouldBe
+            BillingManager.AckSweepResult.RETRY
+    }
+
+    @Test fun `a sweep reports PERMANENT_FAILURE on a permanently rejected ack`(): Unit = runBlocking {
+        val unacked = TestPurchases.purchase(iapId, acknowledged = false)
+        val playClient = client(iap = FakeBillingClient.Answer(purchases = listOf(unacked))).apply {
+            acknowledgeResponseCode = BillingResponseCode.DEVELOPER_ERROR
+        }
+        val manager = connectedManager(playClient)
+        withTimeout(TIMEOUT_MS) { manager.billingData.first() }
+
+        // Play will keep rejecting this one; retrying until the refund deadline would just burn
+        // battery, so the worker has to be told to stop.
+        withTimeout(TIMEOUT_MS) { manager.ensureAllAcknowledged() } shouldBe
+            BillingManager.AckSweepResult.PERMANENT_FAILURE
+    }
+
+    @Test fun `a sweep reports RETRY on an incomplete refresh even with nothing to ack`(): Unit = runBlocking {
+        val playClient = client(
+            iap = FakeBillingClient.Answer(purchases = listOf(TestPurchases.purchase(iapId))),
+            subs = failing(BillingResponseCode.SERVICE_UNAVAILABLE),
+        )
+        val manager = connectedManager(playClient)
+        withTimeout(TIMEOUT_MS) { manager.billingData.first() }
+
+        // A failed product-type query may be hiding an unacknowledged purchase of that type: the
+        // worker must come back instead of reporting the net complete.
+        withTimeout(TIMEOUT_MS) { manager.ensureAllAcknowledged() } shouldBe
+            BillingManager.AckSweepResult.RETRY
+    }
+
+    @Test fun `a sweep reports RETRY when the refresh itself fails`(): Unit = runBlocking {
+        val playClient = client()
+        val manager = connectedManager(playClient)
+        withTimeout(TIMEOUT_MS) { manager.billingData.first() }
+
+        // Play goes away after the connection was established: the refresh learned nothing and both
+        // queries failed, so it throws rather than reporting "nothing owned".
+        playClient.answers = mapOf(
+            BillingClient.ProductType.INAPP to failing(BillingResponseCode.SERVICE_UNAVAILABLE),
+            BillingClient.ProductType.SUBS to failing(BillingResponseCode.SERVICE_UNAVAILABLE),
+        )
+
+        withTimeout(TIMEOUT_MS) { manager.ensureAllAcknowledged() } shouldBe
+            BillingManager.AckSweepResult.RETRY
+    }
+
+    @Test fun `an ack pass arms the safety net before attempting, with the newest refund deadline`(): Unit =
+        runBlocking {
+            val order = mutableListOf<String>()
+            val scheduler = FakePurchaseAckScheduler(order)
+            val playClient = client(
+                iap = FakeBillingClient.Answer(
+                    purchases = listOf(TestPurchases.purchase(iapId, purchaseTime = 5_000L, acknowledged = false)),
+                ),
+                subs = FakeBillingClient.Answer(
+                    purchases = listOf(TestPurchases.purchase(subId, purchaseTime = 9_000L, acknowledged = false)),
+                ),
+            ).apply { onAcknowledge = { order.add(ACK) } }
+            BillingManager(
+                ConnectingProvider(
+                    ApplicationProvider.getApplicationContext(),
+                    listOf(playClient),
+                    Channel(Channel.UNLIMITED),
+                ),
+                scheduler,
+            )
+
+            withTimeout(TIMEOUT_MS) {
+                while (playClient.acknowledged.isEmpty()) delay(50)
+            }
+
+            // Armed (and awaited) BEFORE the first attempt: a process death during the inline
+            // retries must still leave the persistent net in place. The deadline derives from the
+            // NEWEST purchase, so a purchase made later is covered for its full three days.
+            order.first() shouldBe
+                "${FakePurchaseAckScheduler.RESCUE}:${9_000L + BillingManager.ACK_SAFETY_NET_DEADLINE_MS}"
+            order shouldContain ACK
+        }
+
+    @Test fun `a failing safety net arm never blocks the ack pass`(): Unit = runBlocking {
+        val scheduler = FakePurchaseAckScheduler().apply {
+            failure = { RuntimeException("workmanager broken") }
+        }
+        val unacked = TestPurchases.purchase(iapId, acknowledged = false)
+        val playClient = client(iap = FakeBillingClient.Answer(purchases = listOf(unacked)))
+        BillingManager(
+            ConnectingProvider(
+                ApplicationProvider.getApplicationContext(),
+                listOf(playClient),
+                Channel(Channel.UNLIMITED),
+            ),
+            scheduler,
+        )
+
+        // The net is an extra layer: a broken WorkManager must never stop the ack itself.
+        withTimeout(TIMEOUT_MS) {
+            while (playClient.acknowledged.isEmpty()) delay(50)
+        }
+        playClient.acknowledged.distinct() shouldBe listOf(unacked.purchaseToken)
+    }
+
+    // endregion
+
     private companion object {
         const val TIMEOUT_MS = 15_000L
         // Long enough for the (synchronous) fake round-trips and their flow plumbing to have run.
@@ -345,5 +492,8 @@ class BillingManagerTest {
         // Comfortably inside the loop's 2s first backoff, so "did not retry yet" and "retried early"
         // are both decidable without racing the timer.
         const val BACKOFF_FLOOR_MS = 1_500L
+        // Recorded by the fake Play client when it is asked to acknowledge, so the ack round-trips
+        // and the safety-net arming land in one ordered list.
+        const val ACK = "ack"
     }
 }

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/client/FakeBillingClient.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/client/FakeBillingClient.kt
@@ -55,6 +55,12 @@ internal class FakeBillingClient : BillingClient() {
     var acknowledgeResponseCode: Int = BillingResponseCode.OK
 
     /**
+     * Runs with the purchase token just before Play answers an acknowledgement. Lets a test order
+     * the ack round-trips against events recorded elsewhere (the safety-net arming, for instance).
+     */
+    var onAcknowledge: ((String) -> Unit)? = null
+
+    /**
      * Runs with the queried product type just before Play answers it. The seam for the races that
      * decide the reducer's ordering rules: a purchase event delivered from here lands AFTER the query
      * started, which is the only way it survives that query's commit.
@@ -75,6 +81,7 @@ internal class FakeBillingClient : BillingClient() {
         params: AcknowledgePurchaseParams,
         listener: AcknowledgePurchaseResponseListener,
     ) {
+        onAcknowledge?.invoke(params.purchaseToken)
         acknowledged.add(params.purchaseToken)
         listener.onAcknowledgePurchaseResponse(result(acknowledgeResponseCode))
     }

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/work/FakePurchaseAckScheduler.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/work/FakePurchaseAckScheduler.kt
@@ -1,0 +1,38 @@
+package eu.darken.amply.upgrade.core.billing.work
+
+import androidx.work.WorkManager
+import javax.inject.Provider
+
+/**
+ * Records what the billing stack asked the safety net to do, in call order, without standing up
+ * WorkManager. The [calls] list is shareable so a test can interleave it with other recorded events
+ * (an ack round-trip, a Play launch) and assert the ORDER — the property that makes the net worth
+ * anything when the process dies mid-purchase.
+ *
+ * The real scheduler's WorkManager provider is never resolved here; a resolution would be a bug in
+ * the code under test, so it fails loudly rather than silently returning a stand-in.
+ */
+internal class FakePurchaseAckScheduler(
+    val calls: MutableList<String> = mutableListOf(),
+) : PurchaseAckScheduler(
+    Provider<WorkManager> { error("FakePurchaseAckScheduler must not resolve WorkManager") },
+) {
+
+    /** When set, every arm throws this — the fail-open contract of both trigger sites. */
+    var failure: (() -> Throwable)? = null
+
+    override suspend fun armForBillingFlowLaunch() {
+        calls.add(LAUNCH)
+        failure?.let { throw it() }
+    }
+
+    override suspend fun armForUnackedPurchases(expiresAt: Long) {
+        calls.add("$RESCUE:$expiresAt")
+        failure?.let { throw it() }
+    }
+
+    companion object {
+        const val LAUNCH = "arm-launch"
+        const val RESCUE = "arm-rescue"
+    }
+}

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/work/PurchaseAckSchedulerTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/work/PurchaseAckSchedulerTest.kt
@@ -1,0 +1,113 @@
+package eu.darken.amply.upgrade.core.billing.work
+
+import android.content.Context
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Configuration
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.WorkManagerTestInitHelper
+import eu.darken.amply.BuildConfig
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.UUID
+import javax.inject.Provider
+
+/**
+ * Driven against a REAL WorkManager (in-memory DB, synchronous executor) rather than a hand-written
+ * imitation: what this class has to get right is WorkManager's own unique-work bookkeeping — that a
+ * new purchase flow cannot displace a rescue that is already pending for an existing purchase, and
+ * that a second flow does replace its own watch instead of stacking.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class PurchaseAckSchedulerTest {
+
+    private lateinit var workManager: WorkManager
+
+    @Before fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        WorkManagerTestInitHelper.initializeTestWorkManager(
+            context,
+            Configuration.Builder()
+                .setExecutor(SynchronousExecutor())
+                .setMinimumLoggingLevel(Log.DEBUG)
+                .build(),
+        )
+        workManager = WorkManager.getInstance(context)
+    }
+
+    private fun scheduler() = PurchaseAckScheduler(Provider { workManager })
+
+    // Finished work (a REPLACE'd request that WorkManager kept as CANCELLED) is not what is armed.
+    private fun pending(name: String): List<WorkInfo> =
+        workManager.getWorkInfosForUniqueWork(name).get().filter { !it.state.isFinished }
+
+    private fun pendingId(name: String): UUID = pending(name).single().id
+
+    @Test fun `a billing flow launch arms the launch watch`(): Unit = runBlocking {
+        scheduler().armForBillingFlowLaunch()
+
+        // Delayed, so the worker cannot run (and complete the net) while the user may still be
+        // standing in the Play sheet the net exists for.
+        pending(LAUNCH_NAME).single().state shouldBe WorkInfo.State.ENQUEUED
+        pending(RESCUE_NAME) shouldBe emptyList()
+    }
+
+    @Test fun `a second billing flow replaces the pending launch watch`(): Unit = runBlocking {
+        val scheduler = scheduler()
+        scheduler.armForBillingFlowLaunch()
+        val first = pendingId(LAUNCH_NAME)
+
+        scheduler.armForBillingFlowLaunch()
+
+        // REPLACE, not KEEP: a genuinely new flow refreshes the watch window, and the sweep covers
+        // every unacknowledged purchase anyway, so nothing is lost.
+        val second = pendingId(LAUNCH_NAME)
+        (second == first) shouldBe false
+    }
+
+    @Test fun `a discovered unacknowledged purchase arms the rescue lane and keeps it`(): Unit = runBlocking {
+        val scheduler = scheduler()
+        scheduler.armForUnackedPurchases(System.currentTimeMillis() + DAY_MS)
+        val first = pendingId(RESCUE_NAME)
+
+        scheduler.armForUnackedPurchases(System.currentTimeMillis() + DAY_MS)
+
+        // KEEP: the pending rescue already covers every unacknowledged purchase, and re-arming it
+        // on every ack pass would keep pushing its execution out.
+        pendingId(RESCUE_NAME) shouldBe first
+    }
+
+    @Test fun `a new billing flow never displaces a pending rescue`(): Unit = runBlocking {
+        val scheduler = scheduler()
+        scheduler.armForUnackedPurchases(System.currentTimeMillis() + DAY_MS)
+        val rescue = pendingId(RESCUE_NAME)
+
+        scheduler.armForBillingFlowLaunch()
+
+        // Separate work identities are the whole point: the launch watch's REPLACE must not be able
+        // to cancel the rescue armed for a purchase that already exists.
+        pendingId(RESCUE_NAME) shouldBe rescue
+        pending(LAUNCH_NAME).size shouldBe 1
+    }
+
+    @Test fun `a deadline that already passed schedules nothing`(): Unit = runBlocking {
+        scheduler().armForUnackedPurchases(System.currentTimeMillis() - DAY_MS)
+
+        // Play has already voided such a purchase; a sweep cannot bring it back.
+        pending(RESCUE_NAME) shouldBe emptyList()
+    }
+
+    private companion object {
+        const val DAY_MS = 24 * 60 * 60 * 1000L
+        val LAUNCH_NAME = "${BuildConfig.APPLICATION_ID}.gplay.purchase-ack.launch.v1"
+        val RESCUE_NAME = "${BuildConfig.APPLICATION_ID}.gplay.purchase-ack.rescue.v1"
+    }
+}

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/work/PurchaseAckWorkerTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/core/billing/work/PurchaseAckWorkerTest.kt
@@ -1,0 +1,46 @@
+package eu.darken.amply.upgrade.core.billing.work
+
+import androidx.work.ListenableWorker.Result
+import eu.darken.amply.upgrade.core.billing.BillingManager.AckSweepResult
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+/**
+ * The worker's whole decision surface, extracted as pure functions so it needs no WorkManager
+ * harness: whether a sweep is still worth running, and how its outcome maps to WorkManager's
+ * success/failure/retry verdicts.
+ */
+class PurchaseAckWorkerTest {
+
+    @Test fun `sweeping is only worth it before the refund deadline`() {
+        PurchaseAckWorker.isWorthSweeping(now = 100L, expiresAt = 101L) shouldBe true
+        PurchaseAckWorker.isWorthSweeping(now = 100L, expiresAt = 100L) shouldBe false
+        PurchaseAckWorker.isWorthSweeping(now = 100L, expiresAt = 99L) shouldBe false
+        // Malformed input data (missing/zero deadline) must not retry forever.
+        PurchaseAckWorker.isWorthSweeping(now = 100L, expiresAt = 0L) shouldBe false
+    }
+
+    @Test fun `a complete sweep succeeds`() {
+        PurchaseAckWorker.mapSweep(AckSweepResult.COMPLETE, now = 100L, expiresAt = 200L)
+            .shouldBeInstanceOf<Result.Success>()
+    }
+
+    @Test fun `a permanently rejected ack stops the retries`() {
+        PurchaseAckWorker.mapSweep(AckSweepResult.PERMANENT_FAILURE, now = 100L, expiresAt = 200L)
+            .shouldBeInstanceOf<Result.Failure>()
+    }
+
+    @Test fun `transient outcomes retry until the deadline`() {
+        PurchaseAckWorker.mapSweep(AckSweepResult.RETRY, now = 100L, expiresAt = 200L)
+            .shouldBeInstanceOf<Result.Retry>()
+        // null = the sweep timed out: same transient treatment.
+        PurchaseAckWorker.mapSweep(null, now = 100L, expiresAt = 200L)
+            .shouldBeInstanceOf<Result.Retry>()
+        // Past the deadline Play has already refunded: give up visibly instead of retrying forever.
+        PurchaseAckWorker.mapSweep(AckSweepResult.RETRY, now = 200L, expiresAt = 200L)
+            .shouldBeInstanceOf<Result.Failure>()
+        PurchaseAckWorker.mapSweep(null, now = 200L, expiresAt = 200L)
+            .shouldBeInstanceOf<Result.Failure>()
+    }
+}

--- a/app/src/testGplay/java/eu/darken/amply/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/amply/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -22,6 +22,7 @@ import eu.darken.amply.upgrade.core.billing.TestPurchases
 import eu.darken.amply.upgrade.core.billing.client.BillingConnection
 import eu.darken.amply.upgrade.core.billing.client.BillingConnectionProvider
 import eu.darken.amply.upgrade.core.billing.toBillingData
+import eu.darken.amply.upgrade.core.billing.work.FakePurchaseAckScheduler
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.CoroutineScope
@@ -78,6 +79,7 @@ class GplayUpgradeViewModelTest {
         object : BillingConnectionProvider(ApplicationProvider.getApplicationContext()) {
             override val connection: Flow<BillingConnection> = emptyFlow()
         },
+        FakePurchaseAckScheduler(),
     ) {
         override val isFailureSettled: Flow<Boolean> = MutableStateFlow(false)
         override val freshBillingData: Flow<FreshData> = emptyFlow()
@@ -134,7 +136,7 @@ class GplayUpgradeViewModelTest {
         manager: FakeBillingManager,
         cache: BillingCache = cache(),
     ): UpgradeViewModel = UpgradeViewModel(
-        upgradeRepo = UpgradeRepoGplay(manager, cache),
+        upgradeRepo = UpgradeRepoGplay(manager, cache, FakePurchaseAckScheduler()),
         webpageTool = WebpageTool(ApplicationProvider.getApplicationContext<Context>()),
     )
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -38,7 +38,20 @@ fun DependencyHandlerScope.addBaseAndroid() {
     implementation("androidx.activity:activity-compose:1.12.3")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:${Versions.AndroidX.lifecycle}")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.AndroidX.lifecycle}")
-    implementation("androidx.work:work-runtime-ktx:2.10.0")
+}
+
+fun DependencyHandlerScope.addWorkManager() {
+    val version = "2.10.0"
+    implementation("androidx.work:work-runtime-ktx:$version")
+    // Drives a REAL WorkManager (in-memory DB, synchronous executor) in the scheduler tests instead
+    // of asserting against a hand-written imitation of its unique-work bookkeeping.
+    testImplementation("androidx.work:work-testing:$version")
+
+    // @HiltWorker support: the purchase-acknowledgement safety net needs constructor injection in a
+    // CoroutineWorker. HiltWorkerFactory delegates workers it doesn't know to WorkManager's default
+    // factory, so the plain @EntryPoint workers keep working unchanged.
+    implementation("androidx.hilt:hilt-work:1.2.0")
+    ksp("androidx.hilt:hilt-compiler:1.2.0")
 }
 
 fun DependencyHandlerScope.addDagger() {


### PR DESCRIPTION
## What changed

Google refunds and revokes a Play purchase that is not confirmed back to Google within 3 days. Amply confirms it as soon as it sees the purchase, but if the app gets killed right around the purchase (some phones kill background apps aggressively) and is never reopened before the deadline, the confirmation never happens: the user pays, then quietly loses the upgrade.

The Play build now runs that confirmation in the background too, even if the app is never opened again. It re-tries over the whole 3-day window and stops on its own once everything is confirmed. Nothing changes for the FOSS build.

## Technical Context

- SEMANTIC port of d4rken-org/sdmaid-se#2685 at `f6f5c5e03`. Amply's billing stack is a different shape (BillingManager owns its own scope instead of taking an injected one, pending purchases are filtered at the ack-pass call site, tests use hand-written fakes rather than a mocking framework), so this is behaviour parity, not file parity.
- Wiring amply gains: `androidx.hilt:hilt-work` + its KSP compiler, `AmplyApp` implements `Configuration.Provider` with an injected `HiltWorkerFactory`, the `androidx.startup` `WorkManagerInitializer` is removed from the manifest so that configuration is actually used, and `WorkManager` becomes injectable (`WorkManagerModule`). `SettleRefreshWorker` stays a plain worker on purpose: `HiltWorkerFactory` delegates workers it doesn't know to WorkManager's default reflective factory.
- Two separate unique-work identities, `…purchase-ack.launch.v1` (REPLACE, 30min delay, armed and awaited before the Play sheet opens) and `…purchase-ack.rescue.v1` (KEEP, 1min delay, armed pre-attempt whenever an ack pass finds unacknowledged purchases). Separate so a new purchase flow can never displace a rescue armed for a purchase that already exists. Both arms are fail-open — a broken WorkManager must never block a purchase or an ack.
- The sweep is self-completing: nothing cancels the work from the foreground, because an ack pass can legitimately see zero unacknowledged purchases while the Play sheet is still open. The worker decides success/retry from `BillingManager.ensureAllAcknowledged()`, which refreshes AND acknowledges in the same coroutine — the reactive ack collector is asynchronous, so a worker cannot prove through it that its acks happened.
- Closest review points: the ack pass now runs under a mutex and returns per-outcome counts (the worker sweep and the reactive collector would otherwise race the token bookkeeping); `PurchaseAckScheduler` takes a `Provider<WorkManager>` because `AmplyApp` eagerly injects `UpgradeSurfaceSync` and with it the whole billing stack during Application field injection; and the arming call site inside `UpgradeRepoGplay.launchBillingFlowInternal` sits inside the busy-guard `try` so a failed arm still releases the guard.