### PR TITLE
Battery: See estimated charge times and details for each reading

### DIFF
--- a/app/src/debug/java/eu/darken/amply/screenshots/HubFixtures.kt
+++ b/app/src/debug/java/eu/darken/amply/screenshots/HubFixtures.kt
@@ -1,0 +1,108 @@
+// Battery-hub screenshot content. These composables render the hub's tile grid, the per-metric
+// detail screen and the charge-time card from crafted fixtures, so the screenshotTest source set can
+// capture them to PNGs on the JVM (no device). They live in the debug source set so they never ship
+// in a release build, and each has an IDE @Preview for quick iteration. Engineering regression shots
+// — they are NOT part of the Play Store screenshot flow (see ScreenshotContent.kt).
+package eu.darken.amply.screenshots
+
+import android.os.BatteryManager
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.common.compose.PreviewWrapper
+import eu.darken.amply.main.ui.battery.BatteryHubScreen
+import eu.darken.amply.main.ui.battery.ChargeTeaserState
+import eu.darken.amply.stats.core.ChargeCurvePoint
+import eu.darken.amply.stats.core.ChargeSessionSummary
+import eu.darken.amply.stats.core.ChargingType
+import eu.darken.amply.stats.core.StatsSealReason
+
+// -- Content composables (one per screenshot) --------------------------------------------------
+
+// Recording on with a finished charge behind it: every metric that varies carries a sparkline, and
+// voltage — recorded but flat — deliberately carries none while still being tappable.
+@Composable
+internal fun HubTileGridContent() = PreviewWrapper {
+    HubShot(curve = hubCurve())
+}
+
+// Recording on but nothing recorded yet: the same six tiles, live values only, none navigable.
+@Composable
+internal fun HubTileGridEmptyContent() = PreviewWrapper {
+    HubShot(curve = emptyList(), teaser = ChargeTeaserState.None)
+}
+
+// -- Shared renderer + fixtures ----------------------------------------------------------------
+
+@Composable
+private fun HubShot(
+    curve: List<ChargeCurvePoint>,
+    teaser: ChargeTeaserState = ChargeTeaserState.Last(hubLastSession),
+) = BatteryHubScreen(
+    readout = hubReadout,
+    captureEnabled = true,
+    teaser = teaser,
+    showProBadge = false,
+    onBack = {},
+    onOpenHistory = {},
+    onEnableCapture = {},
+    onOpenSession = {},
+    onOpenMetric = {},
+    curve = curve,
+)
+
+internal val hubReadout = BatteryReadout(
+    levelPercent = 82,
+    status = BatteryManager.BATTERY_STATUS_CHARGING,
+    plugged = BatteryManager.BATTERY_PLUGGED_AC,
+    health = BatteryManager.BATTERY_HEALTH_GOOD,
+    technology = "Li-ion",
+    temperatureTenthsC = 314,
+    voltageMillivolts = 4_185,
+    currentNowMicroamps = 1_250_000,
+    chargeCounterMicroampHours = 3_800_000,
+    cycleCount = 142,
+    maxChargingCurrentMicroamps = 2_000_000,
+    maxChargingVoltageMicrovolts = 9_000_000,
+)
+
+/** A rising level with a tapering current, a warming battery, and a deliberately flat voltage. */
+internal fun hubCurve(): List<ChargeCurvePoint> = (0..24).map { i ->
+    ChargeCurvePoint(
+        elapsedFromStartMillis = i * 300_000L,
+        percent = (42 + i * 2).coerceAtMost(100),
+        powerMilliwatts = (18_000 - i * 600).coerceAtLeast(2_000),
+        temperatureTenthsC = 300 + i,
+        voltageMillivolts = 4_185,
+        currentNowMicroamps = (2_400_000 - i * 80_000).coerceAtLeast(300_000),
+    )
+}
+
+internal val hubLastSession = ChargeSessionSummary(
+    id = 7,
+    startedAtWallMillis = 0,
+    endedAtWallMillis = 0,
+    durationMillis = 7_200_000,
+    startPercent = 42,
+    endPercent = 90,
+    chargingType = ChargingType.AC,
+    avgPowerMilliwatts = 12_000,
+    peakPowerMilliwatts = 27_000,
+    minTemperatureTenthsC = 300,
+    avgTemperatureTenthsC = 312,
+    maxTemperatureTenthsC = 324,
+    limitHit = false,
+    partial = false,
+    fullReachedAtWallMillis = null,
+    sealReason = StatsSealReason.UNPLUGGED,
+)
+
+// -- IDE previews (design-time only; the screenshotTest wrappers drive the actual capture) ------
+
+@Preview(name = "Hub tile grid", showBackground = true, device = DS)
+@Composable
+private fun PreviewHubTileGrid() = HubTileGridContent()
+
+@Preview(name = "Hub tile grid · nothing recorded", showBackground = true, device = DS)
+@Composable
+private fun PreviewHubTileGridEmpty() = HubTileGridEmptyContent()

--- a/app/src/debug/java/eu/darken/amply/screenshots/HubFixtures.kt
+++ b/app/src/debug/java/eu/darken/amply/screenshots/HubFixtures.kt
@@ -6,8 +6,13 @@
 package eu.darken.amply.screenshots
 
 import android.os.BatteryManager
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.common.compose.PreviewWrapper
 import eu.darken.amply.main.ui.battery.BatteryHubScreen
@@ -15,11 +20,16 @@ import eu.darken.amply.main.ui.battery.BatteryMetric
 import eu.darken.amply.main.ui.battery.BatteryMetricDetailScreen
 import eu.darken.amply.main.ui.battery.BatteryMetricDetailState
 import eu.darken.amply.main.ui.battery.ChargeTeaserState
+import eu.darken.amply.main.ui.battery.ChargeTimeCard
+import eu.darken.amply.stats.core.ChargeBandSplit
 import eu.darken.amply.stats.core.ChargeCurvePoint
 import eu.darken.amply.stats.core.ChargeSessionSummary
+import eu.darken.amply.stats.core.ChargeTimeBasis
+import eu.darken.amply.stats.core.ChargeTimeEstimate
 import eu.darken.amply.stats.core.ChargingType
 import eu.darken.amply.stats.core.MetricStats
 import eu.darken.amply.stats.core.StatsSealReason
+import eu.darken.amply.stats.ui.ChargeTimeState
 
 // -- Content composables (one per screenshot) --------------------------------------------------
 
@@ -27,13 +37,25 @@ import eu.darken.amply.stats.core.StatsSealReason
 // voltage — recorded but flat — deliberately carries none while still being tappable.
 @Composable
 internal fun HubTileGridContent() = PreviewWrapper {
-    HubShot(curve = hubCurve())
+    HubShot(
+        curve = hubCurve(),
+        chargeTime = ChargeTimeState.Ready(
+            estimate = chargeTimeEstimate,
+            basis = ChargeTimeBasis.SAME_TYPE,
+            charging = true,
+            currentPercent = 82,
+        ),
+    )
 }
 
 // Recording on but nothing recorded yet: the same six tiles, live values only, none navigable.
 @Composable
 internal fun HubTileGridEmptyContent() = PreviewWrapper {
-    HubShot(curve = emptyList(), teaser = ChargeTeaserState.None)
+    HubShot(
+        curve = emptyList(),
+        teaser = ChargeTeaserState.None,
+        chargeTime = ChargeTimeState.NotEnoughData(sessions = 0),
+    )
 }
 
 // One metric of one session: its latest value, its curve on a real axis, and the statistics taken
@@ -51,12 +73,66 @@ internal fun MetricDetailContent() = PreviewWrapper {
     )
 }
 
+// The charge-time card with a full projection: a countdown while charging, the three figures, the
+// where-the-time-goes bar, and the taper note.
+@Composable
+internal fun ChargeTimeReadyContent() = PreviewWrapper {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        ChargeTimeCard(
+            state = ChargeTimeState.Ready(
+                estimate = chargeTimeEstimate,
+                basis = ChargeTimeBasis.SAME_TYPE,
+                charging = true,
+                currentPercent = 42,
+            ),
+        )
+        // The same figures off the charger: a reference, never a countdown.
+        ChargeTimeCard(
+            state = ChargeTimeState.Ready(
+                estimate = chargeTimeEstimate,
+                basis = ChargeTimeBasis.POOLED,
+                charging = false,
+                currentPercent = 42,
+            ),
+        )
+    }
+}
+
+// Recording is on but too little has been observed to project anything yet.
+@Composable
+internal fun ChargeTimeNotEnoughContent() = PreviewWrapper {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        ChargeTimeCard(state = ChargeTimeState.NotEnoughData(sessions = 1))
+        ChargeTimeCard(state = ChargeTimeState.Loading)
+        ChargeTimeCard(state = ChargeTimeState.Unavailable)
+    }
+}
+
 // -- Shared renderer + fixtures ----------------------------------------------------------------
+
+internal val chargeTimeEstimate = ChargeTimeEstimate(
+    toEightyMillis = 2_040_000,
+    toFullMillis = 4_740_000,
+    avgSpeedMilliwatts = 11_500,
+    split = ChargeBandSplit(
+        toFiftyMillis = 2_700_000,
+        fiftyToEightyMillis = 1_800_000,
+        eightyToHundredMillis = 3_600_000,
+    ),
+    basedOnSessions = 6,
+)
 
 @Composable
 private fun HubShot(
     curve: List<ChargeCurvePoint>,
     teaser: ChargeTeaserState = ChargeTeaserState.Last(hubLastSession),
+    chargeTime: ChargeTimeState = ChargeTimeState.Loading,
 ) = BatteryHubScreen(
     readout = hubReadout,
     captureEnabled = true,
@@ -68,6 +144,7 @@ private fun HubShot(
     onOpenSession = {},
     onOpenMetric = {},
     curve = curve,
+    chargeTime = chargeTime,
 )
 
 internal val hubReadout = BatteryReadout(
@@ -129,3 +206,11 @@ private fun PreviewHubTileGridEmpty() = HubTileGridEmptyContent()
 @Preview(name = "Metric detail", showBackground = true, device = DS)
 @Composable
 private fun PreviewMetricDetail() = MetricDetailContent()
+
+@Preview(name = "Charge time · ready", showBackground = true, device = DS)
+@Composable
+private fun PreviewChargeTimeReady() = ChargeTimeReadyContent()
+
+@Preview(name = "Charge time · not enough data", showBackground = true, device = DS)
+@Composable
+private fun PreviewChargeTimeNotEnough() = ChargeTimeNotEnoughContent()

--- a/app/src/debug/java/eu/darken/amply/screenshots/HubFixtures.kt
+++ b/app/src/debug/java/eu/darken/amply/screenshots/HubFixtures.kt
@@ -50,9 +50,12 @@ internal fun HubTileGridContent() = PreviewWrapper {
 }
 
 // Recording on but nothing recorded yet: the same six tiles, live values only, none navigable.
+// Held at a limit while plugged in, so this shot also carries the longest status value there is —
+// it has to wrap inside its tile rather than end in an ellipsis.
 @Composable
 internal fun HubTileGridEmptyContent() = PreviewWrapper {
     HubShot(
+        readout = hubHeldReadout,
         curve = emptyList(),
         teaser = ChargeTeaserState.None,
         chargeTime = ChargeTimeState.NotEnoughData(sessions = 0),
@@ -132,10 +135,11 @@ internal val chargeTimeEstimate = ChargeTimeEstimate(
 @Composable
 private fun HubShot(
     curve: List<ChargeCurvePoint>,
+    readout: BatteryReadout = hubReadout,
     teaser: ChargeTeaserState = ChargeTeaserState.Last(hubLastSession),
     chargeTime: ChargeTimeState = ChargeTimeState.Loading,
 ) = BatteryHubScreen(
-    readout = hubReadout,
+    readout = readout,
     captureEnabled = true,
     teaser = teaser,
     showProBadge = false,
@@ -162,6 +166,12 @@ internal val hubReadout = BatteryReadout(
     cycleCount = 142,
     maxChargingCurrentMicroamps = 2_000_000,
     maxChargingVoltageMicrovolts = 9_000_000,
+)
+
+/** The same battery, plugged in but not taking charge: the status tile's longest value. */
+internal val hubHeldReadout = hubReadout.copy(
+    status = BatteryManager.BATTERY_STATUS_NOT_CHARGING,
+    currentNowMicroamps = 0,
 )
 
 /** A rising level with a tapering current, a warming battery, and a deliberately flat voltage. */

--- a/app/src/debug/java/eu/darken/amply/screenshots/HubFixtures.kt
+++ b/app/src/debug/java/eu/darken/amply/screenshots/HubFixtures.kt
@@ -11,10 +11,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.common.compose.PreviewWrapper
 import eu.darken.amply.main.ui.battery.BatteryHubScreen
+import eu.darken.amply.main.ui.battery.BatteryMetric
+import eu.darken.amply.main.ui.battery.BatteryMetricDetailScreen
+import eu.darken.amply.main.ui.battery.BatteryMetricDetailState
 import eu.darken.amply.main.ui.battery.ChargeTeaserState
 import eu.darken.amply.stats.core.ChargeCurvePoint
 import eu.darken.amply.stats.core.ChargeSessionSummary
 import eu.darken.amply.stats.core.ChargingType
+import eu.darken.amply.stats.core.MetricStats
 import eu.darken.amply.stats.core.StatsSealReason
 
 // -- Content composables (one per screenshot) --------------------------------------------------
@@ -30,6 +34,21 @@ internal fun HubTileGridContent() = PreviewWrapper {
 @Composable
 internal fun HubTileGridEmptyContent() = PreviewWrapper {
     HubShot(curve = emptyList(), teaser = ChargeTeaserState.None)
+}
+
+// One metric of one session: its latest value, its curve on a real axis, and the statistics taken
+// from the raw samples (deliberately wider than the plotted curve).
+@Composable
+internal fun MetricDetailContent() = PreviewWrapper {
+    BatteryMetricDetailScreen(
+        state = BatteryMetricDetailState(
+            metric = BatteryMetric.POWER,
+            sessionMissing = false,
+            curve = hubCurve(),
+            stats = MetricStats(min = 1_850, avg = 9_400, max = 19_200, sampleCount = 214),
+        ),
+        onBack = {},
+    )
 }
 
 // -- Shared renderer + fixtures ----------------------------------------------------------------
@@ -106,3 +125,7 @@ private fun PreviewHubTileGrid() = HubTileGridContent()
 @Preview(name = "Hub tile grid · nothing recorded", showBackground = true, device = DS)
 @Composable
 private fun PreviewHubTileGridEmpty() = HubTileGridEmptyContent()
+
+@Preview(name = "Metric detail", showBackground = true, device = DS)
+@Composable
+private fun PreviewMetricDetail() = MetricDetailContent()

--- a/app/src/debug/java/eu/darken/amply/screenshots/HubFixtures.kt
+++ b/app/src/debug/java/eu/darken/amply/screenshots/HubFixtures.kt
@@ -27,6 +27,7 @@ import eu.darken.amply.stats.core.ChargeSessionSummary
 import eu.darken.amply.stats.core.ChargeTimeBasis
 import eu.darken.amply.stats.core.ChargeTimeEstimate
 import eu.darken.amply.stats.core.ChargingType
+import eu.darken.amply.stats.core.CurveMetricAvailability
 import eu.darken.amply.stats.core.MetricStats
 import eu.darken.amply.stats.core.StatsSealReason
 import eu.darken.amply.stats.ui.ChargeTimeState
@@ -144,6 +145,7 @@ private fun HubShot(
     onOpenSession = {},
     onOpenMetric = {},
     curve = curve,
+    availability = CurveMetricAvailability.of(curve),
     chargeTime = chargeTime,
 )
 

--- a/app/src/main/java/eu/darken/amply/battery/ui/BatteryEffect.kt
+++ b/app/src/main/java/eu/darken/amply/battery/ui/BatteryEffect.kt
@@ -106,3 +106,35 @@ fun chargePowerFallbackRes(effect: BatteryEffect): Int = when (effect) {
     BatteryEffect.Unknown,
     -> R.string.battery_value_not_reported
 }
+
+/** What a half-width tile shows for a withheld charge power, and what it announces instead. */
+data class ChargePowerTileFallback(
+    @StringRes val textRes: Int,
+    @StringRes val spokenRes: Int,
+)
+
+/**
+ * The tile-grid variant of [chargePowerFallbackRes] — same `when`, different rendering, kept
+ * adjacent so any future divergence between the two is visible in one place.
+ *
+ * A tile is half the screen wide and fits roughly twelve characters, so "Not charging" is a
+ * wrapped or ellipsised sentence in a slot whose neighbours are numbers. The dash reads as absence
+ * at that size and the spoken form carries the meaning that the glyph cannot, which is why this
+ * returns both. A label-left/value-right detail row has no such width problem, so it keeps the
+ * words.
+ *
+ * "Not reported" never collapses into the dash: it states a *device capability* — the platform
+ * exposed no figure — rather than a charging state, and a dash there would claim the battery is
+ * observably not charging when nothing observed it.
+ */
+fun chargePowerTileFallback(effect: BatteryEffect): ChargePowerTileFallback = when (effect) {
+    is BatteryEffect.OnBattery,
+    is BatteryEffect.ConnectedNotCharging,
+    is BatteryEffect.Full,
+    -> ChargePowerTileFallback(R.string.battery_value_none, R.string.battery_value_not_charging)
+
+    is BatteryEffect.Charging,
+    is BatteryEffect.Connected,
+    BatteryEffect.Unknown,
+    -> ChargePowerTileFallback(R.string.battery_value_not_reported, R.string.battery_value_not_reported)
+}

--- a/app/src/main/java/eu/darken/amply/common/compose/chart/Sparkline.kt
+++ b/app/src/main/java/eu/darken/amply/common/compose/chart/Sparkline.kt
@@ -1,0 +1,131 @@
+package eu.darken.amply.common.compose.chart
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.PreviewWrapper
+
+const val SPARKLINE_TEST_TAG = "chart.sparkline"
+
+/**
+ * A single self-normalized series with no axes, labels or legend — the shape of one metric, small
+ * enough to sit inside a stat tile.
+ *
+ * Deliberately **not** [LineChart] with everything switched off: that component always renders its
+ * legend `FlowRow` and reserves an end-label gutter, neither of which can be disabled, so at tile
+ * size the result would be mostly chrome.
+ *
+ * The API takes real [ChartPoint]s rather than a bare list of values because battery samples are not
+ * evenly spaced in time (the recorder samples on level change as well as on its timer) — spacing
+ * them equally would draw a shape the session never had. X is elapsed-from-start.
+ *
+ * Nothing is drawn unless the series has an **adjacent** non-null pair with **different** values —
+ * the same rule `StatsCurveChart` gates its live curve on. A self-normalized series with no range
+ * would otherwise render as a flat line at the canvas midpoint, which reads as a plotted trend but
+ * is really the "no range" fallback; and a path broken at nulls draws nothing at all. Callers can
+ * assert presence/absence via [SPARKLINE_TEST_TAG], which only the drawn case carries.
+ */
+@Composable
+fun Sparkline(
+    points: List<ChartPoint>,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.primary,
+    height: Dp = 28.dp,
+) {
+    if (!points.hasDrawableVariation()) return
+
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(height)
+            .testTag(SPARKLINE_TEST_TAG),
+    ) {
+        val drawn = points.filter { it.y != null }
+        val xs = drawn.map { it.x }
+        val ys = drawn.map { it.y!! }
+        val xMin = xs.min()
+        val xSpan = (xs.max() - xMin).takeIf { it > 0f } ?: 1f
+        val yMin = ys.min()
+        val ySpan = (ys.max() - yMin).takeIf { it > 0f } ?: 1f
+        // Inset by the stroke so the extremes aren't clipped at the canvas edges.
+        val inset = 2f
+        val usableHeight = (size.height - inset * 2).coerceAtLeast(1f)
+
+        fun px(x: Float) = (x - xMin) / xSpan * size.width
+        fun py(y: Float) = inset + usableHeight * (1f - (y - yMin) / ySpan)
+
+        // Break the path across null gaps rather than interpolating over missing data.
+        var path: Path? = null
+        points.forEach { point ->
+            val y = point.y
+            if (y == null) {
+                path?.let { drawPath(it, color, style = Stroke(width = 3f, cap = StrokeCap.Round)) }
+                path = null
+                return@forEach
+            }
+            val offset = Offset(px(point.x), py(y))
+            val current = path
+            if (current == null) {
+                path = Path().apply { moveTo(offset.x, offset.y) }
+            } else {
+                current.lineTo(offset.x, offset.y)
+            }
+        }
+        path?.let { drawPath(it, color, style = Stroke(width = 3f, cap = StrokeCap.Round)) }
+    }
+}
+
+/**
+ * True when at least one **adjacent** pair of non-null samples differs — the only case a
+ * self-normalized single-series line can actually draw as a curve.
+ */
+fun List<ChartPoint>.hasDrawableVariation(): Boolean = zipWithNext().any { (first, second) ->
+    val a = first.y
+    val b = second.y
+    a != null && b != null && a != b
+}
+
+@AmplyPreview
+@Composable
+private fun SparklinePreview() = PreviewWrapper {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text("Rising level", style = MaterialTheme.typography.labelSmall)
+        Sparkline(points = (0..20).map { ChartPoint(it * 60_000f, 42f + it * 2.4f) })
+
+        Text("Uneven sample spacing, with a gap", style = MaterialTheme.typography.labelSmall)
+        Sparkline(
+            points = listOf(
+                ChartPoint(0f, 18_000f),
+                ChartPoint(30_000f, 17_200f),
+                ChartPoint(45_000f, 12_400f),
+                ChartPoint(600_000f, null),
+                ChartPoint(900_000f, 6_100f),
+                ChartPoint(1_500_000f, 2_400f),
+            ),
+            color = MaterialTheme.colorScheme.tertiary,
+        )
+
+        // A constant series draws nothing at all rather than a fake midline — this row stays empty.
+        Text("Constant (renders nothing)", style = MaterialTheme.typography.labelSmall)
+        Sparkline(points = (0..10).map { ChartPoint(it * 60_000f, 4_185f) })
+    }
+}

--- a/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
@@ -51,6 +51,7 @@ import eu.darken.amply.charging.core.adapter.OemChargingShortcuts
 import eu.darken.amply.diagnostics.ui.ContributionWizardScreen
 import eu.darken.amply.diagnostics.ui.ContributionWizardViewModel
 import eu.darken.amply.main.ui.battery.BatteryHubScreen
+import eu.darken.amply.main.ui.battery.BatteryMetricDetailScreen
 import eu.darken.amply.main.ui.battery.ChargeTeaserState
 import eu.darken.amply.main.ui.dashboard.DashboardScreen
 import eu.darken.amply.main.ui.dashboard.DashboardViewModel
@@ -405,6 +406,13 @@ class MainActivity : ComponentActivity() {
                             SettingsDestination.BATTERY -> destination = SettingsDestination.DASHBOARD
                             // The history list is only reachable from the battery hub's top bar.
                             SettingsDestination.CHARGE_HISTORY -> destination = SettingsDestination.BATTERY
+                            // The metric detail is only reachable from a hub tile. Both saved keys
+                            // are cleared together, so a restored process can't come back to a
+                            // metric without the session it belonged to.
+                            SettingsDestination.BATTERY_METRIC_DETAIL -> {
+                                statsViewModel.closeMetric()
+                                destination = SettingsDestination.BATTERY
+                            }
                             // Reached from the dashboard card or the settings hub.
                             SettingsDestination.CHARGE_RULES -> destination = rulesOrigin
                             // Asks rather than closes: an edited draft raises the discard
@@ -680,8 +688,27 @@ class MainActivity : ComponentActivity() {
                                     statsViewModel.requestEnableCapture()
                                 },
                                 onOpenSession = { id -> openSession(id, SettingsDestination.BATTERY) },
-                                onOpenMetric = {},
+                                // A tile only offers the tap when that metric has samples in the
+                                // shown charge, so there is always a session id to pair it with.
+                                onOpenMetric = { metric ->
+                                    val sessionId = (teaser as? ChargeTeaserState.Live)?.session?.id
+                                        ?: lastSessionId
+                                    if (sessionId != null) {
+                                        statsViewModel.openMetric(sessionId, metric)
+                                        destination = SettingsDestination.BATTERY_METRIC_DETAIL
+                                    }
+                                },
                                 curve = liveCurve ?: if (lastSessionId != null) lastCurve else emptyList(),
+                            )
+                        }
+                        SettingsDestination.BATTERY_METRIC_DETAIL -> {
+                            val metricDetail by statsViewModel.metricDetailState.collectAsState()
+                            BatteryMetricDetailScreen(
+                                state = metricDetail,
+                                onBack = {
+                                    statsViewModel.closeMetric()
+                                    destination = SettingsDestination.BATTERY
+                                },
                             )
                         }
                         // The Room-backed session list is collected only here, so the stats DB isn't

--- a/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
@@ -659,20 +659,31 @@ class MainActivity : ComponentActivity() {
                         // state (already collected and resolved, so the opt-in card can't flash on for
                         // a frame beside a teaser saying a charge is being recorded) — deliberately not
                         // the stats ViewModel's history flow, which is what would open stats.db.
-                        SettingsDestination.BATTERY -> BatteryHubScreen(
-                            readout = state.batteryReadout,
-                            captureEnabled = state.stats.enabled,
-                            teaser = ChargeTeaserState.from(state.stats, state.batteryReadout),
-                            showProBadge = shouldShowUpgradePromo(state.upgrade),
-                            onBack = { destination = SettingsDestination.DASHBOARD },
-                            onOpenHistory = { destination = SettingsDestination.CHARGE_HISTORY },
-                            // Enable-only: turning recording back off lives in Settings › Charging history.
-                            onEnableCapture = {
-                                captureGateOrigin = SettingsDestination.BATTERY
-                                statsViewModel.requestEnableCapture()
-                            },
-                            onOpenSession = { id -> openSession(id, SettingsDestination.BATTERY) },
-                        )
+                        SettingsDestination.BATTERY -> {
+                            val teaser = ChargeTeaserState.from(state.stats, state.batteryReadout)
+                            // A live charge already carries its (bounded) curve in the teaser; only a
+                            // finished one has to be read, and only while the hub is on screen.
+                            val liveCurve = (teaser as? ChargeTeaserState.Live)?.session?.curve
+                            val lastSessionId = (teaser as? ChargeTeaserState.Last)?.summary?.id
+                            LaunchedEffect(lastSessionId) { statsViewModel.setHubSession(lastSessionId) }
+                            val lastCurve by statsViewModel.hubCurve.collectAsState()
+                            BatteryHubScreen(
+                                readout = state.batteryReadout,
+                                captureEnabled = state.stats.enabled,
+                                teaser = teaser,
+                                showProBadge = shouldShowUpgradePromo(state.upgrade),
+                                onBack = { destination = SettingsDestination.DASHBOARD },
+                                onOpenHistory = { destination = SettingsDestination.CHARGE_HISTORY },
+                                // Enable-only: turning recording back off lives in Settings › Charging history.
+                                onEnableCapture = {
+                                    captureGateOrigin = SettingsDestination.BATTERY
+                                    statsViewModel.requestEnableCapture()
+                                },
+                                onOpenSession = { id -> openSession(id, SettingsDestination.BATTERY) },
+                                onOpenMetric = {},
+                                curve = liveCurve ?: if (lastSessionId != null) lastCurve else emptyList(),
+                            )
+                        }
                         // The Room-backed session list is collected only here, so the stats DB isn't
                         // opened just by visiting the hub — a user who never enables statistics never
                         // creates stats.db by looking at their battery.

--- a/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
@@ -688,6 +688,9 @@ class MainActivity : ComponentActivity() {
                                     statsViewModel.requestEnableCapture()
                                 },
                                 onOpenSession = { id -> openSession(id, SettingsDestination.BATTERY) },
+                                // The same fold the dashboard's charging card reads, so the two
+                                // surfaces can never quote different charge times.
+                                chargeTime = state.chargeTime,
                                 // A tile only offers the tap when that metric has samples in the
                                 // shown charge, so there is always a session id to pair it with.
                                 onOpenMetric = { metric ->

--- a/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
@@ -70,6 +70,7 @@ import eu.darken.amply.rules.core.PlugKind
 import eu.darken.amply.rules.ui.ChargeRuleEditorScreen
 import eu.darken.amply.rules.ui.ChargeRulesScreen
 import eu.darken.amply.rules.ui.ChargeRulesViewModel
+import eu.darken.amply.stats.core.CurveMetricAvailability
 import eu.darken.amply.stats.ui.ChargeHistoryScreen
 import eu.darken.amply.stats.ui.StatsSessionDetailScreen
 import eu.darken.amply.stats.ui.StatsViewModel
@@ -669,12 +670,22 @@ class MainActivity : ComponentActivity() {
                         // the stats ViewModel's history flow, which is what would open stats.db.
                         SettingsDestination.BATTERY -> {
                             val teaser = ChargeTeaserState.from(state.stats, state.batteryReadout)
-                            // A live charge already carries its (bounded) curve in the teaser; only a
-                            // finished one has to be read, and only while the hub is on screen.
-                            val liveCurve = (teaser as? ChargeTeaserState.Live)?.session?.curve
+                            // A live charge already carries its (bounded) curve — and what it
+                            // recorded — in the teaser; only a finished one has to be read, and only
+                            // while the hub is on screen.
+                            val liveSession = (teaser as? ChargeTeaserState.Live)?.session
                             val lastSessionId = (teaser as? ChargeTeaserState.Last)?.summary?.id
                             LaunchedEffect(lastSessionId) { statsViewModel.setHubSession(lastSessionId) }
                             val lastCurve by statsViewModel.hubCurve.collectAsState()
+                            val shownCurve = liveSession?.curve
+                                ?: if (lastSessionId != null) lastCurve.curve else emptyList()
+                            // Tile tappability rides on this, never on the decimated curve above.
+                            val shownAvailability = liveSession?.availability
+                                ?: if (lastSessionId != null) {
+                                    lastCurve.availability
+                                } else {
+                                    CurveMetricAvailability.NONE
+                                }
                             BatteryHubScreen(
                                 readout = state.batteryReadout,
                                 captureEnabled = state.stats.enabled,
@@ -694,14 +705,14 @@ class MainActivity : ComponentActivity() {
                                 // A tile only offers the tap when that metric has samples in the
                                 // shown charge, so there is always a session id to pair it with.
                                 onOpenMetric = { metric ->
-                                    val sessionId = (teaser as? ChargeTeaserState.Live)?.session?.id
-                                        ?: lastSessionId
+                                    val sessionId = liveSession?.id ?: lastSessionId
                                     if (sessionId != null) {
                                         statsViewModel.openMetric(sessionId, metric)
                                         destination = SettingsDestination.BATTERY_METRIC_DETAIL
                                     }
                                 },
-                                curve = liveCurve ?: if (lastSessionId != null) lastCurve else emptyList(),
+                                curve = shownCurve,
+                                availability = shownAvailability,
                             )
                         }
                         SettingsDestination.BATTERY_METRIC_DETAIL -> {

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
@@ -37,7 +37,7 @@ import eu.darken.amply.battery.ui.BatteryEffect
 import eu.darken.amply.battery.ui.batteryHealthLabel
 import eu.darken.amply.battery.ui.batteryPlugLabel
 import eu.darken.amply.battery.ui.batteryStatusLabel
-import eu.darken.amply.battery.ui.chargePowerFallbackRes
+import eu.darken.amply.battery.ui.chargePowerTileFallback
 import eu.darken.amply.battery.ui.formatChargeCounter
 import eu.darken.amply.common.compose.AmplyCard
 import eu.darken.amply.common.compose.AmplyCardDefaults
@@ -195,16 +195,27 @@ private fun StatTileGrid(
     val openLabel = stringResource(R.string.battery_metric_open_action)
     val notReported = stringResource(R.string.battery_value_not_reported)
     // Charge power is the one reading with a meaningful "not charging" state, and it is the same
-    // rule the electrical rows used before the tiles existed.
-    val powerFallback = stringResource(chargePowerFallbackRes(BatteryEffect.from(readout)))
+    // rule the electrical rows used before the tiles existed — rendered as a dash here, because a
+    // half-width tile has no room for the words.
+    val powerFallback = chargePowerTileFallback(BatteryEffect.from(readout))
+    val powerFallbackText = stringResource(powerFallback.textRes)
+    val powerFallbackSpoken = stringResource(powerFallback.spokenRes)
 
     @Composable
     fun metricTile(metric: BatteryMetric, modifier: Modifier, icon: ImageVector? = null) {
-        val fallback = if (metric == BatteryMetric.POWER) powerFallback else notReported
+        val isPower = metric == BatteryMetric.POWER
+        val fallback = if (isPower) powerFallbackText else notReported
+        val shown = metric.format(metric.select(readout))
+        // The dash stands in for a figure rather than being one, so it is dimmed and speaks the
+        // words it replaces — which is exactly the case where the fallback's shown and spoken forms
+        // differ. Every other value, "Not reported" included, renders as written.
+        val isDash = isPower && shown == null && powerFallback.textRes != powerFallback.spokenRes
         BatteryStatTile(
             label = stringResource(metric.titleRes),
-            value = metric.format(metric.select(readout)) ?: fallback,
+            value = shown ?: fallback,
             modifier = modifier,
+            valueColor = if (isDash) MaterialTheme.colorScheme.onSurfaceVariant else Color.Unspecified,
+            valueDescription = if (isDash) powerFallbackSpoken else null,
             icon = icon,
             sparkline = curve.map {
                 ChartPoint(it.elapsedFromStartMillis.toFloat(), metric.select(it)?.toFloat())

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
@@ -44,8 +44,12 @@ import eu.darken.amply.common.compose.AmplyCardDefaults
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
 import eu.darken.amply.common.compose.chart.ChartPoint
+import eu.darken.amply.stats.core.ChargeBandSplit
 import eu.darken.amply.stats.core.ChargeCurvePoint
+import eu.darken.amply.stats.core.ChargeTimeBasis
+import eu.darken.amply.stats.core.ChargeTimeEstimate
 import eu.darken.amply.stats.core.StatsPowerCalculator
+import eu.darken.amply.stats.ui.ChargeTimeState
 import eu.darken.amply.stats.ui.StatsFormat
 
 /**
@@ -75,6 +79,9 @@ fun BatteryHubScreen(
     // The charge being shown by the teaser, for the tiles' sparklines and their tappability. Empty
     // until something has been recorded — every tile still renders its live value.
     curve: List<ChargeCurvePoint> = emptyList(),
+    // Charge-time estimates. Only rendered while recording is on: they come entirely from recorded
+    // history, so with recording off there is no card rather than an empty one.
+    chargeTime: ChargeTimeState = ChargeTimeState.Loading,
 ) {
     Scaffold(
         topBar = {
@@ -125,6 +132,9 @@ fun BatteryHubScreen(
                         currentPercent = data.levelPercent,
                     )
                 }
+            }
+            if (captureEnabled) {
+                item { ChargeTimeCard(state = chargeTime) }
             }
             item { SectionHeader(stringResource(R.string.battery_hub_section_now)) }
             // A Column of Rows, not a LazyVerticalGrid: this screen is itself a LazyColumn, and
@@ -327,6 +337,23 @@ private val previewCharging = BatteryReadout(
     maxChargingVoltageMicrovolts = 9_000_000,
 )
 
+private val previewChargeTime = ChargeTimeState.Ready(
+    estimate = ChargeTimeEstimate(
+        toEightyMillis = null,
+        toFullMillis = 1_080_000,
+        avgSpeedMilliwatts = 11_500,
+        split = ChargeBandSplit(
+            toFiftyMillis = 2_700_000,
+            fiftyToEightyMillis = 1_800_000,
+            eightyToHundredMillis = 3_600_000,
+        ),
+        basedOnSessions = 6,
+    ),
+    basis = ChargeTimeBasis.SAME_TYPE,
+    charging = true,
+    currentPercent = 82,
+)
+
 @AmplyPreview
 @Composable
 private fun BatteryHubScreenLivePreview() = PreviewWrapper {
@@ -342,6 +369,7 @@ private fun BatteryHubScreenLivePreview() = PreviewWrapper {
         onOpenSession = {},
         onOpenMetric = {},
         curve = previewCurve,
+        chargeTime = previewChargeTime,
     )
 }
 

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
@@ -151,9 +151,11 @@ fun BatteryHubScreen(
                     onOpenMetric = onOpenMetric,
                 )
             }
-            item { ChargingSection(data) }
-            item { HealthSection(data) }
-            item { ElectricalSection(data) }
+            // Battery before charger: unplugged, both charger rows read "Not reported", and a
+            // charger-first order would open the section list with two empty rows in the most
+            // common state. Keep this order.
+            item { BatterySection(data) }
+            item { ChargerSection(data) }
         }
     }
 }
@@ -267,25 +269,15 @@ private fun BatteryMetric.accentColor(): Color = when (this) {
     BatteryMetric.VOLTAGE, BatteryMetric.CURRENT -> MaterialTheme.colorScheme.secondary
 }
 
+/** Facts about the cell itself. Voltage, current and charge power moved up into the tile grid. */
 @Composable
-private fun ChargingSection(readout: BatteryReadout) {
+private fun BatterySection(readout: BatteryReadout) {
     val notReported = stringResource(R.string.battery_value_not_reported)
-    DetailSection(stringResource(R.string.battery_detail_section_charging)) {
-        DetailRow(
-            stringResource(R.string.battery_detail_power_source),
-            batteryPlugLabel(readout.plugged)?.let { stringResource(it) } ?: notReported,
-        )
+    DetailSection(stringResource(R.string.battery_detail_section_battery)) {
         DetailRow(
             stringResource(R.string.battery_detail_technology),
             readout.technology ?: notReported,
         )
-    }
-}
-
-@Composable
-private fun HealthSection(readout: BatteryReadout) {
-    val notReported = stringResource(R.string.battery_value_not_reported)
-    DetailSection(stringResource(R.string.battery_detail_section_health)) {
         DetailRow(
             stringResource(R.string.battery_detail_health),
             stringResource(batteryHealthLabel(readout.health)),
@@ -294,15 +286,22 @@ private fun HealthSection(readout: BatteryReadout) {
             stringResource(R.string.battery_detail_cycle_count),
             readout.cycleCount?.toString() ?: notReported,
         )
+        DetailRow(
+            stringResource(R.string.battery_detail_charge_counter),
+            formatChargeCounter(readout.chargeCounterMicroampHours) ?: notReported,
+        )
     }
 }
 
+/** Facts about whatever is currently plugged in. */
 @Composable
-private fun ElectricalSection(readout: BatteryReadout) {
+private fun ChargerSection(readout: BatteryReadout) {
     val notReported = stringResource(R.string.battery_value_not_reported)
-    // Voltage, current and charge power moved up into the tile grid; what stays here is the pair
-    // that has no live series to chart.
-    DetailSection(stringResource(R.string.battery_detail_section_electrical)) {
+    DetailSection(stringResource(R.string.battery_detail_section_charger)) {
+        DetailRow(
+            stringResource(R.string.battery_detail_power_source),
+            batteryPlugLabel(readout.plugged)?.let { stringResource(it) } ?: notReported,
+        )
         // Advertised, not measured: what the connected supply claims. Nothing connected means nothing
         // to claim, so the extras are only read through while on a charger.
         DetailRow(
@@ -310,10 +309,6 @@ private fun ElectricalSection(readout: BatteryReadout) {
             readout.takeIf { it.onCharger }
                 ?.let { StatsFormat.power(StatsPowerCalculator.advertisedMaxMilliwatts(it)) }
                 ?: notReported,
-        )
-        DetailRow(
-            stringResource(R.string.battery_detail_charge_counter),
-            formatChargeCounter(readout.chargeCounterMicroampHours) ?: notReported,
         )
     }
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
@@ -249,6 +249,10 @@ private fun StatTileGrid(
                 // ("Plugged in, not charging"), so it reads a step smaller than the numbers and wraps
                 // into the room that buys instead of being clipped.
                 valueStyle = MaterialTheme.typography.titleMedium,
+                // The third line is for accessibility font scales, not for normal rendering: at 2x
+                // the sentence needs 24 characters where two lines of this style hold 22. The box is
+                // a minimum height, so at normal scale the value still takes the lines it needs.
+                valueMaxLines = 3,
             )
         }
     }

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
@@ -48,6 +48,7 @@ import eu.darken.amply.stats.core.ChargeBandSplit
 import eu.darken.amply.stats.core.ChargeCurvePoint
 import eu.darken.amply.stats.core.ChargeTimeBasis
 import eu.darken.amply.stats.core.ChargeTimeEstimate
+import eu.darken.amply.stats.core.CurveMetricAvailability
 import eu.darken.amply.stats.core.StatsPowerCalculator
 import eu.darken.amply.stats.ui.ChargeTimeState
 import eu.darken.amply.stats.ui.StatsFormat
@@ -76,9 +77,12 @@ fun BatteryHubScreen(
     onEnableCapture: () -> Unit,
     onOpenSession: (Long) -> Unit,
     onOpenMetric: (BatteryMetric) -> Unit,
-    // The charge being shown by the teaser, for the tiles' sparklines and their tappability. Empty
-    // until something has been recorded — every tile still renders its live value.
+    // The charge being shown by the teaser, for the tiles' sparklines. Empty until something has been
+    // recorded — every tile still renders its live value.
     curve: List<ChargeCurvePoint> = emptyList(),
+    // What that charge actually recorded, taken from its raw samples: the curve above is decimated,
+    // so it cannot answer "was this metric ever reported" (see CurveMetricAvailability).
+    availability: CurveMetricAvailability = CurveMetricAvailability.NONE,
     // Charge-time estimates. Only rendered while recording is on: they come entirely from recorded
     // history, so with recording off there is no card rather than an empty one.
     chargeTime: ChargeTimeState = ChargeTimeState.Loading,
@@ -139,7 +143,14 @@ fun BatteryHubScreen(
             item { SectionHeader(stringResource(R.string.battery_hub_section_now)) }
             // A Column of Rows, not a LazyVerticalGrid: this screen is itself a LazyColumn, and
             // nesting a lazy grid in a lazy column throws at runtime.
-            item { StatTileGrid(readout = data, curve = curve, onOpenMetric = onOpenMetric) }
+            item {
+                StatTileGrid(
+                    readout = data,
+                    curve = curve,
+                    availability = availability,
+                    onOpenMetric = onOpenMetric,
+                )
+            }
             item { ChargingSection(data) }
             item { HealthSection(data) }
             item { ElectricalSection(data) }
@@ -170,11 +181,15 @@ private fun SectionHeader(title: String) = Text(
  * samples vary. A constant reading is still worth opening (min == avg == max is an answer, and the
  * detail chart plots a zero-range series on a real axis); only the sparkline needs variation,
  * which it decides for itself. Status is a label, not a series, so it never navigates.
+ *
+ * Tappability comes from [availability], never from [curve]: the curve is decimated for drawing, so
+ * an intermittently reported metric can be absent from it while the session holds readings for it.
  */
 @Composable
 private fun StatTileGrid(
     readout: BatteryReadout,
     curve: List<ChargeCurvePoint>,
+    availability: CurveMetricAvailability,
     onOpenMetric: (BatteryMetric) -> Unit,
 ) {
     val openLabel = stringResource(R.string.battery_metric_open_action)
@@ -195,7 +210,7 @@ private fun StatTileGrid(
                 ChartPoint(it.elapsedFromStartMillis.toFloat(), metric.select(it)?.toFloat())
             },
             accentColor = metric.accentColor(),
-            onClick = if (metric.hasSamples(curve)) {
+            onClick = if (metric.hasSamples(availability)) {
                 { onOpenMetric(metric) }
             } else {
                 null
@@ -369,6 +384,7 @@ private fun BatteryHubScreenLivePreview() = PreviewWrapper {
         onOpenSession = {},
         onOpenMetric = {},
         curve = previewCurve,
+        availability = CurveMetricAvailability.of(previewCurve),
         chargeTime = previewChargeTime,
     )
 }
@@ -390,6 +406,7 @@ private fun BatteryHubScreenLastPreview() = PreviewWrapper {
         onOpenSession = {},
         onOpenMetric = {},
         curve = previewCurve,
+        availability = CurveMetricAvailability.of(previewCurve),
     )
 }
 
@@ -470,5 +487,6 @@ private fun BatteryHubScreenLargeFontPreview() = PreviewWrapper {
         onOpenSession = {},
         onOpenMetric = {},
         curve = previewCurve,
+        availability = CurveMetricAvailability.of(previewCurve),
     )
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
@@ -234,6 +234,10 @@ private fun StatTileGrid(
                 label = stringResource(R.string.battery_detail_status),
                 value = stringResource(batteryStatusLabel(readout.status, readout.plugged)),
                 modifier = tile,
+                // A state label, not a measurement: it is the one tile whose value is a sentence
+                // ("Plugged in, not charging"), so it reads a step smaller than the numbers and wraps
+                // into the room that buys instead of being clipped.
+                valueStyle = MaterialTheme.typography.titleMedium,
             )
         }
     }

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryHubScreen.kt
@@ -1,6 +1,7 @@
 package eu.darken.amply.main.ui.battery
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,6 +11,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ShowChart
+import androidx.compose.material.icons.filled.BatteryChargingFull
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Thermostat
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -20,6 +24,8 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -33,13 +39,12 @@ import eu.darken.amply.battery.ui.batteryPlugLabel
 import eu.darken.amply.battery.ui.batteryStatusLabel
 import eu.darken.amply.battery.ui.chargePowerFallbackRes
 import eu.darken.amply.battery.ui.formatChargeCounter
-import eu.darken.amply.battery.ui.formatCurrent
-import eu.darken.amply.battery.ui.formatTemperature
-import eu.darken.amply.battery.ui.formatVoltage
 import eu.darken.amply.common.compose.AmplyCard
 import eu.darken.amply.common.compose.AmplyCardDefaults
 import eu.darken.amply.common.compose.AmplyPreview
 import eu.darken.amply.common.compose.PreviewWrapper
+import eu.darken.amply.common.compose.chart.ChartPoint
+import eu.darken.amply.stats.core.ChargeCurvePoint
 import eu.darken.amply.stats.core.StatsPowerCalculator
 import eu.darken.amply.stats.ui.StatsFormat
 
@@ -66,6 +71,10 @@ fun BatteryHubScreen(
     onOpenHistory: () -> Unit,
     onEnableCapture: () -> Unit,
     onOpenSession: (Long) -> Unit,
+    onOpenMetric: (BatteryMetric) -> Unit,
+    // The charge being shown by the teaser, for the tiles' sparklines and their tappability. Empty
+    // until something has been recorded — every tile still renders its live value.
+    curve: List<ChargeCurvePoint> = emptyList(),
 ) {
     Scaffold(
         topBar = {
@@ -118,10 +127,12 @@ fun BatteryHubScreen(
                 }
             }
             item { SectionHeader(stringResource(R.string.battery_hub_section_now)) }
+            // A Column of Rows, not a LazyVerticalGrid: this screen is itself a LazyColumn, and
+            // nesting a lazy grid in a lazy column throws at runtime.
+            item { StatTileGrid(readout = data, curve = curve, onOpenMetric = onOpenMetric) }
             item { ChargingSection(data) }
             item { HealthSection(data) }
             item { ElectricalSection(data) }
-            item { ThermalSection(data) }
         }
     }
 }
@@ -142,18 +153,80 @@ private fun SectionHeader(title: String) = Text(
     modifier = Modifier.padding(start = 4.dp, top = 4.dp),
 )
 
+/**
+ * The six live readings as a 2-column tile grid.
+ *
+ * A tile is tappable when the shown charge recorded **any** sample for that metric — not when the
+ * samples vary. A constant reading is still worth opening (min == avg == max is an answer, and the
+ * detail chart plots a zero-range series on a real axis); only the sparkline needs variation,
+ * which it decides for itself. Status is a label, not a series, so it never navigates.
+ */
+@Composable
+private fun StatTileGrid(
+    readout: BatteryReadout,
+    curve: List<ChargeCurvePoint>,
+    onOpenMetric: (BatteryMetric) -> Unit,
+) {
+    val openLabel = stringResource(R.string.battery_metric_open_action)
+    val notReported = stringResource(R.string.battery_value_not_reported)
+    // Charge power is the one reading with a meaningful "not charging" state, and it is the same
+    // rule the electrical rows used before the tiles existed.
+    val powerFallback = stringResource(chargePowerFallbackRes(BatteryEffect.from(readout)))
+
+    @Composable
+    fun metricTile(metric: BatteryMetric, modifier: Modifier, icon: ImageVector? = null) {
+        val fallback = if (metric == BatteryMetric.POWER) powerFallback else notReported
+        BatteryStatTile(
+            label = stringResource(metric.titleRes),
+            value = metric.format(metric.select(readout)) ?: fallback,
+            modifier = modifier,
+            icon = icon,
+            sparkline = curve.map {
+                ChartPoint(it.elapsedFromStartMillis.toFloat(), metric.select(it)?.toFloat())
+            },
+            accentColor = metric.accentColor(),
+            onClick = if (metric.hasSamples(curve)) {
+                { onOpenMetric(metric) }
+            } else {
+                null
+            },
+            onClickLabel = openLabel,
+        )
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        BatteryStatTileRow { tile ->
+            metricTile(BatteryMetric.LEVEL, tile, Icons.Filled.BatteryChargingFull)
+            metricTile(BatteryMetric.POWER, tile, Icons.Filled.Bolt)
+        }
+        BatteryStatTileRow { tile ->
+            metricTile(BatteryMetric.VOLTAGE, tile)
+            metricTile(BatteryMetric.CURRENT, tile)
+        }
+        BatteryStatTileRow { tile ->
+            metricTile(BatteryMetric.TEMPERATURE, tile, Icons.Filled.Thermostat)
+            BatteryStatTile(
+                label = stringResource(R.string.battery_detail_status),
+                value = stringResource(batteryStatusLabel(readout.status, readout.plugged)),
+                modifier = tile,
+            )
+        }
+    }
+}
+
+/** Matches the charge curve's series colours, so a tile and the chart it opens read as one metric. */
+@Composable
+private fun BatteryMetric.accentColor(): Color = when (this) {
+    BatteryMetric.LEVEL -> MaterialTheme.colorScheme.primary
+    BatteryMetric.POWER -> MaterialTheme.colorScheme.tertiary
+    BatteryMetric.TEMPERATURE -> MaterialTheme.colorScheme.error
+    BatteryMetric.VOLTAGE, BatteryMetric.CURRENT -> MaterialTheme.colorScheme.secondary
+}
+
 @Composable
 private fun ChargingSection(readout: BatteryReadout) {
     val notReported = stringResource(R.string.battery_value_not_reported)
     DetailSection(stringResource(R.string.battery_detail_section_charging)) {
-        DetailRow(
-            stringResource(R.string.battery_detail_level),
-            readout.levelPercent?.let { "$it%" } ?: notReported,
-        )
-        DetailRow(
-            stringResource(R.string.battery_detail_status),
-            stringResource(batteryStatusLabel(readout.status, readout.plugged)),
-        )
         DetailRow(
             stringResource(R.string.battery_detail_power_source),
             batteryPlugLabel(readout.plugged)?.let { stringResource(it) } ?: notReported,
@@ -183,22 +256,9 @@ private fun HealthSection(readout: BatteryReadout) {
 @Composable
 private fun ElectricalSection(readout: BatteryReadout) {
     val notReported = stringResource(R.string.battery_value_not_reported)
+    // Voltage, current and charge power moved up into the tile grid; what stays here is the pair
+    // that has no live series to chart.
     DetailSection(stringResource(R.string.battery_detail_section_electrical)) {
-        DetailRow(
-            stringResource(R.string.battery_detail_voltage),
-            formatVoltage(readout.voltageMillivolts) ?: notReported,
-        )
-        DetailRow(
-            stringResource(R.string.battery_detail_current),
-            formatCurrent(readout.currentNowMicroamps) ?: notReported,
-        )
-        // Voltage × current above is a magnitude in either direction; this row is the gated charge
-        // power, so a discharge draw can never be read here as charge power.
-        DetailRow(
-            stringResource(R.string.battery_detail_power),
-            StatsFormat.power(StatsPowerCalculator.chargeMilliwatts(readout))
-                ?: stringResource(chargePowerFallbackRes(BatteryEffect.from(readout))),
-        )
         // Advertised, not measured: what the connected supply claims. Nothing connected means nothing
         // to claim, so the extras are only read through while on a charger.
         DetailRow(
@@ -210,17 +270,6 @@ private fun ElectricalSection(readout: BatteryReadout) {
         DetailRow(
             stringResource(R.string.battery_detail_charge_counter),
             formatChargeCounter(readout.chargeCounterMicroampHours) ?: notReported,
-        )
-    }
-}
-
-@Composable
-private fun ThermalSection(readout: BatteryReadout) {
-    val notReported = stringResource(R.string.battery_value_not_reported)
-    DetailSection(stringResource(R.string.battery_detail_section_thermal)) {
-        DetailRow(
-            stringResource(R.string.battery_detail_temperature),
-            formatTemperature(readout.temperatureTenthsC) ?: notReported,
         )
     }
 }
@@ -291,6 +340,8 @@ private fun BatteryHubScreenLivePreview() = PreviewWrapper {
         onOpenHistory = {},
         onEnableCapture = {},
         onOpenSession = {},
+        onOpenMetric = {},
+        curve = previewCurve,
     )
 }
 
@@ -309,6 +360,8 @@ private fun BatteryHubScreenLastPreview() = PreviewWrapper {
         onOpenHistory = {},
         onEnableCapture = {},
         onOpenSession = {},
+        onOpenMetric = {},
+        curve = previewCurve,
     )
 }
 
@@ -326,6 +379,7 @@ private fun BatteryHubScreenCaptureOffPreview() = PreviewWrapper {
         onOpenHistory = {},
         onEnableCapture = {},
         onOpenSession = {},
+        onOpenMetric = {},
     )
 }
 
@@ -343,6 +397,7 @@ private fun BatteryHubScreenCaptureOffProPreview() = PreviewWrapper {
         onOpenHistory = {},
         onEnableCapture = {},
         onOpenSession = {},
+        onOpenMetric = {},
     )
 }
 
@@ -367,6 +422,7 @@ private fun BatteryHubScreenSparsePreview() = PreviewWrapper {
         onOpenHistory = {},
         onEnableCapture = {},
         onOpenSession = {},
+        onOpenMetric = {},
     )
 }
 
@@ -384,5 +440,7 @@ private fun BatteryHubScreenLargeFontPreview() = PreviewWrapper {
         onOpenHistory = {},
         onEnableCapture = {},
         onOpenSession = {},
+        onOpenMetric = {},
+        curve = previewCurve,
     )
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryMetric.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryMetric.kt
@@ -8,6 +8,7 @@ import eu.darken.amply.battery.ui.formatTemperature
 import eu.darken.amply.battery.ui.formatVoltage
 import eu.darken.amply.stats.core.ChargeCurvePoint
 import eu.darken.amply.stats.core.CurveAggregates
+import eu.darken.amply.stats.core.CurveMetricAvailability
 import eu.darken.amply.stats.core.MetricStats
 import eu.darken.amply.stats.core.StatsPowerCalculator
 import eu.darken.amply.stats.ui.StatsFormat
@@ -78,12 +79,22 @@ enum class BatteryMetric(
     fun formatAxis(value: Float): String = format(value.toInt()) ?: ""
 
     /**
-     * True when the recorded curve holds at least one reading for this metric.
+     * True when the shown charge recorded at least one reading for this metric.
+     *
+     * Reads the availability flags rather than the drawn curve, because that curve is decimated: a
+     * metric reported only intermittently can lose every one of its readings to the stride and would
+     * then look absent although the detail screen (which reads the raw samples) has data to show.
      *
      * Deliberately *presence*, not variation: a constant metric is still worth opening — the chart
      * renders a zero-range series as a flat line on a real axis, and a min == avg == max reading is
      * a meaningful answer. Only the sparkline needs variation, because a self-normalized series
      * without a range would draw a fake midline.
      */
-    fun hasSamples(curve: List<ChargeCurvePoint>): Boolean = curve.any { select(it) != null }
+    fun hasSamples(availability: CurveMetricAvailability): Boolean = when (this) {
+        LEVEL -> availability.level
+        POWER -> availability.power
+        VOLTAGE -> availability.voltage
+        CURRENT -> availability.current
+        TEMPERATURE -> availability.temperature
+    }
 }

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryMetric.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryMetric.kt
@@ -1,0 +1,89 @@
+package eu.darken.amply.main.ui.battery
+
+import androidx.annotation.StringRes
+import eu.darken.amply.R
+import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.battery.ui.formatCurrent
+import eu.darken.amply.battery.ui.formatTemperature
+import eu.darken.amply.battery.ui.formatVoltage
+import eu.darken.amply.stats.core.ChargeCurvePoint
+import eu.darken.amply.stats.core.CurveAggregates
+import eu.darken.amply.stats.core.MetricStats
+import eu.darken.amply.stats.core.StatsPowerCalculator
+import eu.darken.amply.stats.ui.StatsFormat
+
+/**
+ * A battery reading that exists both as a live value and as a recorded series — the set the hub can
+ * offer a per-metric detail screen for.
+ *
+ * Status and the descriptive fields (technology, health) are deliberately absent: they are not
+ * numeric series, so there is nothing to chart or to take a minimum of.
+ *
+ * Every accessor here works off the *raw* unit the sample stores (percent, milliwatts, millivolts,
+ * microamps, tenths of a degree) and formatting is delegated to the existing shared formatters, so a
+ * tile, a chart axis and a statistics row can never render the same reading differently.
+ */
+enum class BatteryMetric(
+    @get:StringRes val titleRes: Int,
+    @get:StringRes val explainerRes: Int,
+) {
+    LEVEL(R.string.battery_metric_level_title, R.string.battery_metric_level_explainer),
+    POWER(R.string.battery_metric_power_title, R.string.battery_metric_power_explainer),
+    VOLTAGE(R.string.battery_metric_voltage_title, R.string.battery_metric_voltage_explainer),
+    CURRENT(R.string.battery_metric_current_title, R.string.battery_metric_current_explainer),
+    TEMPERATURE(R.string.battery_metric_temperature_title, R.string.battery_metric_temperature_explainer),
+    ;
+
+    /** This metric's value at one recorded curve point, in its raw stored unit. */
+    fun select(point: ChargeCurvePoint): Int? = when (this) {
+        LEVEL -> point.percent
+        POWER -> point.powerMilliwatts
+        VOLTAGE -> point.voltageMillivolts
+        CURRENT -> point.currentNowMicroamps
+        TEMPERATURE -> point.temperatureTenthsC
+    }
+
+    /**
+     * This metric's current value from a live readout.
+     *
+     * Power routes through [StatsPowerCalculator.chargeMilliwatts] rather than multiplying the two
+     * fields here, so a discharge draw is never presented as charge power.
+     */
+    fun select(readout: BatteryReadout?): Int? = when (this) {
+        LEVEL -> readout?.levelPercent
+        POWER -> StatsPowerCalculator.chargeMilliwatts(readout)
+        VOLTAGE -> readout?.voltageMillivolts
+        CURRENT -> readout?.currentNowMicroamps
+        TEMPERATURE -> readout?.temperatureTenthsC
+    }
+
+    fun stats(aggregates: CurveAggregates): MetricStats? = when (this) {
+        LEVEL -> aggregates.level
+        POWER -> aggregates.power
+        VOLTAGE -> aggregates.voltage
+        CURRENT -> aggregates.current
+        TEMPERATURE -> aggregates.temperature
+    }
+
+    /** Formats a raw value in this metric's unit; null in, null out (the caller owns the fallback). */
+    fun format(value: Int?): String? = when (this) {
+        LEVEL -> value?.let { "$it%" }
+        POWER -> StatsFormat.power(value)
+        VOLTAGE -> formatVoltage(value)
+        CURRENT -> formatCurrent(value)
+        TEMPERATURE -> formatTemperature(value)
+    }
+
+    /** Formats a chart axis tick, which arrives as a float in the same raw unit. */
+    fun formatAxis(value: Float): String = format(value.toInt()) ?: ""
+
+    /**
+     * True when the recorded curve holds at least one reading for this metric.
+     *
+     * Deliberately *presence*, not variation: a constant metric is still worth opening — the chart
+     * renders a zero-range series as a flat line on a real axis, and a min == avg == max reading is
+     * a meaningful answer. Only the sparkline needs variation, because a self-normalized series
+     * without a range would draw a fake midline.
+     */
+    fun hasSamples(curve: List<ChargeCurvePoint>): Boolean = curve.any { select(it) != null }
+}

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryMetricDetailScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryMetricDetailScreen.kt
@@ -1,0 +1,275 @@
+package eu.darken.amply.main.ui.battery
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import eu.darken.amply.R
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardDefaults
+import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.PreviewWrapper
+import eu.darken.amply.common.compose.chart.ChartAxis
+import eu.darken.amply.common.compose.chart.ChartPoint
+import eu.darken.amply.common.compose.chart.ChartSeries
+import eu.darken.amply.common.compose.chart.LineChart
+import eu.darken.amply.common.compose.chart.YAxisSide
+import eu.darken.amply.stats.core.ChargeCurvePoint
+import eu.darken.amply.stats.core.MetricStats
+import eu.darken.amply.stats.ui.StatsFormat
+
+/**
+ * One metric of one charge session: its latest recorded value, its curve, its real min / average /
+ * max, and a plain-language explainer.
+ *
+ * [stats] never comes from [curve] — the curve is decimated for plotting, so a brief extreme is
+ * simply not in it, and a "Maximum" taken from the plotted points would not be the session's. The
+ * repository computes both from the same raw samples.
+ *
+ * A null [state] is "the selection is still resolving" (a spinner), [BatteryMetricDetailState.sessionMissing]
+ * is "that session is gone" (retention, or cleared data) and gets a notice rather than an eternal
+ * spinner, and a null [stats] hides the statistics row rather than printing zeros.
+ */
+data class BatteryMetricDetailState(
+    val metric: BatteryMetric,
+    val sessionMissing: Boolean,
+    val curve: List<ChargeCurvePoint>,
+    val stats: MetricStats?,
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BatteryMetricDetailScreen(
+    state: BatteryMetricDetailState?,
+    onBack: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        state?.metric?.titleRes?.let { stringResource(it) }
+                            ?: stringResource(R.string.stats_detail_title),
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.action_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        if (state == null) {
+            Centered(padding) { CircularProgressIndicator() }
+            return@Scaffold
+        }
+        if (state.sessionMissing) {
+            Centered(padding) {
+                Text(
+                    stringResource(R.string.stats_detail_missing),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            return@Scaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { CurveCard(state) }
+            if (state.stats != null) {
+                item { StatsCard(state.metric, state.stats) }
+            }
+            item { ExplainerCard(state.metric) }
+        }
+    }
+}
+
+@Composable
+private fun Centered(padding: PaddingValues, content: @Composable () -> Unit) = Box(
+    Modifier
+        .padding(padding)
+        .fillMaxSize(),
+    contentAlignment = Alignment.Center,
+) { content() }
+
+@Composable
+private fun CurveCard(state: BatteryMetricDetailState) {
+    val metric = state.metric
+    val color = MaterialTheme.colorScheme.primary
+    val label = stringResource(metric.titleRes)
+    val latest = state.curve.lastOrNull { metric.select(it) != null }?.let { metric.select(it) }
+
+    AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+        Text(
+            metric.format(latest) ?: stringResource(R.string.battery_value_not_reported),
+            style = MaterialTheme.typography.headlineMedium,
+        )
+        LineChart(
+            // One series, so it owns the left axis outright — StatsCurveChart is hard-wired to the
+            // three-series charge curve and can't render a single metric on its own scale.
+            series = listOf(
+                ChartSeries(
+                    label = label,
+                    color = color,
+                    points = state.curve.map {
+                        ChartPoint(it.elapsedFromStartMillis.toFloat(), metric.select(it)?.toFloat())
+                    },
+                    endLabel = metric.format(latest),
+                    axisSide = YAxisSide.LEFT,
+                ),
+            ),
+            emptyLabel = stringResource(R.string.stats_curve_empty),
+            xAxisFormatter = { millis -> StatsFormat.elapsedAxis(millis.toLong()) },
+            xAxisContentDescription = stringResource(R.string.stats_curve_axis_time_desc),
+            leftAxis = metric.chartAxis(),
+            chartContentDescription = metric.format(latest)?.let { "$label: $it" },
+        )
+    }
+}
+
+/**
+ * The metric's Y-axis. Bounds exist only where the quantity is physically bounded; [ChartAxis.minStep]
+ * is the display resolution of the metric's own formatter, so two ticks can never format identically.
+ */
+private fun BatteryMetric.chartAxis(): ChartAxis = when (this) {
+    BatteryMetric.LEVEL -> ChartAxis(formatter = ::formatAxis, bounds = 0f..100f, minStep = 1f)
+    // Same ceiling the charge-power calculator treats as implausible.
+    BatteryMetric.POWER -> ChartAxis(formatter = ::formatAxis, bounds = 0f..250_000f, minStep = 100f)
+    // 10 mV: the voltage formatter shows two decimals of a volt.
+    BatteryMetric.VOLTAGE -> ChartAxis(formatter = ::formatAxis, minStep = 10f)
+    // 1 mA: the current formatter rounds to whole milliamps.
+    BatteryMetric.CURRENT -> ChartAxis(formatter = ::formatAxis, minStep = 1_000f)
+    // A tenth of a degree, the unit temperature is stored and formatted in.
+    BatteryMetric.TEMPERATURE -> ChartAxis(formatter = ::formatAxis, minStep = 1f)
+}
+
+@Composable
+private fun StatsCard(metric: BatteryMetric, stats: MetricStats) {
+    AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            StatColumn(stringResource(R.string.battery_metric_min), metric.format(stats.min))
+            StatColumn(stringResource(R.string.battery_metric_avg), metric.format(stats.avg))
+            StatColumn(stringResource(R.string.battery_metric_max), metric.format(stats.max))
+        }
+    }
+}
+
+@Composable
+private fun StatColumn(label: String, value: String?) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            label.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            value ?: stringResource(R.string.battery_value_not_reported),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun ExplainerCard(metric: BatteryMetric) {
+    AmplyCard(verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing)) {
+        Text(
+            stringResource(metric.titleRes),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            stringResource(metric.explainerRes),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun previewState(
+    metric: BatteryMetric = BatteryMetric.LEVEL,
+    curve: List<ChargeCurvePoint> = previewMetricCurve,
+    stats: MetricStats? = MetricStats(min = 42, avg = 68, max = 90, sampleCount = 13),
+    sessionMissing: Boolean = false,
+) = BatteryMetricDetailState(metric = metric, sessionMissing = sessionMissing, curve = curve, stats = stats)
+
+private val previewMetricCurve = (0..12).map { i ->
+    ChargeCurvePoint(
+        elapsedFromStartMillis = i * 300_000L,
+        percent = (42 + i * 4).coerceAtMost(100),
+        powerMilliwatts = (18_000 - i * 1_100).coerceAtLeast(3_000),
+        temperatureTenthsC = 300 + i,
+        voltageMillivolts = 3_900 + i * 20,
+        currentNowMicroamps = 2_400_000 - i * 150_000,
+    )
+}
+
+@AmplyPreview
+@Composable
+private fun BatteryMetricDetailScreenPreview() = PreviewWrapper {
+    BatteryMetricDetailScreen(state = previewState(), onBack = {})
+}
+
+@AmplyPreview
+@Composable
+private fun BatteryMetricDetailScreenTemperaturePreview() = PreviewWrapper {
+    BatteryMetricDetailScreen(
+        state = previewState(
+            metric = BatteryMetric.TEMPERATURE,
+            stats = MetricStats(min = 300, avg = 306, max = 312, sampleCount = 13),
+        ),
+        onBack = {},
+    )
+}
+
+@AmplyPreview
+@Composable
+private fun BatteryMetricDetailScreenEmptyPreview() = PreviewWrapper {
+    // Nothing recorded for this metric: the chart says so and the statistics row is absent entirely
+    // rather than printing zeros.
+    BatteryMetricDetailScreen(
+        state = previewState(metric = BatteryMetric.POWER, curve = emptyList(), stats = null),
+        onBack = {},
+    )
+}
+
+@AmplyPreview
+@Composable
+private fun BatteryMetricDetailScreenMissingPreview() = PreviewWrapper {
+    // Retention purged the session while the screen was open.
+    BatteryMetricDetailScreen(state = previewState(sessionMissing = true), onBack = {})
+}

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryStatTile.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryStatTile.kt
@@ -1,0 +1,208 @@
+package eu.darken.amply.main.ui.battery
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.BatteryChargingFull
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Thermostat
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardTone
+import eu.darken.amply.common.compose.AmplyClickableCard
+import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.PreviewWrapper
+import eu.darken.amply.common.compose.chart.ChartPoint
+import eu.darken.amply.common.compose.chart.Sparkline
+
+/**
+ * One reading in the hub's tile grid: a small-caps label, a headline value, and — when the recorded
+ * series has a shape to show — a sparkline behind the value.
+ *
+ * [onClick] is what makes the tile navigable: passing null leaves it a plain card with no chevron,
+ * no ripple and no click target, which is the honest rendering for a reading that has nothing
+ * recorded to open. The chevron is therefore never decorative — it appears exactly where a tap does
+ * something.
+ *
+ * Tiles are laid out by [BatteryStatTileRow], which sizes both tiles in a row to the taller one so a
+ * wrapped label can't stagger the grid.
+ */
+@Composable
+fun BatteryStatTile(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    sparkline: List<ChartPoint> = emptyList(),
+    accentColor: Color = MaterialTheme.colorScheme.primary,
+    onClick: (() -> Unit)? = null,
+    onClickLabel: String = "",
+) {
+    val content: @Composable ColumnScope.() -> Unit = {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (icon != null) {
+                Icon(
+                    icon,
+                    contentDescription = null,
+                    tint = accentColor,
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+            Text(
+                label.uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f),
+            )
+            if (onClick != null) {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(VALUE_HEIGHT),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            // Behind the value, and dimmed: the number is the point of the tile, the shape is context.
+            Sparkline(
+                points = sparkline,
+                modifier = Modifier.align(Alignment.BottomStart),
+                color = accentColor.copy(alpha = 0.35f),
+                height = SPARKLINE_HEIGHT,
+            )
+            Text(
+                value,
+                style = MaterialTheme.typography.headlineSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+
+    if (onClick == null) {
+        AmplyCard(
+            modifier = modifier,
+            tone = AmplyCardTone.SurfaceContainer,
+            contentPadding = TILE_PADDING,
+            content = content,
+        )
+    } else {
+        AmplyClickableCard(
+            onClick = onClick,
+            onClickLabel = onClickLabel,
+            modifier = modifier,
+            tone = AmplyCardTone.SurfaceContainer,
+            contentPadding = TILE_PADDING,
+            content = content,
+        )
+    }
+}
+
+/**
+ * One row of the tile grid: two equal-width tiles, both stretched to the taller one's height.
+ *
+ * A plain [Row] of cards would let a tile whose label wraps stand taller than its neighbour;
+ * `IntrinsicSize.Max` plus `fillMaxHeight` keeps the grid square at every font scale. A single
+ * trailing tile keeps its half-width rather than stretching across the row.
+ */
+@Composable
+fun BatteryStatTileRow(
+    modifier: Modifier = Modifier,
+    content: @Composable (tileModifier: Modifier) -> Unit,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Max),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        content(Modifier.weight(1f).fillMaxHeight())
+    }
+}
+
+private val TILE_PADDING = PaddingValues(horizontal = 12.dp, vertical = 10.dp)
+private val VALUE_HEIGHT = 40.dp
+private val SPARKLINE_HEIGHT = 26.dp
+
+@AmplyPreview
+@Preview(name = "Tiles · large font", fontScale = 1.5f, showBackground = true)
+@Composable
+private fun BatteryStatTilePreview() = PreviewWrapper {
+    val rising = (0..16).map { ChartPoint(it * 60_000f, 42f + it * 2.4f) }
+    val falling = (0..16).map { ChartPoint(it * 60_000f, 18_000f - it * 900f) }
+    val flat = (0..16).map { ChartPoint(it * 60_000f, 4_185f) }
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        BatteryStatTileRow { tile ->
+            // Tappable, with a recorded shape behind the value.
+            BatteryStatTile(
+                label = "Level",
+                value = "82%",
+                modifier = tile,
+                icon = Icons.Filled.BatteryChargingFull,
+                sparkline = rising,
+                onClick = {},
+                onClickLabel = "Open",
+            )
+            BatteryStatTile(
+                label = "Charge power",
+                value = "5.2 W",
+                modifier = tile,
+                icon = Icons.Filled.Bolt,
+                sparkline = falling,
+                onClick = {},
+                onClickLabel = "Open",
+            )
+        }
+        BatteryStatTileRow { tile ->
+            // Recorded but constant: tappable (a flat reading is still a reading), no sparkline.
+            BatteryStatTile(
+                label = "Voltage",
+                value = "4.19 V",
+                modifier = tile,
+                sparkline = flat,
+                onClick = {},
+                onClickLabel = "Open",
+            )
+            // Nothing recorded: a plain card, no chevron, not clickable.
+            BatteryStatTile(
+                label = "Temperature",
+                value = "31.4 °C",
+                modifier = tile,
+                icon = Icons.Filled.Thermostat,
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryStatTile.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryStatTile.kt
@@ -52,7 +52,10 @@ import eu.darken.amply.common.compose.chart.Sparkline
  * rather than being clipped ("Plugged in, n…" on a Pixel 7a), with ellipsis left as the last resort.
  * Numbers never wrap, so the ordinary tile is unchanged. [valueStyle] exists for the values that are
  * state labels rather than measurements — they are legitimately secondary to the numbers, and a
- * smaller style buys the wrapped label room.
+ * smaller style buys the wrapped label room. [valueMaxLines] raises that ceiling for the values that
+ * need it: two lines hold the longest status sentence at normal font scale but not at 2x, where the
+ * same string needs a third. Since the box is a minimum height, an unused line costs nothing — the
+ * text occupies only the lines it fills.
  *
  * Tiles are laid out by [BatteryStatTileRow], which sizes both tiles in a row to the taller one so a
  * wrapped label or value can't stagger the grid.
@@ -69,6 +72,7 @@ fun BatteryStatTile(
     modifier: Modifier = Modifier,
     valueStyle: TextStyle = MaterialTheme.typography.headlineSmall,
     valueColor: Color = Color.Unspecified,
+    valueMaxLines: Int = 2,
     valueDescription: String? = null,
     icon: ImageVector? = null,
     sparkline: List<ChartPoint> = emptyList(),
@@ -122,7 +126,7 @@ fun BatteryStatTile(
                 value,
                 style = valueStyle,
                 color = valueColor,
-                maxLines = 2,
+                maxLines = valueMaxLines,
                 overflow = TextOverflow.Ellipsis,
                 modifier = if (valueDescription != null) {
                     Modifier.semantics { contentDescription = valueDescription }

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryStatTile.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryStatTile.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -54,6 +56,11 @@ import eu.darken.amply.common.compose.chart.Sparkline
  *
  * Tiles are laid out by [BatteryStatTileRow], which sizes both tiles in a row to the taller one so a
  * wrapped label or value can't stagger the grid.
+ *
+ * [valueColor] and [valueDescription] exist for values that stand in for a missing figure: a
+ * dimmed placeholder reads as absence rather than as a reading, and a glyph that carries no words
+ * needs a spoken form. Both default to the ordinary rendering, so a tile showing a real value is
+ * unchanged.
  */
 @Composable
 fun BatteryStatTile(
@@ -61,6 +68,8 @@ fun BatteryStatTile(
     value: String,
     modifier: Modifier = Modifier,
     valueStyle: TextStyle = MaterialTheme.typography.headlineSmall,
+    valueColor: Color = Color.Unspecified,
+    valueDescription: String? = null,
     icon: ImageVector? = null,
     sparkline: List<ChartPoint> = emptyList(),
     accentColor: Color = MaterialTheme.colorScheme.primary,
@@ -112,8 +121,14 @@ fun BatteryStatTile(
             Text(
                 value,
                 style = valueStyle,
+                color = valueColor,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
+                modifier = if (valueDescription != null) {
+                    Modifier.semantics { contentDescription = valueDescription }
+                } else {
+                    Modifier
+                },
             )
         }
     }

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryStatTile.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/BatteryStatTile.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -24,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -44,14 +46,21 @@ import eu.darken.amply.common.compose.chart.Sparkline
  * recorded to open. The chevron is therefore never decorative — it appears exactly where a tap does
  * something.
  *
+ * The value area is a floor, not a fixed height: a value too long for one line wraps to a second
+ * rather than being clipped ("Plugged in, n…" on a Pixel 7a), with ellipsis left as the last resort.
+ * Numbers never wrap, so the ordinary tile is unchanged. [valueStyle] exists for the values that are
+ * state labels rather than measurements — they are legitimately secondary to the numbers, and a
+ * smaller style buys the wrapped label room.
+ *
  * Tiles are laid out by [BatteryStatTileRow], which sizes both tiles in a row to the taller one so a
- * wrapped label can't stagger the grid.
+ * wrapped label or value can't stagger the grid.
  */
 @Composable
 fun BatteryStatTile(
     label: String,
     value: String,
     modifier: Modifier = Modifier,
+    valueStyle: TextStyle = MaterialTheme.typography.headlineSmall,
     icon: ImageVector? = null,
     sparkline: List<ChartPoint> = emptyList(),
     accentColor: Color = MaterialTheme.colorScheme.primary,
@@ -90,7 +99,7 @@ fun BatteryStatTile(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(VALUE_HEIGHT),
+                .heightIn(min = VALUE_HEIGHT),
             contentAlignment = Alignment.CenterStart,
         ) {
             // Behind the value, and dimmed: the number is the point of the tile, the shape is context.
@@ -102,8 +111,8 @@ fun BatteryStatTile(
             )
             Text(
                 value,
-                style = MaterialTheme.typography.headlineSmall,
-                maxLines = 1,
+                style = valueStyle,
+                maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
         }

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/ChargeTeaser.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/ChargeTeaser.kt
@@ -184,6 +184,10 @@ internal val previewCurve = (0..12).map { i ->
         percent = (42 + i * 3).coerceAtMost(100),
         powerMilliwatts = (18_000 - i * 700).coerceAtLeast(2_000),
         temperatureTenthsC = 300 + i,
+        // Voltage is deliberately flat: a real device holds it steady over a few points, and it is
+        // the fixture for a metric that has samples (so its tile opens) but no sparkline to draw.
+        voltageMillivolts = 4_185,
+        currentNowMicroamps = (2_400_000 - i * 120_000).coerceAtLeast(300_000),
     )
 }
 

--- a/app/src/main/java/eu/darken/amply/main/ui/battery/ChargeTimeCard.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/battery/ChargeTimeCard.kt
@@ -1,0 +1,320 @@
+package eu.darken.amply.main.ui.battery
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import eu.darken.amply.R
+import eu.darken.amply.common.compose.AmplyCard
+import eu.darken.amply.common.compose.AmplyCardDefaults
+import eu.darken.amply.common.compose.AmplyCardHeader
+import eu.darken.amply.common.compose.AmplyPreview
+import eu.darken.amply.common.compose.PreviewWrapper
+import eu.darken.amply.stats.core.ChargeBandSplit
+import eu.darken.amply.stats.core.ChargeTimeBasis
+import eu.darken.amply.stats.core.ChargeTimeEstimate
+import eu.darken.amply.stats.ui.ChargeTimeState
+import eu.darken.amply.stats.ui.StatsFormat
+
+/**
+ * How long a charge takes on this device, projected from the user's own recorded charges.
+ *
+ * Every number here is history, never live extrapolation, and every absent number says so rather
+ * than being filled in: a null target means Amply has not watched enough charges across that stretch,
+ * which is a different statement from "zero minutes".
+ *
+ * The wording is gated on the battery actually taking charge. A countdown ("Full in about 1h 19m")
+ * is a claim that the device is moving toward that target; unplugged, or held at an OEM limit — which
+ * reports NOT_CHARGING while the charge session is still open — the same figures are presented as a
+ * reference for what a charge from here usually costs.
+ */
+@Composable
+fun ChargeTimeCard(
+    state: ChargeTimeState,
+    modifier: Modifier = Modifier,
+) {
+    AmplyCard(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(AmplyCardDefaults.ItemSpacing),
+    ) {
+        AmplyCardHeader(
+            title = stringResource(R.string.charge_time_title),
+            icon = Icons.Filled.Schedule,
+        )
+        when (state) {
+            ChargeTimeState.Loading -> Body(stringResource(R.string.charge_time_loading))
+            ChargeTimeState.Unavailable -> Body(stringResource(R.string.charge_time_unavailable))
+            is ChargeTimeState.NotEnoughData -> Body(stringResource(R.string.charge_time_not_enough))
+            is ChargeTimeState.Ready -> ReadyBody(state)
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.ReadyBody(state: ChargeTimeState.Ready) {
+    val estimate = state.estimate
+    Text(
+        headline(state),
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.Medium,
+    )
+
+    val missing = stringResource(R.string.charge_time_value_missing)
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // Omitted rather than rendered as "0m": at 80% and above there is nothing left to count.
+        if ((state.currentPercent ?: 0) < 80) {
+            Figure(
+                label = stringResource(R.string.charge_time_to_eighty),
+                value = StatsFormat.duration(estimate.toEightyMillis) ?: missing,
+            )
+        }
+        Figure(
+            label = stringResource(R.string.charge_time_to_full),
+            value = StatsFormat.duration(estimate.toFullMillis) ?: missing,
+        )
+        Figure(
+            label = stringResource(R.string.charge_time_avg_speed),
+            value = StatsFormat.power(estimate.avgSpeedMilliwatts) ?: missing,
+        )
+    }
+
+    if (estimate.split.hasAny) {
+        SplitBar(estimate.split)
+    }
+    if (estimate.split.trickleDominates) {
+        Text(
+            stringResource(R.string.charge_time_trickle_note),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+
+    Text(
+        pluralStringResource(
+            if (state.basis == ChargeTimeBasis.SAME_TYPE) {
+                R.plurals.charge_time_provenance_same_type
+            } else {
+                R.plurals.charge_time_provenance_pooled
+            },
+            estimate.basedOnSessions,
+            estimate.basedOnSessions,
+        ),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+/**
+ * The headline target: to full where that is known, else to 80%, else nothing to state.
+ *
+ * The countdown/reference split is the honesty rule — see [ChargeTimeCard].
+ */
+@Composable
+private fun headline(state: ChargeTimeState.Ready): String {
+    val toFull = StatsFormat.duration(state.estimate.toFullMillis)
+    if (toFull != null) {
+        return stringResource(
+            if (state.charging) {
+                R.string.charge_time_headline_full_countdown
+            } else {
+                R.string.charge_time_headline_full_reference
+            },
+            toFull,
+        )
+    }
+    val toEighty = StatsFormat.duration(state.estimate.toEightyMillis)
+    if (toEighty != null) {
+        return stringResource(
+            if (state.charging) {
+                R.string.charge_time_headline_eighty_countdown
+            } else {
+                R.string.charge_time_headline_eighty_reference
+            },
+            toEighty,
+        )
+    }
+    return stringResource(R.string.charge_time_value_missing)
+}
+
+/**
+ * The 80-100% stretch is worth calling out only when it actually dominates: the note explains a
+ * taper, so it must not appear beside a bar where the taper is unremarkable.
+ */
+private val ChargeBandSplit.trickleDominates: Boolean
+    get() {
+        val tail = eightyToHundredMillis ?: return false
+        val middle = fiftyToEightyMillis ?: return false
+        return tail >= middle * 3 / 2
+    }
+
+@Composable
+private fun ColumnScope.SplitBar(split: ChargeBandSplit) {
+    val segments = listOfNotNull(
+        split.toFiftyMillis?.let { Triple(it, MaterialTheme.colorScheme.primary, R.string.charge_time_split_to_fifty) },
+        split.fiftyToEightyMillis?.let {
+            Triple(it, MaterialTheme.colorScheme.tertiary, R.string.charge_time_split_fifty_eighty)
+        },
+        split.eightyToHundredMillis?.let {
+            Triple(it, MaterialTheme.colorScheme.secondary, R.string.charge_time_split_eighty_hundred)
+        },
+    )
+    if (segments.isEmpty()) return
+
+    Text(
+        stringResource(R.string.charge_time_split_title),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(10.dp)
+            .clip(MaterialTheme.shapes.small),
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        segments.forEach { (millis, color, _) ->
+            Bar(weight = millis.coerceAtLeast(1L).toFloat(), color = color)
+        }
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        segments.forEach { (millis, color, labelRes) ->
+            Column(modifier = Modifier.weight(millis.coerceAtLeast(1L).toFloat())) {
+                Text(
+                    stringResource(labelRes),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = color,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    StatsFormat.duration(millis) ?: "",
+                    style = MaterialTheme.typography.labelMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RowScope.Bar(weight: Float, color: Color) = Column(
+    modifier = Modifier
+        .weight(weight)
+        .height(10.dp)
+        .background(color),
+) {}
+
+@Composable
+private fun RowScope.Figure(label: String, value: String) {
+    Column(modifier = Modifier.weight(1f)) {
+        Text(
+            label.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+            value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
+private fun Body(text: String) = Text(
+    text,
+    style = MaterialTheme.typography.bodyMedium,
+    color = MaterialTheme.colorScheme.onSurfaceVariant,
+)
+
+private val previewEstimate = ChargeTimeEstimate(
+    toEightyMillis = 2_040_000,
+    toFullMillis = 4_740_000,
+    avgSpeedMilliwatts = 11_500,
+    split = ChargeBandSplit(
+        toFiftyMillis = 2_700_000,
+        fiftyToEightyMillis = 1_800_000,
+        eightyToHundredMillis = 3_600_000,
+    ),
+    basedOnSessions = 6,
+)
+
+@AmplyPreview
+@Composable
+private fun ChargeTimeCardPreview() = PreviewWrapper {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // Charging: a countdown, and the taper note because the last stretch dominates.
+        ChargeTimeCard(
+            state = ChargeTimeState.Ready(
+                estimate = previewEstimate,
+                basis = ChargeTimeBasis.SAME_TYPE,
+                charging = true,
+                currentPercent = 42,
+            ),
+        )
+        // Unplugged: the same figures, stated as a reference rather than a count down.
+        ChargeTimeCard(
+            state = ChargeTimeState.Ready(
+                estimate = previewEstimate,
+                basis = ChargeTimeBasis.POOLED,
+                charging = false,
+                currentPercent = 42,
+            ),
+        )
+    }
+}
+
+@AmplyPreview
+@Composable
+private fun ChargeTimeCardPartialPreview() = PreviewWrapper {
+    Column(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        // Above 80%: the "To 80%" cell is gone rather than reading "0m", and this user always
+        // unplugs early, so the top stretch has never been observed.
+        ChargeTimeCard(
+            state = ChargeTimeState.Ready(
+                estimate = previewEstimate.copy(
+                    toEightyMillis = null,
+                    toFullMillis = null,
+                    split = ChargeBandSplit(toFiftyMillis = 2_700_000, fiftyToEightyMillis = 1_800_000),
+                ),
+                basis = ChargeTimeBasis.SAME_TYPE,
+                charging = true,
+                currentPercent = 86,
+            ),
+        )
+        ChargeTimeCard(state = ChargeTimeState.NotEnoughData(sessions = 1))
+        ChargeTimeCard(state = ChargeTimeState.Loading)
+        ChargeTimeCard(state = ChargeTimeState.Unavailable)
+    }
+}

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/ChargingCard.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/ChargingCard.kt
@@ -33,6 +33,7 @@ import eu.darken.amply.stats.core.ChargeSessionSummary
 import eu.darken.amply.stats.core.ChargingType
 import eu.darken.amply.stats.core.StatsLiveSession
 import eu.darken.amply.stats.core.StatsSealReason
+import eu.darken.amply.stats.ui.ChargeTimeState
 import eu.darken.amply.stats.ui.StatsCurveChart
 import eu.darken.amply.stats.ui.StatsFormat
 import eu.darken.amply.stats.ui.rememberLiveElapsedMillis
@@ -64,6 +65,9 @@ fun ChargingCard(
     onOpenHub: () -> Unit,
     onRetryCapture: () -> Unit,
     modifier: Modifier = Modifier,
+    // Only ever a single remaining-time line, and only while a charge is actually running — the full
+    // breakdown lives on the battery hub's own card.
+    chargeTime: ChargeTimeState = ChargeTimeState.Loading,
     // Monotonic (never negative, immune to clock changes) and shares the curve's clock; re-evaluated
     // on each recomposition and backstopped by a minute tick while live (see rememberLiveElapsedMillis).
     nowElapsedRealtimeMillis: Long = SystemClock.elapsedRealtime(),
@@ -109,7 +113,7 @@ fun ChargingCard(
             ChargingCardPresentation.Unavailable -> BodyText(stringResource(R.string.dashboard_stats_unavailable))
             ChargingCardPresentation.Indeterminate ->
                 BodyText(stringResource(R.string.dashboard_charging_indeterminate))
-            is ChargingCardPresentation.Live -> LiveBody(presentation, battery, elapsedMillis ?: 0L)
+            is ChargingCardPresentation.Live -> LiveBody(presentation, battery, elapsedMillis ?: 0L, chargeTime)
             is ChargingCardPresentation.ConnectedWithoutSession -> ConnectedBody(presentation, onRetryCapture)
             is ChargingCardPresentation.Idle -> IdleBody(presentation)
         }
@@ -162,7 +166,10 @@ private fun ColumnScope.LiveBody(
     live: ChargingCardPresentation.Live,
     battery: BatteryReadout,
     elapsedMillis: Long,
+    chargeTime: ChargeTimeState,
 ) {
+    RemainingTimeLine(chargeTime)
+
     if (shouldShowLiveCurve(live.session.curve, elapsedMillis)) {
         StatsCurveChart(
             curve = live.session.curve,
@@ -185,6 +192,32 @@ private fun ColumnScope.LiveBody(
             modifier = Modifier.align(Alignment.End),
         )
     }
+}
+
+/**
+ * The one line of charge-time estimate this card carries.
+ *
+ * Three conditions, all of them refusals rather than fallbacks: the estimate must be [Ready], the
+ * battery must actually be taking charge (a device held at an OEM limit is not counting down toward
+ * anything), and there must be a real target to name. Anything else renders no line at all —
+ * "Not enough data yet" belongs on the hub's card, which is about charge times; this card is about
+ * the charge that is happening.
+ */
+@Composable
+private fun RemainingTimeLine(chargeTime: ChargeTimeState) {
+    val ready = chargeTime as? ChargeTimeState.Ready ?: return
+    if (!ready.charging) return
+    val toFull = StatsFormat.duration(ready.estimate.toFullMillis)
+    val text = when {
+        toFull != null -> stringResource(R.string.charge_time_headline_full_countdown, toFull)
+        else -> StatsFormat.duration(ready.estimate.toEightyMillis)
+            ?.let { stringResource(R.string.charge_time_headline_eighty_countdown, it) }
+    } ?: return
+    Text(
+        text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.primary,
+    )
 }
 
 @Composable

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -210,6 +210,7 @@ fun DashboardScreen(
                             onOpenHub = onOpenBatteryHub,
                             onRetryCapture = onRetryCapture,
                             nowElapsedRealtimeMillis = nowElapsedRealtimeMillis,
+                            chargeTime = state.chargeTime,
                         )
                     }
                 }

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardViewModel.kt
@@ -65,8 +65,11 @@ import eu.darken.amply.rules.core.RuleRuntimeState
 import eu.darken.amply.stats.core.CaptureServiceHealth
 import eu.darken.amply.stats.core.ChargeSessionSummary
 import eu.darken.amply.stats.core.ChargeStatsRepository
+import eu.darken.amply.stats.core.ChargeTimeModelSource
 import eu.darken.amply.stats.core.StatsLiveSession
 import eu.darken.amply.stats.core.StatsPreferences
+import eu.darken.amply.stats.ui.ChargeTimeState
+import eu.darken.amply.stats.ui.chargeTimeStates
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -117,6 +120,11 @@ data class DashboardUiState(
     val notificationsBlocked: Boolean = false,
     /** Everything the stats card needs: capture switch, pipeline health, and the Room teaser data. */
     val stats: StatsDashboardState = StatsDashboardState(),
+    /**
+     * Charge-time estimates from recorded history, shared with the battery hub's card so both
+     * surfaces read one fold rather than each loading and re-extracting ten sessions.
+     */
+    val chargeTime: ChargeTimeState = ChargeTimeState.Loading,
     /** A pending "Amply was interrupted while owing a restore" warning, or null when there is none. */
     val interruption: InterruptionEvent? = null,
     /** The conditional charge rules and which one, if any, currently owns the policy. */
@@ -173,6 +181,7 @@ class DashboardViewModel @Inject constructor(
     private val chargeAlarmStore: ChargeAlarmStore,
     private val statsPreferences: StatsPreferences,
     private val statsRepository: ChargeStatsRepository,
+    private val chargeTimeModelSource: ChargeTimeModelSource,
     private val captureServiceHealth: CaptureServiceHealth,
     private val interruptionStore: InterruptionStore,
     private val upgradeRepo: UpgradeRepo,
@@ -254,6 +263,18 @@ class DashboardViewModel @Inject constructor(
         currentSession = { statsRepository.currentSession() },
     )
 
+    // Paired with the stats slice rather than taking a combine slot of its own (the flat helper
+    // stops at six), and gated on the same capture flag: with recording off the model provider is
+    // never invoked, so this can't be what creates stats.db either.
+    private val statsAndChargeTime = combine(
+        statsDashboard,
+        chargeTimeStates(
+            captureEnabled = statsPreferences.captureEnabled.flow,
+            readouts = batteryReadoutSource.readouts(),
+            model = { chargeTimeModelSource.states },
+        ),
+    ) { stats, chargeTime -> stats to chargeTime }
+
     val state = combine6(
         combine(
             repository.state,
@@ -289,8 +310,8 @@ class DashboardViewModel @Inject constructor(
         quickAccessChecked,
         tileRequestPending,
         unprivilegedExtras,
-        statsDashboard,
-    ) { base, quickAccess, checked, tilePending, extras, stats ->
+        statsAndChargeTime,
+    ) { base, quickAccess, checked, tilePending, extras, (stats, chargeTime) ->
         base.copy(
             quickAccess = quickAccess,
             quickAccessChecked = checked,
@@ -302,6 +323,7 @@ class DashboardViewModel @Inject constructor(
             upgrade = extras.upgrade,
             conditions = extras.conditions,
             stats = stats,
+            chargeTime = chargeTime,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), DashboardUiState())
 

--- a/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsDestination.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/settings/SettingsDestination.kt
@@ -28,6 +28,9 @@ enum class SettingsDestination {
     /** "Battery & charging" — the single telemetry destination (live readout + charge teaser). */
     BATTERY,
 
+    /** One metric of one charge session, always entered from (and returning to) [BATTERY]. */
+    BATTERY_METRIC_DETAIL,
+
     /** The recorded-session list (the data), reached from [BATTERY]'s top bar. */
     CHARGE_HISTORY,
     STATS_SESSION_DETAIL,

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeBandExtractor.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeBandExtractor.kt
@@ -1,0 +1,137 @@
+package eu.darken.amply.stats.core
+
+import android.os.BatteryManager
+
+/**
+ * One recorded sample, reduced to what step extraction needs. Deliberately not [ChargeCurvePoint]:
+ * the curve carries no battery status, and the status is what separates a real 1% step from a
+ * protection hold, a thermal pause or a supply too weak to charge.
+ */
+data class ChargeStepSample(
+    val elapsedMillis: Long,
+    val percent: Int?,
+    val batteryStatus: Int?,
+)
+
+/**
+ * How long one completed 1% step took during one session, with the identity needed to weigh it:
+ * [sessionId] because a rate must be a median across *sessions*, and [chargingType] because a
+ * wireless charge and a 65 W wired one describe different devices.
+ */
+data class BandObservation(
+    val sessionId: Long,
+    val chargingType: ChargingType,
+    /** The level the step started at, so 80 means "the 80 → 81 step". */
+    val percentFrom: Int,
+    val millis: Long,
+)
+
+/** A batch of observations plus each contributing session's recorded average power. */
+data class BandObservationBatch(
+    val observations: List<BandObservation>,
+    val sessionPowerMilliwatts: Map<Long, Int>,
+)
+
+/**
+ * Turns one session's samples into completed 1% step durations.
+ *
+ * A step is the interval from the first sample at level L to the first sample at L+1, and it counts
+ * only under a strict state machine:
+ *
+ * - **The first step of a run is discarded.** Recording starts partway through whatever level the
+ *   session begins at, so that step is systematically too short. The same argument applies after any
+ *   break in the run, where the level's true start was equally unobserved — so a step counts only
+ *   when its start is a transition this extractor actually saw.
+ * - **A step spanning a non-charging sample is discarded.** This is the hold filter: a device held at
+ *   an OEM limit, paused for heat, or on a supply too weak to charge reports something other than
+ *   `BATTERY_STATUS_CHARGING`, and folding those minutes into a rate would describe a charger nobody
+ *   owns. A duration cutoff cannot do this job — it both admits holds shorter than the cutoff and
+ *   throws away genuinely slow trickle charging, which would bias the estimate optimistic in exactly
+ *   the 80-100% stretch this feature exists to describe.
+ * - [MIN_STEP_MILLIS] / [MAX_STEP_MILLIS] are backstops for readings no charger produces (a real 1%
+ *   step on a 65 W charger is roughly 35 seconds).
+ * - A null percent, a multi-percent jump, a level decrease or time running backwards breaks the run.
+ * - A step already recorded for this session is never recorded twice, so a 79 → 80 → 79 → 80 wobble
+ *   contributes one observation rather than two.
+ *
+ * A session held at a limit therefore contributes nothing structurally: it never completes the step
+ * out of the level it is held at.
+ */
+object ChargeBandExtractor {
+
+    /** Below this a "step" is a reporting glitch, not a charge. */
+    const val MIN_STEP_MILLIS = 5_000L
+
+    /** Above this the device was not meaningfully charging, whatever it reported. */
+    const val MAX_STEP_MILLIS = 3_600_000L
+
+    fun extract(
+        sessionId: Long,
+        chargingType: ChargingType,
+        samples: List<ChargeStepSample>,
+    ): List<BandObservation> {
+        val observations = mutableListOf<BandObservation>()
+        val recorded = mutableSetOf<Int>()
+
+        var lastElapsed: Long? = null
+        var lastLevel: Int? = null
+        // The level whose start we observed as a real transition, and when. Null means "no step is
+        // open" — a run start, or a break.
+        var openLevel: Int? = null
+        var openStartMillis = 0L
+        // False once a non-charging sample has been seen inside the currently open step.
+        var openCharging = true
+
+        samples.forEach { sample ->
+            val previousElapsed = lastElapsed
+            lastElapsed = sample.elapsedMillis
+            if (previousElapsed != null && sample.elapsedMillis < previousElapsed) {
+                // The clock base changed under us, so nothing before this is comparable to it. The
+                // new stamp becomes the base rather than being ignored, or every later sample would
+                // keep failing against a timeline that no longer exists.
+                lastLevel = null
+                openLevel = null
+                return@forEach
+            }
+
+            val percent = sample.percent
+            if (percent == null) {
+                lastLevel = null
+                openLevel = null
+                return@forEach
+            }
+            val charging = sample.batteryStatus == BatteryManager.BATTERY_STATUS_CHARGING
+            val previousLevel = lastLevel
+
+            when {
+                previousLevel == null -> Unit // Run start: no transition observed yet.
+
+                percent == previousLevel -> if (!charging) openCharging = false
+
+                percent == previousLevel + 1 -> {
+                    if (openLevel == previousLevel) {
+                        val millis = sample.elapsedMillis - openStartMillis
+                        val clean = openCharging && charging
+                        if (clean && millis in MIN_STEP_MILLIS..MAX_STEP_MILLIS && recorded.add(previousLevel)) {
+                            observations += BandObservation(
+                                sessionId = sessionId,
+                                chargingType = chargingType,
+                                percentFrom = previousLevel,
+                                millis = millis,
+                            )
+                        }
+                    }
+                    // This transition is the observed start of the next step.
+                    openLevel = percent
+                    openStartMillis = sample.elapsedMillis
+                    openCharging = charging
+                }
+
+                // A decrease, or a jump across levels we never saw the boundaries of.
+                else -> openLevel = null
+            }
+            lastLevel = percent
+        }
+        return observations
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
@@ -8,6 +8,7 @@ import eu.darken.amply.stats.core.db.StatsDatabase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -97,6 +98,38 @@ class ChargeStatsRepository @Inject constructor(
         database.get().statsDao().recentSamplesForSession(id, LIVE_SAMPLE_WINDOW).map { samples ->
             StatsDownsampler.decimate(samples.toCurve(), maxPoints)
         }
+
+    /**
+     * The step samples of the most recent finished sessions, already reduced to what
+     * [ChargeBandExtractor] needs, plus each session's recorded average power (the estimator's
+     * "speed" figure is a median across these, not a recomputation).
+     *
+     * Suspending and one-shot on purpose: the charge-time model is an expensive fold that must run
+     * off the main thread, and nothing here may touch Room until it is actually called.
+     */
+    suspend fun bandObservations(sessionLimit: Int = DEFAULT_BAND_SESSION_LIMIT): BandObservationBatch {
+        val dao = database.get().statsDao()
+        val sessions = dao.finishedSessions(sessionLimit).first()
+        val observations = mutableListOf<BandObservation>()
+        val power = mutableMapOf<Long, Int>()
+        sessions.forEach { row ->
+            val steps = dao.samplesForSessionNow(row.id).map { sample ->
+                ChargeStepSample(
+                    elapsedMillis = sample.elapsedRealtimeMillis,
+                    percent = sample.percent,
+                    batteryStatus = sample.batteryStatus,
+                )
+            }
+            observations += ChargeBandExtractor.extract(
+                sessionId = row.id,
+                chargingType = ChargingTypes.fromPluggedRaw(row.pluggedRaw),
+                samples = steps,
+            )
+            row.avgPowerMilliwatts?.let { power[row.id] = it }
+        }
+        return BandObservationBatch(observations = observations, sessionPowerMilliwatts = power)
+    }
+
 
     /**
      * Raw samples → curve points, timed from the first sample. Voltage and current ride along

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
@@ -66,17 +66,55 @@ class ChargeStatsRepository @Inject constructor(
      */
     fun curveFlow(id: Long, maxPoints: Int = DEFAULT_CURVE_POINTS): Flow<List<ChargeCurvePoint>> =
         database.get().statsDao().samplesForSession(id).map { samples ->
-            val start = samples.firstOrNull()?.elapsedRealtimeMillis ?: 0L
-            val points = samples.map { sample ->
-                ChargeCurvePoint(
-                    elapsedFromStartMillis = sample.elapsedRealtimeMillis - start,
-                    percent = sample.percent,
-                    powerMilliwatts = sample.chargePowerMilliwatts(),
-                    temperatureTenthsC = sample.temperatureTenthsC,
-                )
-            }
-            StatsDownsampler.decimate(points, maxPoints)
+            StatsDownsampler.decimate(samples.toCurve(), maxPoints)
         }
+
+    /**
+     * A session's decimated curve **and** the exact per-metric aggregates, from one pass over the
+     * same raw samples.
+     *
+     * The aggregates deliberately do NOT come from the returned curve: [curveFlow]'s decimation
+     * keeps a uniform stride, so a short temperature or current extreme is simply not among the
+     * points that survive. A screen printing "Maximum" must print the session's real maximum, and
+     * computing both here is what keeps the chart and the numbers beside it from disagreeing.
+     */
+    fun sessionMetrics(id: Long, maxPoints: Int = DEFAULT_CURVE_POINTS): Flow<SessionMetricData> =
+        database.get().statsDao().samplesForSession(id).map { samples ->
+            val points = samples.toCurve()
+            SessionMetricData(
+                curve = StatsDownsampler.decimate(points, maxPoints),
+                aggregates = CurveAggregates.of(points),
+            )
+        }
+
+    /**
+     * A **bounded** recent curve for a session, for the battery hub's sparklines. Unlike [curveFlow]
+     * this reads only the most recent [LIVE_SAMPLE_WINDOW] samples: the hub keeps this subscribed
+     * while it is open, and a session held at an OEM limit stays open for days, so an unbounded read
+     * would reload the entire curve on every appended sample.
+     */
+    fun recentCurveFlow(id: Long, maxPoints: Int = LIVE_CURVE_POINTS): Flow<List<ChargeCurvePoint>> =
+        database.get().statsDao().recentSamplesForSession(id, LIVE_SAMPLE_WINDOW).map { samples ->
+            StatsDownsampler.decimate(samples.toCurve(), maxPoints)
+        }
+
+    /**
+     * Raw samples → curve points, timed from the first sample. Voltage and current ride along
+     * untouched (see [ChargeCurvePoint]); only power passes the charging gate below.
+     */
+    private fun List<BatterySampleEntity>.toCurve(): List<ChargeCurvePoint> {
+        val start = firstOrNull()?.elapsedRealtimeMillis ?: 0L
+        return map { sample ->
+            ChargeCurvePoint(
+                elapsedFromStartMillis = sample.elapsedRealtimeMillis - start,
+                percent = sample.percent,
+                powerMilliwatts = sample.chargePowerMilliwatts(),
+                temperatureTenthsC = sample.temperatureTenthsC,
+                voltageMillivolts = sample.voltageMillivolts,
+                currentNowMicroamps = sample.currentNowMicroamps,
+            )
+        }
+    }
 
     /**
      * A sample's power, but only where it is charge power.
@@ -110,6 +148,8 @@ class ChargeStatsRepository @Inject constructor(
                 percent = sample.percent,
                 powerMilliwatts = sample.chargePowerMilliwatts(),
                 temperatureTenthsC = sample.temperatureTenthsC,
+                voltageMillivolts = sample.voltageMillivolts,
+                currentNowMicroamps = sample.currentNowMicroamps,
             )
         }
         return StatsLiveSession(
@@ -144,6 +184,9 @@ class ChargeStatsRepository @Inject constructor(
     private companion object {
         const val DEFAULT_SESSION_LIMIT = 100
         const val DEFAULT_CURVE_POINTS = 200
+
+        // How many recent finished sessions the charge-time model folds over.
+        const val DEFAULT_BAND_SESSION_LIMIT = 10
 
         // Live dashboard curve: a bounded recent window, decimated for a compact glance.
         const val LIVE_SAMPLE_WINDOW = 300

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
@@ -34,6 +34,17 @@ class ChargeStatsRepository @Inject constructor(
     fun sessionCount(): Flow<Int> = database.get().statsDao().finishedSessionCount()
 
     /**
+     * The ids of the most recent finished sessions — the refresh key for the charge-time fold.
+     *
+     * Identities, not a count: a newly sealed charge and a retention purge landing in one Room
+     * invalidation window leave the count unchanged while the history behind it is a different set,
+     * and a fold keyed on the count would keep quoting the removed charge. An open session is not in
+     * this list, so the per-tick recorder writes it suppresses stay suppressed.
+     */
+    fun recentFinishedSessionIds(limit: Int = DEFAULT_BAND_SESSION_LIMIT): Flow<List<Long>> =
+        database.get().statsDao().finishedSessions(limit).map { rows -> rows.map { it.id } }
+
+    /**
      * The in-progress charge session of the current boot, or null when nothing is open, as a live flow
      * for the dashboard card. The curve is a bounded recent window (decimated) so a session that stays
      * open for days at an OEM charge limit never triggers an unbounded reload on every appended sample.
@@ -113,20 +124,31 @@ class ChargeStatsRepository @Inject constructor(
      *
      * Suspending and one-shot on purpose: the charge-time model is an expensive fold that must run
      * off the main thread, and nothing here may touch Room until it is actually called.
+     *
+     * [cutoffWallMillis] applies the retention window to the **samples**, not just to the sessions.
+     * Sessions expire by their end stamp while samples expire by their own, so a charge that stayed
+     * open for days at an OEM limit and ended recently survives as an entry while its early samples
+     * are already outside the window (see `StatsDao.deleteSamplesOlderThan`). Dropping them here
+     * makes the fold describe what retention will leave, whenever the purge actually runs.
      */
-    suspend fun bandObservations(sessionLimit: Int = DEFAULT_BAND_SESSION_LIMIT): BandObservationBatch {
+    suspend fun bandObservations(
+        cutoffWallMillis: Long,
+        sessionLimit: Int = DEFAULT_BAND_SESSION_LIMIT,
+    ): BandObservationBatch {
         val dao = database.get().statsDao()
         val sessions = dao.finishedSessions(sessionLimit).first()
         val observations = mutableListOf<BandObservation>()
         val power = mutableMapOf<Long, Int>()
         sessions.forEach { row ->
-            val steps = dao.samplesForSessionNow(row.id).map { sample ->
-                ChargeStepSample(
-                    elapsedMillis = sample.elapsedRealtimeMillis,
-                    percent = sample.percent,
-                    batteryStatus = sample.batteryStatus,
-                )
-            }
+            val steps = dao.samplesForSessionNow(row.id)
+                .filter { it.wallMillis >= cutoffWallMillis }
+                .map { sample ->
+                    ChargeStepSample(
+                        elapsedMillis = sample.elapsedRealtimeMillis,
+                        percent = sample.percent,
+                        batteryStatus = sample.batteryStatus,
+                    )
+                }
             observations += ChargeBandExtractor.extract(
                 sessionId = row.id,
                 chargingType = ChargingTypes.fromPluggedRaw(row.pluggedRaw),

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeStatsRepository.kt
@@ -93,10 +93,17 @@ class ChargeStatsRepository @Inject constructor(
      * this reads only the most recent [LIVE_SAMPLE_WINDOW] samples: the hub keeps this subscribed
      * while it is open, and a session held at an OEM limit stays open for days, so an unbounded read
      * would reload the entire curve on every appended sample.
+     *
+     * The availability flags come from the raw window, **before** decimation, so a metric whose
+     * readings all fall on dropped indices is still reported as recorded (see [CurveMetricAvailability]).
      */
-    fun recentCurveFlow(id: Long, maxPoints: Int = LIVE_CURVE_POINTS): Flow<List<ChargeCurvePoint>> =
+    fun recentCurveFlow(id: Long, maxPoints: Int = LIVE_CURVE_POINTS): Flow<RecentCurveData> =
         database.get().statsDao().recentSamplesForSession(id, LIVE_SAMPLE_WINDOW).map { samples ->
-            StatsDownsampler.decimate(samples.toCurve(), maxPoints)
+            val points = samples.toCurve()
+            RecentCurveData(
+                curve = StatsDownsampler.decimate(points, maxPoints),
+                availability = CurveMetricAvailability.of(points),
+            )
         }
 
     /**
@@ -192,6 +199,8 @@ class ChargeStatsRepository @Inject constructor(
             startPercent = row.startPercent,
             partial = row.partial,
             curve = StatsDownsampler.decimate(points, LIVE_CURVE_POINTS),
+            // From the raw window, not the decimated curve: see [CurveMetricAvailability].
+            availability = CurveMetricAvailability.of(points),
         )
     }
 

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeTimeEstimator.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeTimeEstimator.kt
@@ -1,0 +1,187 @@
+package eu.darken.amply.stats.core
+
+/** Which history a projection was drawn from — same charger type, or every type pooled together. */
+enum class ChargeTimeBasis { SAME_TYPE, POOLED }
+
+/**
+ * A charge broken into the stretches that behave differently: the bulk phase, the taper, and the
+ * slow top-up. Each is **independently nullable**, because requiring full 0-100 coverage would hide
+ * the whole breakdown from anyone who never drains below 20%.
+ */
+data class ChargeBandSplit(
+    val toFiftyMillis: Long? = null,
+    val fiftyToEightyMillis: Long? = null,
+    val eightyToHundredMillis: Long? = null,
+) {
+    val hasAny: Boolean
+        get() = toFiftyMillis != null || fiftyToEightyMillis != null || eightyToHundredMillis != null
+}
+
+/**
+ * What a charge from the current level is expected to take, projected from recorded history.
+ *
+ * A null target is never a zero: it means Amply has not watched enough charges across that stretch
+ * to say, or (for [toEightyMillis] at 80% and above) that there is nothing left to count down to.
+ * A user who always unplugs at 80% therefore gets a null [toFullMillis] rather than an extrapolation
+ * over a stretch their device has never been observed doing.
+ */
+data class ChargeTimeEstimate(
+    val toEightyMillis: Long?,
+    val toFullMillis: Long?,
+    /** Median of the contributing sessions' recorded (already time-weighted) average power. */
+    val avgSpeedMilliwatts: Int?,
+    val split: ChargeBandSplit,
+    /** Distinct contributing sessions — never the global finished-session count. */
+    val basedOnSessions: Int,
+)
+
+/** An estimate plus which history it came from. */
+data class ChargeTimeProjection(
+    val estimate: ChargeTimeEstimate,
+    val basis: ChargeTimeBasis,
+)
+
+/**
+ * One stratum of the model: the usable bands and who contributed to them.
+ *
+ * [bands] maps a band's start level (0, 10, … 90) to the median across sessions of that session's
+ * mean milliseconds per 1% inside the band. A band that only one session ever crossed is **not**
+ * here: a single charge produces ~10 observations inside one band, so counting observations would
+ * let one charge masquerade as corroborated history.
+ */
+data class ChargeTimeStratum(
+    val bands: Map<Int, Long> = emptyMap(),
+    val sessionIds: Set<Long> = emptySet(),
+    val avgSpeedMilliwatts: Int? = null,
+) {
+    val hasData: Boolean get() = bands.isNotEmpty()
+}
+
+/** The expensive part of the estimate: everything folded out of history, independent of the level. */
+data class ChargeTimeModel(
+    val byType: Map<ChargingType, ChargeTimeStratum> = emptyMap(),
+    val pooled: ChargeTimeStratum = ChargeTimeStratum(),
+    /** Distinct sessions that produced any observation at all, usable or not. */
+    val observedSessions: Int = 0,
+) {
+    val hasData: Boolean get() = pooled.hasData || byType.values.any { it.hasData }
+}
+
+/**
+ * Projects charge times from recorded 1% steps.
+ *
+ * Split in two on purpose: [buildModel] is the history fold and only has to rerun when history
+ * changes, while [project] is a cheap pure function of the current level. That is what lets the
+ * estimate actually count down as the battery fills, instead of being pinned to whatever level it
+ * happened to be built at.
+ */
+object ChargeTimeEstimator {
+
+    /** Bands are 10% wide: wide enough for several sessions to overlap, narrow enough to taper. */
+    const val BAND_SIZE = 10
+
+    /** A band needs this many distinct sessions before it may be used. */
+    const val MIN_SESSIONS_PER_BAND = 2
+
+    fun bandOf(percent: Int): Int = (percent.coerceIn(0, 99) / BAND_SIZE) * BAND_SIZE
+
+    fun buildModel(
+        observations: List<BandObservation>,
+        sessionPowerMilliwatts: Map<Long, Int> = emptyMap(),
+    ): ChargeTimeModel {
+        if (observations.isEmpty()) return ChargeTimeModel()
+        return ChargeTimeModel(
+            byType = observations
+                .groupBy { it.chargingType }
+                .mapValues { (_, forType) -> stratum(forType, sessionPowerMilliwatts) },
+            pooled = stratum(observations, sessionPowerMilliwatts),
+            observedSessions = observations.map { it.sessionId }.distinct().size,
+        )
+    }
+
+    /**
+     * The projection for [currentPercent] on [chargingType].
+     *
+     * Falls back to the pooled history when the same-type stratum cannot answer either target from
+     * here — a median mixing a slow wireless charge with a fast wired one describes neither, so the
+     * caller is told which it got and says so.
+     */
+    fun project(
+        model: ChargeTimeModel,
+        currentPercent: Int,
+        chargingType: ChargingType,
+    ): ChargeTimeProjection? {
+        if (!model.hasData) return null
+        val level = currentPercent.coerceIn(0, 100)
+        val sameType = model.byType[chargingType]
+        val sameTypeEstimate = sameType?.let { estimate(it, level) }
+        if (sameTypeEstimate != null && (sameTypeEstimate.toEightyMillis != null || sameTypeEstimate.toFullMillis != null)) {
+            return ChargeTimeProjection(sameTypeEstimate, ChargeTimeBasis.SAME_TYPE)
+        }
+        return ChargeTimeProjection(estimate(model.pooled, level), ChargeTimeBasis.POOLED)
+    }
+
+    private fun estimate(stratum: ChargeTimeStratum, level: Int): ChargeTimeEstimate = ChargeTimeEstimate(
+        // Nothing to count down to once the target is behind us.
+        toEightyMillis = if (level >= 80) null else span(stratum, level, 80),
+        toFullMillis = if (level >= 100) null else span(stratum, level, 100),
+        avgSpeedMilliwatts = stratum.avgSpeedMilliwatts,
+        split = ChargeBandSplit(
+            toFiftyMillis = span(stratum, 0, 50),
+            fiftyToEightyMillis = span(stratum, 50, 80),
+            eightyToHundredMillis = span(stratum, 80, 100),
+        ),
+        basedOnSessions = stratum.sessionIds.size,
+    )
+
+    /** Sum of the per-percent rates from [from] to [to]; null as soon as one band is unusable. */
+    private fun span(stratum: ChargeTimeStratum, from: Int, to: Int): Long? {
+        if (from >= to) return null
+        var total = 0L
+        for (percent in from until to) {
+            total += stratum.bands[bandOf(percent)] ?: return null
+        }
+        return total
+    }
+
+    private fun stratum(
+        observations: List<BandObservation>,
+        sessionPowerMilliwatts: Map<Long, Int>,
+    ): ChargeTimeStratum {
+        val bands = mutableMapOf<Int, Long>()
+        val contributors = mutableSetOf<Long>()
+
+        observations.groupBy { bandOf(it.percentFrom) }.forEach { (band, inBand) ->
+            // One rate per session first, so a session that crossed the band slowly contributes one
+            // slow vote rather than ten.
+            val perSession = inBand.groupBy { it.sessionId }
+                .mapValues { (_, steps) -> steps.sumOf { it.millis } / steps.size }
+            if (perSession.size < MIN_SESSIONS_PER_BAND) return@forEach
+            bands[band] = median(perSession.values.toList())
+            contributors += perSession.keys
+        }
+
+        return ChargeTimeStratum(
+            bands = bands,
+            sessionIds = contributors,
+            // The speed figure describes the same charges the durations do, so it is a median over
+            // the contributing sessions' own recorded averages — not a recomputation.
+            avgSpeedMilliwatts = contributors
+                .mapNotNull { sessionPowerMilliwatts[it] }
+                .takeIf { it.isNotEmpty() }
+                ?.let { median(it.map(Int::toLong)).toInt() },
+        )
+    }
+
+    private fun median(values: List<Long>): Long {
+        val sorted = values.sorted()
+        val middle = sorted.size / 2
+        return if (sorted.size % 2 == 1) {
+            sorted[middle]
+        } else {
+            // Averaged rather than "lower middle": with two sessions — the common case — taking one
+            // side would discard half the evidence.
+            (sorted[middle - 1] + sorted[middle]) / 2
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeTimeEstimator.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeTimeEstimator.kt
@@ -33,7 +33,9 @@ data class ChargeTimeEstimate(
     val split: ChargeBandSplit,
     /** Distinct contributing sessions — never the global finished-session count. */
     val basedOnSessions: Int,
-)
+) {
+    val hasAnyTarget: Boolean get() = toEightyMillis != null || toFullMillis != null
+}
 
 /** An estimate plus which history it came from. */
 data class ChargeTimeProjection(
@@ -42,17 +44,31 @@ data class ChargeTimeProjection(
 )
 
 /**
- * One stratum of the model: the usable bands and who contributed to them.
+ * One usable band: the median across sessions of that session's mean milliseconds per 1% inside it,
+ * **with** the sessions that produced that median.
  *
- * [bands] maps a band's start level (0, 10, … 90) to the median across sessions of that session's
- * mean milliseconds per 1% inside the band. A band that only one session ever crossed is **not**
- * here: a single charge produces ~10 observations inside one band, so counting observations would
- * let one charge masquerade as corroborated history.
+ * The contributors are stored per band rather than per stratum because a figure may only be
+ * described by the charges behind it: unioning every usable band's contributors would let a session
+ * that covered one isolated band count towards a duration it contributed nothing to.
+ */
+data class ChargeTimeBand(
+    val medianMillisPerPercent: Long,
+    val sessionIds: Set<Long>,
+)
+
+/**
+ * One stratum of the model: the usable bands, keyed by their start level (0, 10, … 90).
+ *
+ * A band that only one session ever crossed is **not** here: a single charge produces ~10
+ * observations inside one band, so counting observations would let one charge masquerade as
+ * corroborated history.
+ *
+ * [sessionPowerMilliwatts] carries the contributing sessions' own recorded averages, so the speed
+ * figure can be narrowed to whichever of them actually stand behind a projection.
  */
 data class ChargeTimeStratum(
-    val bands: Map<Int, Long> = emptyMap(),
-    val sessionIds: Set<Long> = emptySet(),
-    val avgSpeedMilliwatts: Int? = null,
+    val bands: Map<Int, ChargeTimeBand> = emptyMap(),
+    val sessionPowerMilliwatts: Map<Long, Int> = emptyMap(),
 ) {
     val hasData: Boolean get() = bands.isNotEmpty()
 }
@@ -102,9 +118,15 @@ object ChargeTimeEstimator {
     /**
      * The projection for [currentPercent] on [chargingType].
      *
-     * Falls back to the pooled history when the same-type stratum cannot answer either target from
-     * here — a median mixing a slow wireless charge with a fast wired one describes neither, so the
-     * caller is told which it got and says so.
+     * Falls back to the pooled history only when pooling actually answers a target the same-type
+     * history could not — a median mixing a slow wireless charge with a fast wired one describes
+     * neither, so it is worth the trade only when it buys a figure, and the caller is told which it
+     * got and says so.
+     *
+     * The condition is not "the same-type stratum produced a target": [toEightyMillis] is null by
+     * rule from 80% up, so at 82% with same-type history that stops below 80 both targets are null
+     * and a target-only test would label the card "across all charger types" (and render the pooled
+     * split) although the same-type history is the better description of everything else on it.
      */
     fun project(
         model: ChargeTimeModel,
@@ -113,42 +135,74 @@ object ChargeTimeEstimator {
     ): ChargeTimeProjection? {
         if (!model.hasData) return null
         val level = currentPercent.coerceIn(0, 100)
-        val sameType = model.byType[chargingType]
-        val sameTypeEstimate = sameType?.let { estimate(it, level) }
-        if (sameTypeEstimate != null && (sameTypeEstimate.toEightyMillis != null || sameTypeEstimate.toFullMillis != null)) {
+        val sameTypeEstimate = model.byType[chargingType]?.let { estimate(it, level) }
+        val pooledEstimate = estimate(model.pooled, level)
+        if (sameTypeEstimate != null &&
+            (sameTypeEstimate.hasAnyTarget || pooledEstimate?.hasAnyTarget != true)
+        ) {
             return ChargeTimeProjection(sameTypeEstimate, ChargeTimeBasis.SAME_TYPE)
         }
-        return ChargeTimeProjection(estimate(model.pooled, level), ChargeTimeBasis.POOLED)
+        return pooledEstimate?.let { ChargeTimeProjection(it, ChargeTimeBasis.POOLED) }
     }
 
-    private fun estimate(stratum: ChargeTimeStratum, level: Int): ChargeTimeEstimate = ChargeTimeEstimate(
+    /**
+     * The figures for [level], plus the provenance of exactly those figures.
+     *
+     * Null when nothing at all could be projected — no target and no split segment. A card whose
+     * "From N charges" line described bands that produced nothing displayed would be worse than the
+     * not-enough-data state it replaces.
+     */
+    private fun estimate(stratum: ChargeTimeStratum, level: Int): ChargeTimeEstimate? {
         // Nothing to count down to once the target is behind us.
-        toEightyMillis = if (level >= 80) null else span(stratum, level, 80),
-        toFullMillis = if (level >= 100) null else span(stratum, level, 100),
-        avgSpeedMilliwatts = stratum.avgSpeedMilliwatts,
-        split = ChargeBandSplit(
-            toFiftyMillis = span(stratum, 0, 50),
-            fiftyToEightyMillis = span(stratum, 50, 80),
-            eightyToHundredMillis = span(stratum, 80, 100),
-        ),
-        basedOnSessions = stratum.sessionIds.size,
-    )
+        val toEighty = if (level >= 80) null else span(stratum, level, 80)
+        val toFull = if (level >= 100) null else span(stratum, level, 100)
+        val toFifty = span(stratum, 0, 50)
+        val fiftyToEighty = span(stratum, 50, 80)
+        val eightyToHundred = span(stratum, 80, 100)
+
+        val shown = listOfNotNull(toEighty, toFull, toFifty, fiftyToEighty, eightyToHundred)
+        if (shown.isEmpty()) return null
+
+        // Only the spans that actually produced a figure: those charges, and no others, are what the
+        // provenance line and the speed median describe.
+        val contributors = shown.flatMapTo(mutableSetOf()) { it.sessionIds }
+        return ChargeTimeEstimate(
+            toEightyMillis = toEighty?.millis,
+            toFullMillis = toFull?.millis,
+            avgSpeedMilliwatts = contributors
+                .mapNotNull { stratum.sessionPowerMilliwatts[it] }
+                .takeIf { it.isNotEmpty() }
+                ?.let { median(it.map(Int::toLong)).toInt() },
+            split = ChargeBandSplit(
+                toFiftyMillis = toFifty?.millis,
+                fiftyToEightyMillis = fiftyToEighty?.millis,
+                eightyToHundredMillis = eightyToHundred?.millis,
+            ),
+            basedOnSessions = contributors.size,
+        )
+    }
+
+    /** A projected stretch: its duration and the sessions the bands it consumed were medians of. */
+    private data class Span(val millis: Long, val sessionIds: Set<Long>)
 
     /** Sum of the per-percent rates from [from] to [to]; null as soon as one band is unusable. */
-    private fun span(stratum: ChargeTimeStratum, from: Int, to: Int): Long? {
+    private fun span(stratum: ChargeTimeStratum, from: Int, to: Int): Span? {
         if (from >= to) return null
         var total = 0L
+        val contributors = mutableSetOf<Long>()
         for (percent in from until to) {
-            total += stratum.bands[bandOf(percent)] ?: return null
+            val band = stratum.bands[bandOf(percent)] ?: return null
+            total += band.medianMillisPerPercent
+            contributors += band.sessionIds
         }
-        return total
+        return Span(millis = total, sessionIds = contributors)
     }
 
     private fun stratum(
         observations: List<BandObservation>,
         sessionPowerMilliwatts: Map<Long, Int>,
     ): ChargeTimeStratum {
-        val bands = mutableMapOf<Int, Long>()
+        val bands = mutableMapOf<Int, ChargeTimeBand>()
         val contributors = mutableSetOf<Long>()
 
         observations.groupBy { bandOf(it.percentFrom) }.forEach { (band, inBand) ->
@@ -157,19 +211,18 @@ object ChargeTimeEstimator {
             val perSession = inBand.groupBy { it.sessionId }
                 .mapValues { (_, steps) -> steps.sumOf { it.millis } / steps.size }
             if (perSession.size < MIN_SESSIONS_PER_BAND) return@forEach
-            bands[band] = median(perSession.values.toList())
+            bands[band] = ChargeTimeBand(
+                medianMillisPerPercent = median(perSession.values.toList()),
+                sessionIds = perSession.keys.toSet(),
+            )
             contributors += perSession.keys
         }
 
         return ChargeTimeStratum(
             bands = bands,
-            sessionIds = contributors,
-            // The speed figure describes the same charges the durations do, so it is a median over
-            // the contributing sessions' own recorded averages — not a recomputation.
-            avgSpeedMilliwatts = contributors
-                .mapNotNull { sessionPowerMilliwatts[it] }
-                .takeIf { it.isNotEmpty() }
-                ?.let { median(it.map(Int::toLong)).toInt() },
+            // Kept for the sessions behind a usable band only; the projection narrows it further to
+            // the ones behind the figures it actually shows.
+            sessionPowerMilliwatts = sessionPowerMilliwatts.filterKeys { it in contributors },
         )
     }
 

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeTimeModelSource.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeTimeModelSource.kt
@@ -10,12 +10,12 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -38,10 +38,18 @@ sealed interface ChargeTimeModelState {
  * neither may load and re-extract ten sessions of samples on its own — hence a singleton with a
  * shared, replayed flow rather than a per-ViewModel one.
  *
- * The refresh trigger is the finished-session count with an explicit `distinctUntilChanged`. Room
- * invalidates per *table*, so every per-tick update to the open session re-emits an unchanged count;
- * without the guard the whole ten-session extraction would rerun every recorder tick during a
- * charge.
+ * The refresh trigger is the **identities** of the recent finished sessions plus the retention
+ * window, with an explicit `distinctUntilChanged`. Room invalidates per *table*, so every per-tick
+ * update to the open session re-emits an unchanged list; without the guard the whole ten-session
+ * extraction would rerun every recorder tick during a charge. A bare count would be the wrong key in
+ * the other direction: a sealed charge and a purged one landing in the same invalidation window
+ * cancel out, leaving the fold quoting history that is gone. The retention setting rides along
+ * because it is what decides which samples the fold may use.
+ *
+ * There is deliberately **no** `onStart { emit(Loading) }`. It would sit upstream of the `shareIn`
+ * and therefore re-run on every upstream restart, so a subscriber returning after the stop timeout
+ * would get the replayed `Ready` followed by a fresh `Loading` — the card visibly blinking back to
+ * its loading line. First-load `Loading` comes from the downstream initial state instead.
  *
  * Nothing here touches Room until [states] is actually collected: the trigger flow is built inside
  * the `flow` block, so merely injecting this class never creates `stats.db`.
@@ -49,17 +57,26 @@ sealed interface ChargeTimeModelState {
 @Singleton
 class ChargeTimeModelSource @Inject constructor(
     private val repository: ChargeStatsRepository,
+    private val statsPreferences: StatsPreferences,
     @param:StatsDispatcher private val dispatcher: CoroutineDispatcher,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
     val states: Flow<ChargeTimeModelState> = flow<ChargeTimeModelState> {
         emitAll(
-            repository.sessionCount()
+            combine(
+                repository.recentFinishedSessionIds(),
+                statsPreferences.retentionDays.flow,
+            ) { sessionIds, retentionDays -> sessionIds to retentionDays }
                 .distinctUntilChanged()
-                .map { count ->
-                    log(TAG) { "Rebuilding the charge-time model over $count finished sessions" }
-                    val batch = repository.bandObservations()
+                .map { (sessionIds, retentionDays) ->
+                    log(TAG) { "Rebuilding the charge-time model over ${sessionIds.size} finished sessions" }
+                    val batch = repository.bandObservations(
+                        cutoffWallMillis = StatsRetention.cutoffWallMillis(
+                            nowWallMillis = System.currentTimeMillis(),
+                            days = StatsRetention.clampDays(retentionDays),
+                        ),
+                    )
                     ChargeTimeModelState.Ready(
                         ChargeTimeEstimator.buildModel(
                             observations = batch.observations,
@@ -69,7 +86,6 @@ class ChargeTimeModelSource @Inject constructor(
                 },
         )
     }
-        .onStart { emit(ChargeTimeModelState.Loading) }
         .catch { e ->
             log(TAG, Logging.Priority.ERROR) { "Charge-time model failed: ${e.asLog()}" }
             emit(ChargeTimeModelState.Unavailable)

--- a/app/src/main/java/eu/darken/amply/stats/core/ChargeTimeModelSource.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/ChargeTimeModelSource.kt
@@ -1,0 +1,85 @@
+package eu.darken.amply.stats.core
+
+import eu.darken.amply.common.debug.logging.Logging
+import eu.darken.amply.common.debug.logging.asLog
+import eu.darken.amply.common.debug.logging.log
+import eu.darken.amply.common.debug.logging.logTag
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.shareIn
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** The charge-time history model, or why there isn't one yet. */
+sealed interface ChargeTimeModelState {
+    /** Not folded yet. Distinct from an empty model: it is not a statement about the user's history. */
+    data object Loading : ChargeTimeModelState
+
+    /** The stats pipeline failed. Our outage must stay distinguishable from an empty history. */
+    data object Unavailable : ChargeTimeModelState
+
+    data class Ready(val model: ChargeTimeModel) : ChargeTimeModelState
+}
+
+/**
+ * Owns the charge-time history fold **once** for every consumer.
+ *
+ * Two surfaces show an estimate (the battery hub's card and the dashboard's charging card), and
+ * neither may load and re-extract ten sessions of samples on its own — hence a singleton with a
+ * shared, replayed flow rather than a per-ViewModel one.
+ *
+ * The refresh trigger is the finished-session count with an explicit `distinctUntilChanged`. Room
+ * invalidates per *table*, so every per-tick update to the open session re-emits an unchanged count;
+ * without the guard the whole ten-session extraction would rerun every recorder tick during a
+ * charge.
+ *
+ * Nothing here touches Room until [states] is actually collected: the trigger flow is built inside
+ * the `flow` block, so merely injecting this class never creates `stats.db`.
+ */
+@Singleton
+class ChargeTimeModelSource @Inject constructor(
+    private val repository: ChargeStatsRepository,
+    @param:StatsDispatcher private val dispatcher: CoroutineDispatcher,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    val states: Flow<ChargeTimeModelState> = flow<ChargeTimeModelState> {
+        emitAll(
+            repository.sessionCount()
+                .distinctUntilChanged()
+                .map { count ->
+                    log(TAG) { "Rebuilding the charge-time model over $count finished sessions" }
+                    val batch = repository.bandObservations()
+                    ChargeTimeModelState.Ready(
+                        ChargeTimeEstimator.buildModel(
+                            observations = batch.observations,
+                            sessionPowerMilliwatts = batch.sessionPowerMilliwatts,
+                        ),
+                    )
+                },
+        )
+    }
+        .onStart { emit(ChargeTimeModelState.Loading) }
+        .catch { e ->
+            log(TAG, Logging.Priority.ERROR) { "Charge-time model failed: ${e.asLog()}" }
+            emit(ChargeTimeModelState.Unavailable)
+        }
+        // The fold reads every sample of ten sessions; it never runs on the caller's thread.
+        .flowOn(dispatcher)
+        .shareIn(scope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS), replay = 1)
+
+    private companion object {
+        val TAG = logTag("Stats", "ChargeTimeModelSource")
+        const val STOP_TIMEOUT_MILLIS = 5_000L
+    }
+}

--- a/app/src/main/java/eu/darken/amply/stats/core/CurveAggregates.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/CurveAggregates.kt
@@ -1,0 +1,104 @@
+package eu.darken.amply.stats.core
+
+import kotlin.math.roundToInt
+
+/**
+ * The min / time-weighted average / max of one metric across a session, plus how many samples
+ * actually carried a value for it. A metric with no readings at all has no [MetricStats] — the
+ * caller hides the row rather than printing zeros.
+ */
+data class MetricStats(
+    val min: Int,
+    val avg: Int,
+    val max: Int,
+    val sampleCount: Int,
+)
+
+/** Per-metric statistics for one session's curve. A null entry means the metric was never reported. */
+data class CurveAggregates(
+    val level: MetricStats? = null,
+    val power: MetricStats? = null,
+    val voltage: MetricStats? = null,
+    val current: MetricStats? = null,
+    val temperature: MetricStats? = null,
+) {
+
+    companion object {
+        val EMPTY = CurveAggregates()
+
+        /**
+         * Aggregate one session's **raw, undecimated** points.
+         *
+         * Feeding this a decimated curve would be wrong: `StatsDownsampler.decimate` thins with a
+         * uniform stride, so a brief temperature or current extreme is dropped outright and a
+         * "Maximum" computed from the survivors is not the session's maximum.
+         */
+        fun of(points: List<ChargeCurvePoint>): CurveAggregates = CurveAggregates(
+            level = points.statsOf { it.percent },
+            power = points.statsOf { it.powerMilliwatts },
+            voltage = points.statsOf { it.voltageMillivolts },
+            current = points.statsOf { it.currentNowMicroamps },
+            temperature = points.statsOf { it.temperatureTenthsC },
+        )
+    }
+}
+
+/**
+ * Longest inter-sample interval credited to a single reading, mirroring
+ * [StatsSessionEngine.MAX_WEIGHT_GAP_MILLIS] so a Doze gap can't massively overweight one stale
+ * value here either.
+ */
+private const val MAX_WEIGHT_GAP_MILLIS = StatsSessionEngine.MAX_WEIGHT_GAP_MILLIS
+
+/**
+ * One metric's statistics over [this].
+ *
+ * The average is **time-weighted** (left-Riemann: each sample is credited the interval up to the
+ * next one), not a plain mean. `StatsCadence` records on every level change as well as on its
+ * timer, so samples are denser while charging fast — a plain mean would over-weight exactly that
+ * stretch. It also matches how `ChargeSessionSummary.avgPowerMilliwatts` is folded online, so one
+ * session can never show two different "average power" figures on two screens.
+ *
+ * Sums accumulate in [Double]/[Long]: `currentNowMicroamps` in the millions overflows an `Int` sum
+ * after a few hundred samples.
+ */
+private fun List<ChargeCurvePoint>.statsOf(select: (ChargeCurvePoint) -> Int?): MetricStats? {
+    var min = Int.MAX_VALUE
+    var max = Int.MIN_VALUE
+    var count = 0
+    var plainSum = 0L
+    var weightedSum = 0.0
+    var weightedDuration = 0L
+
+    forEachIndexed { index, point ->
+        val value = select(point) ?: return@forEachIndexed
+        count++
+        plainSum += value
+        if (value < min) min = value
+        if (value > max) max = value
+        val next = getOrNull(index + 1) ?: return@forEachIndexed
+        // Negative (clock went backwards) collapses to zero rather than subtracting weight.
+        val dt = (next.elapsedFromStartMillis - point.elapsedFromStartMillis)
+            .coerceIn(0L, MAX_WEIGHT_GAP_MILLIS)
+        if (dt > 0) {
+            weightedSum += value.toDouble() * dt
+            weightedDuration += dt
+        }
+    }
+
+    if (count == 0) return null
+    // No interval carried weight (a single sample, or every gap zero-length): the plain mean is the
+    // only honest answer, and it degenerates to the value itself for one sample.
+    val avg = if (weightedDuration > 0) {
+        (weightedSum / weightedDuration).roundToInt()
+    } else {
+        (plainSum.toDouble() / count).roundToInt()
+    }
+    return MetricStats(min = min, avg = avg, max = max, sampleCount = count)
+}
+
+/** A session's decimated curve paired with the aggregates taken from its raw samples. */
+data class SessionMetricData(
+    val curve: List<ChargeCurvePoint>,
+    val aggregates: CurveAggregates,
+)

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsModels.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsModels.kt
@@ -43,6 +43,41 @@ data class ChargeCurvePoint(
 )
 
 /**
+ * Which metrics a charge actually recorded, computed from its **raw** samples.
+ *
+ * Deliberately not derived from the curve a surface draws: [StatsDownsampler.decimate] thins with a
+ * uniform stride, so a metric reported only intermittently can lose every one of its readings to
+ * decimation. A tile deciding "nothing recorded" from the survivors would refuse to open a detail
+ * screen that has data to show — the detail screen reads the undecimated samples.
+ */
+data class CurveMetricAvailability(
+    val level: Boolean = false,
+    val power: Boolean = false,
+    val voltage: Boolean = false,
+    val current: Boolean = false,
+    val temperature: Boolean = false,
+) {
+    companion object {
+        /** Nothing recorded — the honest state before any curve has been read. */
+        val NONE = CurveMetricAvailability()
+
+        fun of(points: List<ChargeCurvePoint>) = CurveMetricAvailability(
+            level = points.any { it.percent != null },
+            power = points.any { it.powerMilliwatts != null },
+            voltage = points.any { it.voltageMillivolts != null },
+            current = points.any { it.currentNowMicroamps != null },
+            temperature = points.any { it.temperatureTenthsC != null },
+        )
+    }
+}
+
+/** A finished session's bounded recent curve paired with what its raw samples actually recorded. */
+data class RecentCurveData(
+    val curve: List<ChargeCurvePoint> = emptyList(),
+    val availability: CurveMetricAvailability = CurveMetricAvailability.NONE,
+)
+
+/**
  * The in-progress charge session for the dashboard's live card. Carries only what Room owns
  * authoritatively — the session's start, its "partial" nature, and a bounded recent curve. The live
  * "now" values (current level, temperature, power) are read from the dashboard's fresh battery
@@ -61,6 +96,8 @@ data class StatsLiveSession(
     /** True when capture began mid-charge — the card frames it as "since …", not a full history. */
     val partial: Boolean,
     val curve: List<ChargeCurvePoint>,
+    /** Taken from the raw window, so a metric decimation dropped is still known to exist. */
+    val availability: CurveMetricAvailability = CurveMetricAvailability.NONE,
 )
 
 /** Maps a raw [android.os.BatteryManager.EXTRA_PLUGGED] bitmask to a [ChargingType]. */

--- a/app/src/main/java/eu/darken/amply/stats/core/StatsModels.kt
+++ b/app/src/main/java/eu/darken/amply/stats/core/StatsModels.kt
@@ -25,12 +25,21 @@ data class ChargeSessionSummary(
     val sealReason: StatsSealReason?,
 )
 
-/** One point on a session's charge curve, timed from the session start. */
+/**
+ * One point on a session's charge curve, timed from the session start.
+ *
+ * [voltageMillivolts] and [currentNowMicroamps] are raw observations carried through verbatim —
+ * unlike [powerMilliwatts] they are **not** withheld while the battery isn't taking charge, because
+ * they are directional readings that stay meaningful in either direction (the current keeps the
+ * sign the OEM reported; it is never made absolute here).
+ */
 data class ChargeCurvePoint(
     val elapsedFromStartMillis: Long,
     val percent: Int?,
     val powerMilliwatts: Int?,
     val temperatureTenthsC: Int?,
+    val voltageMillivolts: Int? = null,
+    val currentNowMicroamps: Int? = null,
 )
 
 /**

--- a/app/src/main/java/eu/darken/amply/stats/ui/ChargeTimeState.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/ChargeTimeState.kt
@@ -1,0 +1,108 @@
+package eu.darken.amply.stats.ui
+
+import android.os.BatteryManager
+import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.stats.core.ChargeTimeBasis
+import eu.darken.amply.stats.core.ChargeTimeEstimate
+import eu.darken.amply.stats.core.ChargeTimeEstimator
+import eu.darken.amply.stats.core.ChargeTimeModelState
+import eu.darken.amply.stats.core.ChargingTypes
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * What the charge-time surfaces show.
+ *
+ * [Unavailable] is deliberately distinct from [NotEnoughData]: our own outage is not a statement
+ * about the user's history.
+ */
+sealed interface ChargeTimeState {
+
+    /** The history model hasn't been folded yet — a skeleton, never the empty copy. */
+    data object Loading : ChargeTimeState
+
+    /** The stats pipeline failed. */
+    data object Unavailable : ChargeTimeState
+
+    /** Recording is on and healthy, but too few charges have been observed to project anything. */
+    data class NotEnoughData(val sessions: Int) : ChargeTimeState
+
+    /**
+     * A projection for the current level.
+     *
+     * [charging] is what decides the wording: a countdown toward a target the device is not moving
+     * toward would be a false claim, so unplugged — or held at an OEM limit, where the platform
+     * reports NOT_CHARGING while the session is still live — the same figures are presented as a
+     * reference rather than a count down.
+     */
+    data class Ready(
+        val estimate: ChargeTimeEstimate,
+        val basis: ChargeTimeBasis,
+        val charging: Boolean,
+        val currentPercent: Int?,
+    ) : ChargeTimeState
+}
+
+/**
+ * Combines the cached history model with the **live** readout, so the estimate tracks the charge as
+ * the level moves rather than being pinned to the level the model was folded at.
+ *
+ * [captureEnabled] gates the whole thing: with recording off there is nothing to project from, no
+ * surface renders a card, and — crucially — the model provider is never invoked, so a user who never
+ * enabled recording never gets `stats.db` created for them. [model] is a provider function for the
+ * same reason the dashboard's stats slice uses one: it must not be a flow built at construction.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal fun chargeTimeStates(
+    captureEnabled: Flow<Boolean>,
+    readouts: Flow<BatteryReadout?>,
+    model: () -> Flow<ChargeTimeModelState>,
+): Flow<ChargeTimeState> = captureEnabled.flatMapLatest { enabled ->
+    if (!enabled) {
+        flowOf(ChargeTimeState.Loading)
+    } else {
+        flow {
+            emitAll(
+                combine(model(), readouts) { modelState, readout ->
+                    chargeTimeState(modelState, readout)
+                },
+            )
+        }.catch { emit(ChargeTimeState.Unavailable) }
+    }
+}
+
+/** Pure projection of one model state against one readout. */
+internal fun chargeTimeState(modelState: ChargeTimeModelState, readout: BatteryReadout?): ChargeTimeState =
+    when (modelState) {
+        ChargeTimeModelState.Loading -> ChargeTimeState.Loading
+        ChargeTimeModelState.Unavailable -> ChargeTimeState.Unavailable
+        is ChargeTimeModelState.Ready -> {
+            val level = readout?.levelPercent
+            val projection = level?.let {
+                ChargeTimeEstimator.project(
+                    model = modelState.model,
+                    currentPercent = it,
+                    chargingType = ChargingTypes.fromPluggedRaw(readout.plugged),
+                )
+            }
+            if (projection == null) {
+                ChargeTimeState.NotEnoughData(modelState.model.observedSessions)
+            } else {
+                ChargeTimeState.Ready(
+                    estimate = projection.estimate,
+                    basis = projection.basis,
+                    // Both halves matter: a device on a charger that reports NOT_CHARGING is being
+                    // held, not counted down.
+                    charging = readout.onCharger &&
+                        readout.status == BatteryManager.BATTERY_STATUS_CHARGING,
+                    currentPercent = level,
+                )
+            }
+        }
+    }

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsViewModel.kt
@@ -21,6 +21,7 @@ import eu.darken.amply.stats.core.ChargeCurvePoint
 import eu.darken.amply.stats.core.ChargeSessionSummary
 import eu.darken.amply.stats.core.ChargeStatsRecorder
 import eu.darken.amply.stats.core.ChargeStatsRepository
+import eu.darken.amply.stats.core.RecentCurveData
 import eu.darken.amply.stats.core.StatsPreferences
 import eu.darken.amply.stats.core.StatsRetention
 import eu.darken.amply.upgrade.core.UpgradeRepo
@@ -166,7 +167,9 @@ class StatsViewModel @Inject constructor(
     }
 
     /**
-     * The hub's sparkline curve for a **finished** session. A live session needs nothing from here:
+     * The hub's sparkline curve for a **finished** session, plus what that session's raw samples
+     * actually recorded (the curve is decimated, so it cannot answer that). A live session needs
+     * nothing from here:
      * the teaser already carries `StatsLiveSession.curve`, which `currentSession()` bounds on
      * purpose — opening the unbounded curve for that same session would reload the whole thing on
      * every appended sample, which is exactly what the bounded window exists to avoid. This read is
@@ -177,19 +180,19 @@ class StatsViewModel @Inject constructor(
      * `stats.db` for a user who never enabled capture and merely opened the battery hub.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    val hubCurve: StateFlow<List<ChargeCurvePoint>> = hubSessionId
+    val hubCurve: StateFlow<RecentCurveData> = hubSessionId
         .flatMapLatest { id ->
             if (id == null) {
-                flowOf(emptyList())
+                flowOf(RecentCurveData())
             } else {
                 flow { emitAll(repository.recentCurveFlow(id)) }
                     .catch { e ->
                         log(TAG, Logging.Priority.ERROR) { "Hub curve flow failed for $id: ${e.message}" }
-                        emit(emptyList())
+                        emit(RecentCurveData())
                     }
             }
         }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS), emptyList())
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS), RecentCurveData())
 
     fun openSession(id: Long) {
         savedStateHandle[KEY_SELECTED_SESSION] = id

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsViewModel.kt
@@ -26,6 +26,7 @@ import eu.darken.amply.upgrade.core.isProForUi
 import eu.darken.amply.upgrade.core.isProSettled
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
@@ -150,6 +151,43 @@ class StatsViewModel @Inject constructor(
             }
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS), null)
+
+    /**
+     * The session whose curve the battery hub's tiles are drawing, set by the composition root from
+     * the hub's charge teaser. Not saved state: the hub derives it from the teaser on every entry,
+     * so a restored process re-supplies it rather than restoring a stale id.
+     */
+    private val hubSessionId = MutableStateFlow<Long?>(null)
+
+    fun setHubSession(id: Long?) {
+        hubSessionId.value = id
+    }
+
+    /**
+     * The hub's sparkline curve for a **finished** session. A live session needs nothing from here:
+     * the teaser already carries `StatsLiveSession.curve`, which `currentSession()` bounds on
+     * purpose — opening the unbounded curve for that same session would reload the whole thing on
+     * every appended sample, which is exactly what the bounded window exists to avoid. This read is
+     * bounded for the same reason.
+     *
+     * The repository flow is built **inside** the [flatMapLatest] block, like [detailState]:
+     * `ChargeStatsRepository` calls `database.get()` eagerly, so constructing it up front would open
+     * `stats.db` for a user who never enabled capture and merely opened the battery hub.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val hubCurve: StateFlow<List<ChargeCurvePoint>> = hubSessionId
+        .flatMapLatest { id ->
+            if (id == null) {
+                flowOf(emptyList())
+            } else {
+                flow { emitAll(repository.recentCurveFlow(id)) }
+                    .catch { e ->
+                        log(TAG, Logging.Priority.ERROR) { "Hub curve flow failed for $id: ${e.message}" }
+                        emit(emptyList())
+                    }
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS), emptyList())
 
     fun openSession(id: Long) {
         savedStateHandle[KEY_SELECTED_SESSION] = id

--- a/app/src/main/java/eu/darken/amply/stats/ui/StatsViewModel.kt
+++ b/app/src/main/java/eu/darken/amply/stats/ui/StatsViewModel.kt
@@ -14,6 +14,8 @@ import eu.darken.amply.common.debug.logging.log
 import eu.darken.amply.common.debug.logging.logTag
 import eu.darken.amply.common.flow.SingleEventFlow
 import eu.darken.amply.fullcharge.core.ChargeSessionService
+import eu.darken.amply.main.ui.battery.BatteryMetric
+import eu.darken.amply.main.ui.battery.BatteryMetricDetailState
 import eu.darken.amply.stats.core.CaptureServiceHealth
 import eu.darken.amply.stats.core.ChargeCurvePoint
 import eu.darken.amply.stats.core.ChargeSessionSummary
@@ -198,6 +200,87 @@ class StatsViewModel @Inject constructor(
     }
 
     /**
+     * The metric-detail selection, saved as the **pair** (session, metric) rather than the metric
+     * alone.
+     *
+     * Persisting only the metric and letting the session follow whatever the hub's teaser currently
+     * points at would silently swap the chart to a different charge under an unchanged title — a
+     * charge starting while the screen is open, or a process death after the teaser has moved on,
+     * would both do it. The two keys are written and cleared together for the same reason.
+     */
+    private val metricSelection: Flow<MetricSelection?> = combine(
+        savedStateHandle.getStateFlow<Long?>(KEY_METRIC_SESSION, null),
+        savedStateHandle.getStateFlow<String?>(KEY_METRIC_NAME, null),
+    ) { sessionId, metricName -> resolveMetricSelection(sessionId, metricName) }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val metricDetailState: StateFlow<BatteryMetricDetailState?> = metricSelection
+        .flatMapLatest { selection ->
+            if (selection == null) {
+                flowOf<BatteryMetricDetailState?>(null)
+            } else {
+                // Both flows stay live so an open session's chart and statistics keep updating. The
+                // summary is what answers "does this session still exist" — an empty curve alone
+                // cannot, since a session with no samples yet also has one. Built inside the
+                // collected flow so a synchronous construction failure lands in the catch below.
+                flow<BatteryMetricDetailState?> {
+                    emitAll(
+                        combine(
+                            repository.session(selection.sessionId),
+                            repository.sessionMetrics(selection.sessionId),
+                        ) { summary, data ->
+                            BatteryMetricDetailState(
+                                metric = selection.metric,
+                                sessionMissing = summary == null,
+                                curve = data.curve,
+                                stats = selection.metric.stats(data.aggregates),
+                            )
+                        },
+                    )
+                }.catch { e ->
+                    log(TAG, Logging.Priority.ERROR) { "Metric detail flow failed: ${e.message}" }
+                    emit(
+                        BatteryMetricDetailState(
+                            metric = selection.metric,
+                            sessionMissing = true,
+                            curve = emptyList(),
+                            stats = null,
+                        ),
+                    )
+                }
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS), null)
+
+    fun openMetric(sessionId: Long, metric: BatteryMetric) {
+        savedStateHandle[KEY_METRIC_SESSION] = sessionId
+        savedStateHandle[KEY_METRIC_NAME] = metric.name
+    }
+
+    fun closeMetric() {
+        savedStateHandle[KEY_METRIC_SESSION] = null
+        savedStateHandle[KEY_METRIC_NAME] = null
+    }
+
+    /**
+     * A stored metric name is a wire format, so it is parsed defensively: a name this build no
+     * longer knows clears the selection rather than throwing on restore. Clearing also stops the
+     * screen resolving against a session it can't label.
+     */
+    private fun resolveMetricSelection(sessionId: Long?, metricName: String?): MetricSelection? {
+        if (sessionId == null || metricName == null) return null
+        val metric = BatteryMetric.entries.firstOrNull { it.name == metricName }
+        if (metric == null) {
+            log(TAG, Logging.Priority.WARN) { "Unknown saved battery metric '$metricName', clearing" }
+            closeMetric()
+            return null
+        }
+        return MetricSelection(sessionId = sessionId, metric = metric)
+    }
+
+    private data class MetricSelection(val sessionId: Long, val metric: BatteryMetric)
+
+    /**
      * Enable/disable capture. Enabling is routed through the activity's notification-permission flow
      * first (the always-on service shows a persistent notification). Disabling seals any open session
      * before the service is nudged to re-evaluate and stop.
@@ -250,10 +333,14 @@ class StatsViewModel @Inject constructor(
         }
     }
 
-    private companion object {
+    // Internal, not private: the saved-state keys are asserted by the metric-selection test, which
+    // exists precisely to pin that both halves of the selection are written and cleared together.
+    internal companion object {
         val TAG = logTag("Stats", "ViewModel")
         const val STOP_TIMEOUT_MILLIS = 5_000L
         const val KEY_SELECTED_SESSION = "stats.selected_session_id"
+        const val KEY_METRIC_SESSION = "stats.metric.session_id"
+        const val KEY_METRIC_NAME = "stats.metric.name"
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -496,6 +496,7 @@
     <string name="battery_value_not_reported">Not reported</string>
     <string name="battery_value_unknown">Unknown</string>
     <string name="battery_value_not_charging">Not charging</string>
+    <string name="battery_value_none">—</string>
     <string name="battery_hub_title">Battery &amp; charging</string>
     <string name="battery_hub_history_action">Charge history</string>
     <string name="battery_hub_section_now">Now</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -533,6 +533,33 @@
     <string name="battery_metric_min">Minimum</string>
     <string name="battery_metric_avg">Average</string>
     <string name="battery_metric_max">Maximum</string>
+
+    <!-- Charge-time estimates (hub card + dashboard line) -->
+    <string name="charge_time_title">Charge time</string>
+    <string name="charge_time_headline_full_countdown">Full in about %1$s</string>
+    <string name="charge_time_headline_full_reference">Typically about %1$s to full from here</string>
+    <string name="charge_time_headline_eighty_countdown">80%% in about %1$s</string>
+    <string name="charge_time_headline_eighty_reference">Typically about %1$s to 80%% from here</string>
+    <string name="charge_time_to_eighty" formatted="false">To 80%</string>
+    <string name="charge_time_to_full" formatted="false">To 100%</string>
+    <string name="charge_time_avg_speed">Avg speed</string>
+    <string name="charge_time_value_missing">Not enough data yet</string>
+    <string name="charge_time_split_title">Where the time goes</string>
+    <string name="charge_time_split_to_fifty" formatted="false">To 50%</string>
+    <string name="charge_time_split_fifty_eighty" formatted="false">50–80%</string>
+    <string name="charge_time_split_eighty_hundred" formatted="false">80–100%</string>
+    <string name="charge_time_trickle_note" formatted="false">The last stretch takes the longest: your device deliberately slows down near 100% to be easier on the battery.</string>
+    <plurals name="charge_time_provenance_same_type">
+        <item quantity="one">From %1$d charge on this kind of charger</item>
+        <item quantity="other">From %1$d charges on this kind of charger</item>
+    </plurals>
+    <plurals name="charge_time_provenance_pooled">
+        <item quantity="one">From %1$d charge, across all charger types</item>
+        <item quantity="other">From %1$d charges, across all charger types</item>
+    </plurals>
+    <string name="charge_time_loading">Working out your charge times…</string>
+    <string name="charge_time_unavailable">Statistics are unavailable right now</string>
+    <string name="charge_time_not_enough">Amply needs to record a few more charges before it can estimate how long yours take.</string>
     <string name="battery_status_charging">Charging</string>
     <string name="battery_status_discharging">Discharging</string>
     <string name="battery_status_not_charging">Not charging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -510,19 +510,29 @@
     <string name="battery_detail_section_charging">Charging</string>
     <string name="battery_detail_section_health">Health</string>
     <string name="battery_detail_section_electrical">Electrical</string>
-    <string name="battery_detail_section_thermal">Thermal</string>
-    <string name="battery_detail_level">Level</string>
     <string name="battery_detail_status">Status</string>
     <string name="battery_detail_power_source">Power source</string>
     <string name="battery_detail_technology">Technology</string>
     <string name="battery_detail_health">Health</string>
     <string name="battery_detail_cycle_count">Charge cycles</string>
-    <string name="battery_detail_voltage">Voltage</string>
-    <string name="battery_detail_current">Current now</string>
-    <string name="battery_detail_power">Charge power</string>
     <string name="battery_detail_charger_max">Charger max</string>
     <string name="battery_detail_charge_counter">Charge counter</string>
-    <string name="battery_detail_temperature">Temperature</string>
+
+    <!-- Per-metric tiles and their detail screen -->
+    <string name="battery_metric_open_action">Open metric details</string>
+    <string name="battery_metric_level_title">Level</string>
+    <string name="battery_metric_level_explainer">How full the battery is, as a percentage. It is the phone\'s own estimate rather than a direct measurement, so it can move in jumps when the estimate is corrected.</string>
+    <string name="battery_metric_power_title">Charge power</string>
+    <string name="battery_metric_power_explainer">How fast energy is going into the battery, measured at the battery itself (voltage x current). It is normally highest early in a charge and tapers off near the top. It is only recorded while the battery is actually taking charge.</string>
+    <string name="battery_metric_voltage_title">Voltage</string>
+    <string name="battery_metric_voltage_explainer">The battery cell voltage. It rises as the battery fills and drops under load, so it tracks the charge level rather than the charging speed.</string>
+    <string name="battery_metric_current_title">Current now</string>
+    <string name="battery_metric_current_explainer">The current flowing in or out of the battery. Positive normally means charging and negative means discharging, but the sign is up to the manufacturer, so some devices report it the other way round.</string>
+    <string name="battery_metric_temperature_title">Temperature</string>
+    <string name="battery_metric_temperature_explainer">The battery temperature reported by the phone. Sustained heat is what ages a battery fastest, so a charge that stays cool is easier on it than a fast one that runs hot.</string>
+    <string name="battery_metric_min">Minimum</string>
+    <string name="battery_metric_avg">Average</string>
+    <string name="battery_metric_max">Maximum</string>
     <string name="battery_status_charging">Charging</string>
     <string name="battery_status_discharging">Discharging</string>
     <string name="battery_status_not_charging">Not charging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -508,16 +508,15 @@
     <string name="battery_hub_teaser_loading">Loading…</string>
     <string name="battery_hub_teaser_unavailable">Statistics are unavailable right now</string>
     <string name="battery_hub_teaser_open_action">View charge session</string>
-    <string name="battery_detail_section_charging">Charging</string>
-    <string name="battery_detail_section_health">Health</string>
-    <string name="battery_detail_section_electrical">Electrical</string>
+    <string name="battery_detail_section_battery">This battery</string>
+    <string name="battery_detail_section_charger">This charger</string>
     <string name="battery_detail_status">Status</string>
     <string name="battery_detail_power_source">Power source</string>
     <string name="battery_detail_technology">Technology</string>
-    <string name="battery_detail_health">Health</string>
+    <string name="battery_detail_health">Battery health</string>
     <string name="battery_detail_cycle_count">Charge cycles</string>
     <string name="battery_detail_charger_max">Charger max</string>
-    <string name="battery_detail_charge_counter">Charge counter</string>
+    <string name="battery_detail_charge_counter">Charge remaining</string>
 
     <!-- Per-metric tiles and their detail screen -->
     <string name="battery_metric_open_action">Open metric details</string>

--- a/app/src/screenshotTest/kotlin/eu/darken/amply/screenshots/HubScreenshots.kt
+++ b/app/src/screenshotTest/kotlin/eu/darken/amply/screenshots/HubScreenshots.kt
@@ -17,3 +17,8 @@ fun HubTileGrid() = HubTileGridContent()
 @Preview(showBackground = true, device = DS)
 @Composable
 fun HubTileGridEmpty() = HubTileGridEmptyContent()
+
+@PreviewTest
+@Preview(showBackground = true, device = DS)
+@Composable
+fun MetricDetail() = MetricDetailContent()

--- a/app/src/screenshotTest/kotlin/eu/darken/amply/screenshots/HubScreenshots.kt
+++ b/app/src/screenshotTest/kotlin/eu/darken/amply/screenshots/HubScreenshots.kt
@@ -22,3 +22,13 @@ fun HubTileGridEmpty() = HubTileGridEmptyContent()
 @Preview(showBackground = true, device = DS)
 @Composable
 fun MetricDetail() = MetricDetailContent()
+
+@PreviewTest
+@Preview(showBackground = true, device = DS)
+@Composable
+fun ChargeTimeReady() = ChargeTimeReadyContent()
+
+@PreviewTest
+@Preview(showBackground = true, device = DS)
+@Composable
+fun ChargeTimeNotEnough() = ChargeTimeNotEnoughContent()

--- a/app/src/screenshotTest/kotlin/eu/darken/amply/screenshots/HubScreenshots.kt
+++ b/app/src/screenshotTest/kotlin/eu/darken/amply/screenshots/HubScreenshots.kt
@@ -1,0 +1,19 @@
+// Battery-hub screenshot entry points. Each @PreviewTest renders one hub fixture (from HubFixtures.kt
+// in app/src/debug) to a PNG under this class's own HubScreenshotsKt/ reference dir. These are
+// engineering regression shots — they are NOT part of the Play Store screenshot flow (see
+// PlayStoreScreenshots), whose generator counts only PlayStoreScreenshotsKt.
+package eu.darken.amply.screenshots
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+
+@PreviewTest
+@Preview(showBackground = true, device = DS)
+@Composable
+fun HubTileGrid() = HubTileGridContent()
+
+@PreviewTest
+@Preview(showBackground = true, device = DS)
+@Composable
+fun HubTileGridEmpty() = HubTileGridEmptyContent()

--- a/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
@@ -14,6 +14,7 @@ import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.common.compose.chart.SPARKLINE_TEST_TAG
 import eu.darken.amply.stats.core.ChargeCurvePoint
+import eu.darken.amply.stats.ui.ChargeTimeState
 import io.kotest.matchers.shouldBe
 import org.junit.Rule
 import org.junit.Test
@@ -68,12 +69,13 @@ class BatteryHubScreenTest {
     private fun render(
         readout: BatteryReadout?,
         curve: List<ChargeCurvePoint> = emptyList(),
+        captureEnabled: Boolean = true,
         onOpenMetric: (BatteryMetric) -> Unit = {},
     ) {
         compose.setContent {
             BatteryHubScreen(
                 readout = readout,
-                captureEnabled = true,
+                captureEnabled = captureEnabled,
                 teaser = ChargeTeaserState.None,
                 // Recording is on, so the badged opt-in card never renders — these cases are about
                 // the readout itself.
@@ -84,8 +86,25 @@ class BatteryHubScreenTest {
                 onOpenSession = {},
                 onOpenMetric = onOpenMetric,
                 curve = curve,
+                chargeTime = ChargeTimeState.NotEnoughData(sessions = 1),
             )
         }
+    }
+
+    @Test
+    fun `with recording off there is no charge-time card at all`() {
+        // The estimates come entirely from recorded history, so with nothing being recorded there is
+        // no card rather than an empty one.
+        render(charging, captureEnabled = false)
+        compose.onAllNodesWithText(string(R.string.charge_time_title)).assertCountEquals(0)
+        compose.onAllNodesWithText(string(R.string.charge_time_not_enough)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `with recording on the charge-time card is present`() {
+        render(charging)
+        compose.onNodeWithText(string(R.string.charge_time_title)).assertExists()
+        compose.onNodeWithText(string(R.string.charge_time_not_enough)).assertExists()
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
@@ -4,11 +4,17 @@ import android.app.Application
 import android.os.BatteryManager
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.common.compose.chart.SPARKLINE_TEST_TAG
+import eu.darken.amply.stats.core.ChargeCurvePoint
+import io.kotest.matchers.shouldBe
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -17,8 +23,8 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
 /**
- * The electrical section's two wattage rows. The tall qualifier renders the whole list, so a missing
- * row is a missing row rather than one scrolled out of the viewport.
+ * The hub's tile grid and the detail rows below it. The tall qualifier renders the whole list, so a
+ * missing row is a missing row rather than one scrolled out of the viewport.
  */
 @RunWith(RobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
@@ -47,27 +53,73 @@ class BatteryHubScreenTest {
         maxChargingVoltageMicrovolts = 9_000_000,
     )
 
-    private fun render(readout: BatteryReadout?) {
+    // Level and current vary; voltage is recorded but constant; power was never recorded at all.
+    private val curve = (0..8).map { i ->
+        ChargeCurvePoint(
+            elapsedFromStartMillis = i * 300_000L,
+            percent = 60 + i,
+            powerMilliwatts = null,
+            temperatureTenthsC = 300 + i,
+            voltageMillivolts = 4_000,
+            currentNowMicroamps = 2_000_000 - i * 100_000,
+        )
+    }
+
+    private fun render(
+        readout: BatteryReadout?,
+        curve: List<ChargeCurvePoint> = emptyList(),
+        onOpenMetric: (BatteryMetric) -> Unit = {},
+    ) {
         compose.setContent {
             BatteryHubScreen(
                 readout = readout,
                 captureEnabled = true,
                 teaser = ChargeTeaserState.None,
                 // Recording is on, so the badged opt-in card never renders — these cases are about
-                // the electrical section.
+                // the readout itself.
                 showProBadge = false,
                 onBack = {},
                 onOpenHistory = {},
                 onEnableCapture = {},
                 onOpenSession = {},
+                onOpenMetric = onOpenMetric,
+                curve = curve,
             )
         }
     }
 
     @Test
+    fun `all six tiles render`() {
+        render(charging)
+        listOf(
+            R.string.battery_metric_level_title,
+            R.string.battery_metric_power_title,
+            R.string.battery_metric_voltage_title,
+            R.string.battery_metric_current_title,
+            R.string.battery_metric_temperature_title,
+            R.string.battery_detail_status,
+        ).forEach { res ->
+            compose.onNodeWithText(string(res).uppercase()).assertExists()
+        }
+    }
+
+    @Test
+    fun `every pre-existing detail row survives the tile grid`() {
+        render(charging)
+        listOf(
+            R.string.battery_detail_power_source,
+            R.string.battery_detail_technology,
+            R.string.battery_detail_health,
+            R.string.battery_detail_cycle_count,
+            R.string.battery_detail_charger_max,
+            R.string.battery_detail_charge_counter,
+            // "Health" is both a section title and a row label, so match the first of either.
+        ).forEach { res -> compose.onAllNodesWithText(string(res)).onFirst().assertExists() }
+    }
+
+    @Test
     fun `the measured charge power and the advertised maximum are both shown`() {
         render(charging)
-        compose.onNodeWithText(string(R.string.battery_detail_power)).assertExists()
         // 4.0 V x 2.0 A measured at the battery...
         compose.onNodeWithText("8.0 W").assertExists()
         // ...against the 9 V / 2 A the charger claims it could deliver.
@@ -78,7 +130,7 @@ class BatteryHubScreenTest {
     @Test
     fun `a limit hold says the battery is not charging, not that nothing was reported`() {
         render(charging.copy(status = BatteryManager.BATTERY_STATUS_NOT_CHARGING))
-        // The status row spells this out as "Plugged in, not charging", so this is the power row.
+        // The status tile spells this out as "Plugged in, not charging", so this is the power tile.
         compose.onNodeWithText(string(R.string.battery_value_not_charging)).assertExists()
     }
 
@@ -112,7 +164,47 @@ class BatteryHubScreenTest {
     @Test
     fun `an unreadable battery never claims the battery is not charging`() {
         render(null)
-        compose.onNodeWithText(string(R.string.battery_detail_power)).assertExists()
+        compose.onNodeWithText(string(R.string.battery_metric_power_title).uppercase()).assertExists()
         compose.onAllNodesWithText(string(R.string.battery_value_not_charging)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `only the metrics with a drawable shape render a sparkline`() {
+        render(charging, curve)
+        // Level, current and temperature vary; voltage is flat and power has no samples at all.
+        // Unmerged: a tappable tile's card merges its descendants, which would hide the canvas.
+        compose.onAllNodesWithTag(SPARKLINE_TEST_TAG, useUnmergedTree = true).assertCountEquals(3)
+    }
+
+    @Test
+    fun `a metric with no variation is still tappable`() {
+        var opened: BatteryMetric? = null
+        render(charging, curve) { opened = it }
+        // Voltage is constant across the curve, so it draws nothing — but min == avg == max is still
+        // an answer, so the tile must open.
+        compose.onNodeWithText(string(R.string.battery_metric_voltage_title).uppercase()).performClick()
+        opened shouldBe BatteryMetric.VOLTAGE
+    }
+
+    @Test
+    fun `a metric with no samples at all is not tappable`() {
+        var opened: BatteryMetric? = null
+        render(charging, curve) { opened = it }
+        compose.onNodeWithText(string(R.string.battery_metric_power_title).uppercase()).performClick()
+        opened shouldBe null
+    }
+
+    @Test
+    fun `without a recorded curve no tile navigates anywhere`() {
+        var opened: BatteryMetric? = null
+        render(charging) { opened = it }
+        listOf(
+            R.string.battery_metric_level_title,
+            R.string.battery_metric_temperature_title,
+        ).forEach { res ->
+            compose.onNodeWithText(string(res).uppercase()).performClick()
+        }
+        opened shouldBe null
+        compose.onAllNodesWithTag(SPARKLINE_TEST_TAG, useUnmergedTree = true).assertCountEquals(0)
     }
 }

--- a/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
@@ -2,6 +2,7 @@ package eu.darken.amply.main.ui.battery
 
 import android.app.Application
 import android.os.BatteryManager
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -9,6 +10,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
@@ -170,6 +172,22 @@ class BatteryHubScreenTest {
         // Nothing is connected, so the advertised maximum is the screen's only "Not reported" — the
         // extras are not read through while off the charger even when the platform left them set.
         compose.onNodeWithText(string(R.string.battery_value_not_reported)).assertExists()
+    }
+
+    @Test
+    @Config(qualifiers = "+w411dp")
+    fun `the longest status value renders whole at phone width`() {
+        // The reported case: on a Pixel 7a the status tile clipped this to "Plugged in, n…". The
+        // width qualifier is the geometry under test — half of a 411dp screen, minus the tile's own
+        // padding — so a regression to a single fixed-height line fails here rather than on a device.
+        render(charging.copy(status = BatteryManager.BATTERY_STATUS_NOT_CHARGING))
+        val status = string(R.string.battery_status_plugged_not_charging)
+        val node = compose.onNodeWithText(status).fetchSemanticsNode()
+        val layouts = mutableListOf<TextLayoutResult>()
+        node.config[SemanticsActions.GetTextLayoutResult].action?.invoke(layouts)
+        val layout = layouts.single()
+        layout.layoutInput.text.text shouldBe status
+        layout.hasVisualOverflow shouldBe false
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
@@ -14,6 +14,7 @@ import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.common.compose.chart.SPARKLINE_TEST_TAG
 import eu.darken.amply.stats.core.ChargeCurvePoint
+import eu.darken.amply.stats.core.CurveMetricAvailability
 import eu.darken.amply.stats.ui.ChargeTimeState
 import io.kotest.matchers.shouldBe
 import org.junit.Rule
@@ -69,6 +70,8 @@ class BatteryHubScreenTest {
     private fun render(
         readout: BatteryReadout?,
         curve: List<ChargeCurvePoint> = emptyList(),
+        // Defaults to what the drawn curve holds; a case that needs them to disagree passes its own.
+        availability: CurveMetricAvailability = CurveMetricAvailability.of(curve),
         captureEnabled: Boolean = true,
         onOpenMetric: (BatteryMetric) -> Unit = {},
     ) {
@@ -86,6 +89,7 @@ class BatteryHubScreenTest {
                 onOpenSession = {},
                 onOpenMetric = onOpenMetric,
                 curve = curve,
+                availability = availability,
                 chargeTime = ChargeTimeState.NotEnoughData(sessions = 1),
             )
         }
@@ -211,6 +215,21 @@ class BatteryHubScreenTest {
         render(charging, curve) { opened = it }
         compose.onNodeWithText(string(R.string.battery_metric_power_title).uppercase()).performClick()
         opened shouldBe null
+    }
+
+    @Test
+    fun `a metric the decimated curve dropped is still tappable`() {
+        // The drawn curve is decimated, so an intermittently reported metric can lose every one of
+        // its readings to the stride. Availability is taken from the raw samples, and it is what
+        // decides the tap — the detail screen reads those same raw samples.
+        var opened: BatteryMetric? = null
+        render(
+            charging,
+            curve,
+            availability = CurveMetricAvailability.of(curve).copy(power = true),
+        ) { opened = it }
+        compose.onNodeWithText(string(R.string.battery_metric_power_title).uppercase()).performClick()
+        opened shouldBe BatteryMetric.POWER
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.text.TextLayoutResult
@@ -155,8 +156,34 @@ class BatteryHubScreenTest {
     @Test
     fun `a limit hold says the battery is not charging, not that nothing was reported`() {
         render(charging.copy(status = BatteryManager.BATTERY_STATUS_NOT_CHARGING))
-        // The status tile spells this out as "Plugged in, not charging", so this is the power tile.
-        compose.onNodeWithText(string(R.string.battery_value_not_charging)).assertExists()
+        // The tile is half a screen wide, so the words become a dash — but only for the state the
+        // battery positively reported. What this case exists to prove is that the two stay
+        // distinguishable: every other reading here is present, so "Not reported" (a device that
+        // exposes no figure, which the dash must never stand in for) is nowhere on the screen.
+        compose.onNodeWithText(string(R.string.battery_value_none)).assertExists()
+        compose.onAllNodesWithText(string(R.string.battery_value_not_reported)).assertCountEquals(0)
+        // The status tile still spells it out as "Plugged in, not charging"; the bare words do not
+        // appear, because the tile that would have carried them now shows the dash.
+        compose.onAllNodesWithText(string(R.string.battery_value_not_charging)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `a charging battery that reports no current still says not reported, never a dash`() {
+        // The figure is missing, not zero: the device is taking charge and simply exposes no
+        // current. Collapsing that into the dash would claim an observation nothing made.
+        render(charging.copy(currentNowMicroamps = null))
+        compose.onAllNodesWithText(string(R.string.battery_value_none)).assertCountEquals(0)
+        // Two tiles are affected — charge power, which is derived from the current, and current
+        // itself.
+        compose.onAllNodesWithText(string(R.string.battery_value_not_reported)).assertCountEquals(2)
+    }
+
+    @Test
+    fun `the dash announces the state it replaces`() {
+        render(charging.copy(status = BatteryManager.BATTERY_STATUS_NOT_CHARGING))
+        // A dash is a meaningless glyph to a screen reader, so the tile speaks the words the width
+        // did not allow.
+        compose.onNodeWithContentDescription(string(R.string.battery_value_not_charging)).assertExists()
     }
 
     @Test
@@ -168,9 +195,12 @@ class BatteryHubScreenTest {
                 currentNowMicroamps = -500_000,
             ),
         )
-        compose.onNodeWithText(string(R.string.battery_value_not_charging)).assertExists()
+        // Off the charger there is no charge power to state, which the tile shows as a dash.
+        compose.onNodeWithText(string(R.string.battery_value_none)).assertExists()
+        compose.onAllNodesWithText(string(R.string.battery_value_not_charging)).assertCountEquals(0)
         // Nothing is connected, so the advertised maximum is the screen's only "Not reported" — the
         // extras are not read through while off the charger even when the platform left them set.
+        // The single match also proves the dash did not displace it onto the power tile.
         compose.onNodeWithText(string(R.string.battery_value_not_reported)).assertExists()
     }
 

--- a/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -149,8 +148,14 @@ class BatteryHubScreenTest {
             R.string.battery_detail_cycle_count,
             R.string.battery_detail_charger_max,
             R.string.battery_detail_charge_counter,
-            // "Health" is both a section title and a row label, so match the first of either.
-        ).forEach { res -> compose.onAllNodesWithText(string(res)).onFirst().assertExists() }
+        ).forEach { res -> compose.onNodeWithText(string(res)).assertExists() }
+    }
+
+    @Test
+    fun `the detail rows are grouped into a battery and a charger section`() {
+        render(charging)
+        compose.onNodeWithText(string(R.string.battery_detail_section_battery)).assertExists()
+        compose.onNodeWithText(string(R.string.battery_detail_section_charger)).assertExists()
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryHubScreenTest.kt
@@ -2,6 +2,8 @@ package eu.darken.amply.main.ui.battery
 
 import android.app.Application
 import android.os.BatteryManager
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -12,6 +14,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.Density
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
@@ -76,25 +79,32 @@ class BatteryHubScreenTest {
         // Defaults to what the drawn curve holds; a case that needs them to disagree passes its own.
         availability: CurveMetricAvailability = CurveMetricAvailability.of(curve),
         captureEnabled: Boolean = true,
+        // The accessibility font scale to render at; the platform's own scale is unaffected by the
+        // qualifiers, so a large-font case has to provide it.
+        fontScale: Float = 1f,
         onOpenMetric: (BatteryMetric) -> Unit = {},
     ) {
         compose.setContent {
-            BatteryHubScreen(
-                readout = readout,
-                captureEnabled = captureEnabled,
-                teaser = ChargeTeaserState.None,
-                // Recording is on, so the badged opt-in card never renders — these cases are about
-                // the readout itself.
-                showProBadge = false,
-                onBack = {},
-                onOpenHistory = {},
-                onEnableCapture = {},
-                onOpenSession = {},
-                onOpenMetric = onOpenMetric,
-                curve = curve,
-                availability = availability,
-                chargeTime = ChargeTimeState.NotEnoughData(sessions = 1),
-            )
+            CompositionLocalProvider(
+                LocalDensity provides Density(LocalDensity.current.density, fontScale),
+            ) {
+                BatteryHubScreen(
+                    readout = readout,
+                    captureEnabled = captureEnabled,
+                    teaser = ChargeTeaserState.None,
+                    // Recording is on, so the badged opt-in card never renders — these cases are about
+                    // the readout itself.
+                    showProBadge = false,
+                    onBack = {},
+                    onOpenHistory = {},
+                    onEnableCapture = {},
+                    onOpenSession = {},
+                    onOpenMetric = onOpenMetric,
+                    curve = curve,
+                    availability = availability,
+                    chargeTime = ChargeTimeState.NotEnoughData(sessions = 1),
+                )
+            }
         }
     }
 
@@ -204,6 +214,20 @@ class BatteryHubScreenTest {
         compose.onNodeWithText(string(R.string.battery_value_not_reported)).assertExists()
     }
 
+    /**
+     * The status tile's laid-out value. Semantics carry the full string even when it is visually
+     * truncated, so only the layout result can tell a whole rendering from a clipped one.
+     */
+    private fun statusValueLayout(): TextLayoutResult {
+        val status = string(R.string.battery_status_plugged_not_charging)
+        val node = compose.onNodeWithText(status).fetchSemanticsNode()
+        val layouts = mutableListOf<TextLayoutResult>()
+        node.config[SemanticsActions.GetTextLayoutResult].action?.invoke(layouts)
+        val layout = layouts.single()
+        layout.layoutInput.text.text shouldBe status
+        return layout
+    }
+
     @Test
     @Config(qualifiers = "+w411dp")
     fun `the longest status value renders whole at phone width`() {
@@ -211,13 +235,18 @@ class BatteryHubScreenTest {
         // width qualifier is the geometry under test — half of a 411dp screen, minus the tile's own
         // padding — so a regression to a single fixed-height line fails here rather than on a device.
         render(charging.copy(status = BatteryManager.BATTERY_STATUS_NOT_CHARGING))
-        val status = string(R.string.battery_status_plugged_not_charging)
-        val node = compose.onNodeWithText(status).fetchSemanticsNode()
-        val layouts = mutableListOf<TextLayoutResult>()
-        node.config[SemanticsActions.GetTextLayoutResult].action?.invoke(layouts)
-        val layout = layouts.single()
-        layout.layoutInput.text.text shouldBe status
-        layout.hasVisualOverflow shouldBe false
+        statusValueLayout().hasVisualOverflow shouldBe false
+    }
+
+    @Test
+    @Config(qualifiers = "+w411dp")
+    fun `the longest status value renders whole at twice the font scale`() {
+        // The same tile at the largest accessibility font scale, where the wrap alone is not enough:
+        // two lines of this style hold 22 of the 24 characters, which is what the third line is for.
+        // Nothing here changes the normal-scale rendering — the value box is a minimum height, so an
+        // unneeded line is never drawn.
+        render(charging.copy(status = BatteryManager.BATTERY_STATUS_NOT_CHARGING), fontScale = 2f)
+        statusValueLayout().hasVisualOverflow shouldBe false
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryMetricDetailScreenTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/battery/BatteryMetricDetailScreenTest.kt
@@ -1,0 +1,125 @@
+package eu.darken.amply.main.ui.battery
+
+import android.app.Application
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.R
+import eu.darken.amply.stats.core.ChargeCurvePoint
+import eu.darken.amply.stats.core.MetricStats
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The per-metric detail screen. The statistics row is the load-bearing part: it renders the values
+ * the repository computed from the raw samples, never anything re-derived from the plotted curve.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "+h2400dp")
+class BatteryMetricDetailScreenTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    private fun string(res: Int): String = context.getString(res)
+
+    private val curve = (0..8).map { i ->
+        ChargeCurvePoint(
+            elapsedFromStartMillis = i * 300_000L,
+            percent = 60 + i * 2,
+            powerMilliwatts = 12_000 - i * 500,
+            temperatureTenthsC = 300 + i,
+            voltageMillivolts = 4_000 + i * 10,
+            currentNowMicroamps = 2_000_000 - i * 100_000,
+        )
+    }
+
+    private fun render(state: BatteryMetricDetailState?) {
+        compose.setContent { BatteryMetricDetailScreen(state = state, onBack = {}) }
+    }
+
+    @Test
+    fun `the title, the latest value and the statistics all render`() {
+        render(
+            BatteryMetricDetailState(
+                metric = BatteryMetric.LEVEL,
+                sessionMissing = false,
+                curve = curve,
+                // Deliberately wider than the plotted curve: these come from the raw samples, and a
+                // screen that recomputed them from the curve would print 60/68/76 instead.
+                stats = MetricStats(min = 41, avg = 68, max = 93, sampleCount = 120),
+            ),
+        )
+        compose.onAllNodesWithText(string(R.string.battery_metric_level_title)).onFirst().assertExists()
+        // The last recorded point of the curve, as the headline.
+        compose.onNodeWithText("76%").assertExists()
+        compose.onNodeWithText("41%").assertExists()
+        compose.onNodeWithText("68%").assertExists()
+        compose.onNodeWithText("93%").assertExists()
+        compose.onNodeWithText(string(R.string.battery_metric_min).uppercase()).assertExists()
+        compose.onNodeWithText(string(R.string.battery_metric_max).uppercase()).assertExists()
+    }
+
+    @Test
+    fun `temperature renders in its own unit`() {
+        render(
+            BatteryMetricDetailState(
+                metric = BatteryMetric.TEMPERATURE,
+                sessionMissing = false,
+                curve = curve,
+                stats = MetricStats(min = 298, avg = 305, max = 331, sampleCount = 120),
+            ),
+        )
+        compose.onNodeWithText("29.8 °C").assertExists()
+        compose.onNodeWithText("33.1 °C").assertExists()
+    }
+
+    @Test
+    fun `an empty curve shows the chart's own empty label and no statistics`() {
+        render(
+            BatteryMetricDetailState(
+                metric = BatteryMetric.POWER,
+                sessionMissing = false,
+                curve = emptyList(),
+                stats = null,
+            ),
+        )
+        compose.onNodeWithText(string(R.string.stats_curve_empty)).assertExists()
+        // Absent statistics hide the row rather than printing zeros.
+        compose.onAllNodesWithText(string(R.string.battery_metric_avg).uppercase())
+            .assertCountEquals(0)
+        // The explainer is still there — it does not depend on any recorded data.
+        compose.onNodeWithText(string(R.string.battery_metric_power_explainer)).assertExists()
+    }
+
+    @Test
+    fun `a session that no longer resolves shows the missing notice`() {
+        render(
+            BatteryMetricDetailState(
+                metric = BatteryMetric.LEVEL,
+                sessionMissing = true,
+                curve = emptyList(),
+                stats = null,
+            ),
+        )
+        compose.onNodeWithText(string(R.string.stats_detail_missing)).assertExists()
+        compose.onAllNodesWithText(string(R.string.battery_metric_level_explainer))
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `an unresolved selection shows a spinner, not an empty screen`() {
+        render(null)
+        compose.onAllNodesWithText(string(R.string.stats_detail_missing)).assertCountEquals(0)
+        compose.onAllNodesWithText(string(R.string.stats_curve_empty)).assertCountEquals(0)
+    }
+}

--- a/app/src/test/java/eu/darken/amply/main/ui/battery/ChargeTimeCardTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/battery/ChargeTimeCardTest.kt
@@ -1,0 +1,174 @@
+package eu.darken.amply.main.ui.battery
+
+import android.app.Application
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.R
+import eu.darken.amply.stats.core.ChargeBandSplit
+import eu.darken.amply.stats.core.ChargeTimeBasis
+import eu.darken.amply.stats.core.ChargeTimeEstimate
+import eu.darken.amply.stats.ui.ChargeTimeState
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * The card's honesty rules: a countdown is only ever shown while the battery is actually taking
+ * charge, an absent target is stated rather than filled in, and our own outage stays distinguishable
+ * from an empty history.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "+h2400dp")
+class ChargeTimeCardTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Application>()
+
+    // Formatting overload only where there are arguments: several of these strings carry a literal
+    // "%" and are declared formatted="false", so formatting them would throw.
+    private fun string(res: Int, vararg args: Any): String =
+        if (args.isEmpty()) context.getString(res) else context.getString(res, *args)
+
+    private val estimate = ChargeTimeEstimate(
+        toEightyMillis = 2_040_000,
+        toFullMillis = 4_740_000,
+        avgSpeedMilliwatts = 11_500,
+        split = ChargeBandSplit(
+            toFiftyMillis = 2_700_000,
+            fiftyToEightyMillis = 1_800_000,
+            eightyToHundredMillis = 3_600_000,
+        ),
+        basedOnSessions = 6,
+    )
+
+    private fun ready(
+        estimate: ChargeTimeEstimate = this.estimate,
+        charging: Boolean = true,
+        percent: Int? = 42,
+        basis: ChargeTimeBasis = ChargeTimeBasis.SAME_TYPE,
+    ) = ChargeTimeState.Ready(estimate = estimate, basis = basis, charging = charging, currentPercent = percent)
+
+    private fun render(state: ChargeTimeState) {
+        compose.setContent { ChargeTimeCard(state = state) }
+    }
+
+    @Test
+    fun `while charging the headline counts down to full`() {
+        render(ready())
+        compose.onNodeWithText(string(R.string.charge_time_headline_full_countdown, "1h 19m")).assertExists()
+        compose.onNodeWithText("34m").assertExists()
+        compose.onNodeWithText("11.5 W").assertExists()
+    }
+
+    @Test
+    fun `unplugged the same figures are a reference, not a countdown`() {
+        render(ready(charging = false))
+        compose.onNodeWithText(string(R.string.charge_time_headline_full_reference, "1h 19m")).assertExists()
+        compose.onAllNodesWithText(string(R.string.charge_time_headline_full_countdown, "1h 19m"))
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `held at a limit it reads as a reference too`() {
+        // The session is live and the device is on a charger, but the platform reports NOT_CHARGING,
+        // so nothing is moving toward the target and a countdown would be a false claim.
+        render(ready(charging = false, percent = 80))
+        compose.onNodeWithText(string(R.string.charge_time_headline_full_reference, "1h 19m")).assertExists()
+    }
+
+    @Test
+    fun `an absent full target is stated, never rendered as a number`() {
+        render(ready(estimate = estimate.copy(toFullMillis = null)))
+        // The headline falls back to the target that does exist...
+        compose.onNodeWithText(string(R.string.charge_time_headline_eighty_countdown, "34m")).assertExists()
+        // ...and the missing cell says so rather than showing 0m.
+        compose.onNodeWithText(string(R.string.charge_time_value_missing)).assertExists()
+    }
+
+    @Test
+    fun `above eighty percent the To 80 cell is dropped rather than reading zero`() {
+        render(ready(percent = 86, estimate = estimate.copy(toEightyMillis = null)))
+        compose.onAllNodesWithText(string(R.string.charge_time_to_eighty).uppercase()).assertCountEquals(0)
+        compose.onNodeWithText(string(R.string.charge_time_to_full).uppercase()).assertExists()
+    }
+
+    @Test
+    fun `the trickle note appears when the last stretch dominates`() {
+        render(ready())
+        compose.onNodeWithText(string(R.string.charge_time_trickle_note)).assertExists()
+    }
+
+    @Test
+    fun `the trickle note stays away from an unremarkable taper`() {
+        // The note explains a slowdown, so it must not appear where there isn't one.
+        render(
+            ready(
+                estimate = estimate.copy(
+                    split = ChargeBandSplit(
+                        toFiftyMillis = 2_700_000,
+                        fiftyToEightyMillis = 1_800_000,
+                        eightyToHundredMillis = 1_800_000,
+                    ),
+                ),
+            ),
+        )
+        compose.onAllNodesWithText(string(R.string.charge_time_trickle_note)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `only the segments with data are drawn`() {
+        render(
+            ready(
+                estimate = estimate.copy(
+                    split = ChargeBandSplit(fiftyToEightyMillis = 1_800_000, eightyToHundredMillis = 3_600_000),
+                ),
+            ),
+        )
+        compose.onNodeWithText(string(R.string.charge_time_split_fifty_eighty)).assertExists()
+        compose.onAllNodesWithText(string(R.string.charge_time_split_to_fifty)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the provenance line names the session count for this charger type`() {
+        render(ready())
+        compose.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.charge_time_provenance_same_type, 6, 6),
+        ).assertExists()
+    }
+
+    @Test
+    fun `a pooled projection says it is pooled`() {
+        render(ready(basis = ChargeTimeBasis.POOLED))
+        compose.onNodeWithText(
+            context.resources.getQuantityString(R.plurals.charge_time_provenance_pooled, 6, 6),
+        ).assertExists()
+    }
+
+    @Test
+    fun `not enough data is a statement about the user's history`() {
+        render(ChargeTimeState.NotEnoughData(sessions = 1))
+        compose.onNodeWithText(string(R.string.charge_time_not_enough)).assertExists()
+    }
+
+    @Test
+    fun `an outage is never presented as an empty history`() {
+        render(ChargeTimeState.Unavailable)
+        compose.onNodeWithText(string(R.string.charge_time_unavailable)).assertExists()
+        compose.onAllNodesWithText(string(R.string.charge_time_not_enough)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `loading shows neither an estimate nor the empty copy`() {
+        render(ChargeTimeState.Loading)
+        compose.onNodeWithText(string(R.string.charge_time_loading)).assertExists()
+        compose.onAllNodesWithText(string(R.string.charge_time_not_enough)).assertCountEquals(0)
+    }
+}

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/ChargingCardTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/ChargingCardTest.kt
@@ -2,7 +2,9 @@ package eu.darken.amply.main.ui.dashboard
 
 import android.app.Application
 import android.os.BatteryManager
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -10,10 +12,14 @@ import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.stats.core.ChargeBandSplit
 import eu.darken.amply.stats.core.ChargeCurvePoint
 import eu.darken.amply.stats.core.ChargeSessionSummary
+import eu.darken.amply.stats.core.ChargeTimeBasis
+import eu.darken.amply.stats.core.ChargeTimeEstimate
 import eu.darken.amply.stats.core.ChargingType
 import eu.darken.amply.stats.core.StatsLiveSession
+import eu.darken.amply.stats.ui.ChargeTimeState
 import io.kotest.matchers.shouldBe
 import org.junit.Rule
 import org.junit.Test
@@ -93,12 +99,31 @@ class ChargingCardTest {
         )
     }
 
+    private val chargeTimeEstimate = ChargeTimeEstimate(
+        toEightyMillis = 600_000,
+        toFullMillis = 4_740_000,
+        avgSpeedMilliwatts = 11_500,
+        split = ChargeBandSplit(),
+        basedOnSessions = 4,
+    )
+
+    private fun chargeTimeReady(
+        charging: Boolean = true,
+        estimate: ChargeTimeEstimate = chargeTimeEstimate,
+    ) = ChargeTimeState.Ready(
+        estimate = estimate,
+        basis = ChargeTimeBasis.SAME_TYPE,
+        charging = charging,
+        currentPercent = 78,
+    )
+
     private fun render(
         presentation: ChargingCardPresentation,
         readout: BatteryReadout? = charging,
         onOpenHub: () -> Unit = {},
         onRetryCapture: () -> Unit = {},
         nowElapsedRealtimeMillis: Long = 4_320_000L,
+        chargeTime: ChargeTimeState = ChargeTimeState.Loading,
     ) {
         compose.setContent {
             ChargingCard(
@@ -107,6 +132,7 @@ class ChargingCardTest {
                 onOpenHub = onOpenHub,
                 onRetryCapture = onRetryCapture,
                 nowElapsedRealtimeMillis = nowElapsedRealtimeMillis,
+                chargeTime = chargeTime,
             )
         }
     }
@@ -416,6 +442,47 @@ class ChargingCardTest {
         compose.mainClock.advanceTimeBy(61_000)
 
         compose.onNodeWithText("1m").assertExists()
+    }
+
+    @Test
+    fun `a live charge carries the remaining-time line`() {
+        render(ChargingCardPresentation.Live(session = liveSession), chargeTime = chargeTimeReady())
+        compose.onNodeWithText(string(R.string.charge_time_headline_full_countdown, "1h 19m")).assertExists()
+    }
+
+    @Test
+    fun `the remaining-time line is absent while the battery is not taking charge`() {
+        // Held at a limit: the session is live and the device is connected, but nothing is moving
+        // toward the target, so a countdown would be a false claim.
+        render(
+            ChargingCardPresentation.Live(session = liveSession),
+            readout = holding,
+            chargeTime = chargeTimeReady(charging = false),
+        )
+        compose.onAllNodesWithText(string(R.string.charge_time_headline_full_countdown, "1h 19m"))
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `no target means no line rather than an empty one`() {
+        render(
+            ChargingCardPresentation.Live(session = liveSession),
+            chargeTime = chargeTimeReady(
+                estimate = chargeTimeEstimate.copy(toEightyMillis = null, toFullMillis = null),
+            ),
+        )
+        compose.onAllNodesWithText(string(R.string.charge_time_value_missing)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `an idle card never carries a remaining-time line`() {
+        render(
+            ChargingCardPresentation.Idle(lastSession = lastSession, sessionCount = 3),
+            readout = unplugged,
+            chargeTime = chargeTimeReady(charging = false),
+        )
+        compose.onAllNodesWithText(string(R.string.charge_time_headline_full_countdown, "1h 19m"))
+            .assertCountEquals(0)
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/stats/core/ChargeBandExtractorTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/ChargeBandExtractorTest.kt
@@ -1,0 +1,153 @@
+package eu.darken.amply.stats.core
+
+import android.os.BatteryManager
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class ChargeBandExtractorTest {
+
+    private val charging = BatteryManager.BATTERY_STATUS_CHARGING
+    private val notCharging = BatteryManager.BATTERY_STATUS_NOT_CHARGING
+
+    private fun sample(elapsed: Long, percent: Int?, status: Int? = charging) =
+        ChargeStepSample(elapsedMillis = elapsed, percent = percent, batteryStatus = status)
+
+    private fun extract(samples: List<ChargeStepSample>, sessionId: Long = 1L) =
+        ChargeBandExtractor.extract(sessionId, ChargingType.AC, samples)
+
+    /** A clean climb at [stepMillis] per percent, from [from] up to (and including) [to]. */
+    private fun climb(from: Int, to: Int, stepMillis: Long = 60_000L, start: Long = 0L) =
+        (0..(to - from)).map { i -> sample(start + i * stepMillis, from + i) }
+
+    @Test
+    fun `only completed steps count, and the session's first one is discarded`() {
+        // 40 → 43 gives three transitions, but the 40 → 41 step began before recording did, and 43
+        // is never completed because nothing observed 44.
+        val observations = extract(climb(40, 43))
+        observations.map { it.percentFrom } shouldBe listOf(41, 42)
+        observations.map { it.millis } shouldBe listOf(60_000L, 60_000L)
+        observations.first().sessionId shouldBe 1L
+        observations.first().chargingType shouldBe ChargingType.AC
+    }
+
+    @Test
+    fun `a step spanning a non-charging sample is discarded`() {
+        val observations = extract(
+            listOf(
+                sample(0, 60),
+                sample(60_000, 61),
+                // The 61 → 62 step contains a hold, so it describes a pause and not a charge rate.
+                sample(90_000, 61, status = notCharging),
+                sample(120_000, 62),
+                sample(180_000, 63),
+            ),
+        )
+        observations.map { it.percentFrom } shouldBe listOf(62)
+    }
+
+    @Test
+    fun `a plateau at an OEM limit contributes nothing`() {
+        // Recording continues for an hour at 80% and the level never leaves it, so the 80 → 81 step
+        // is never completed and no rate is learned from the hold.
+        val samples = climb(78, 80) + (1..12).map { i -> sample(120_000 + i * 300_000L, 80, notCharging) }
+        extract(samples).map { it.percentFrom } shouldBe listOf(79)
+    }
+
+    @Test
+    fun `sub-minimum and over-maximum steps are discarded`() {
+        val tooFast = extract(
+            listOf(sample(0, 50), sample(60_000, 51), sample(61_000, 52), sample(121_000, 53)),
+        )
+        // The 51 → 52 step took a second, which no charger does; 52 → 53 is normal.
+        tooFast.map { it.percentFrom } shouldBe listOf(52)
+
+        val tooSlow = extract(
+            listOf(sample(0, 50), sample(60_000, 51), sample(4_000_000, 52), sample(4_060_000, 53)),
+        )
+        tooSlow.map { it.percentFrom } shouldBe listOf(52)
+    }
+
+    @Test
+    fun `a null percent breaks the run`() {
+        val observations = extract(
+            listOf(
+                sample(0, 70),
+                sample(60_000, 71),
+                sample(120_000, null),
+                sample(180_000, 72),
+                sample(240_000, 73),
+                sample(300_000, 74),
+            ),
+        )
+        // Neither 71 → 72 nor 72 → 73 is credited: across the unreadable sample the level could have
+        // moved unseen, so the first step after the break has the same problem as a session's first.
+        // 73 → 74 counts, because both its ends were observed.
+        observations.map { it.percentFrom } shouldBe listOf(73)
+    }
+
+    @Test
+    fun `a multi-percent jump breaks the run`() {
+        val observations = extract(
+            listOf(
+                sample(0, 20),
+                sample(60_000, 21),
+                sample(120_000, 25),
+                sample(180_000, 26),
+                sample(240_000, 27),
+            ),
+        )
+        observations.map { it.percentFrom } shouldBe listOf(26)
+    }
+
+    @Test
+    fun `time running backwards breaks the run but not the rest of the session`() {
+        val observations = extract(
+            listOf(
+                sample(0, 30),
+                sample(60_000, 31),
+                // A new clock base: everything before it is incomparable, but what follows is fine.
+                sample(10_000, 32),
+                sample(70_000, 33),
+                sample(130_000, 34),
+                sample(190_000, 35),
+            ),
+        )
+        observations.map { it.percentFrom } shouldBe listOf(34)
+    }
+
+    @Test
+    fun `a level wobble contributes one observation, not two`() {
+        val observations = extract(
+            listOf(
+                sample(0, 79),
+                sample(60_000, 80),
+                sample(120_000, 79),
+                sample(180_000, 80),
+                sample(240_000, 81),
+                sample(300_000, 82),
+            ),
+        )
+        observations.map { it.percentFrom } shouldBe listOf(80, 81)
+        observations.count { it.percentFrom == 80 } shouldBe 1
+    }
+
+    @Test
+    fun `an empty or single-sample session yields nothing`() {
+        extract(emptyList()).shouldBeEmpty()
+        extract(listOf(sample(0, 50))).shouldBeEmpty()
+    }
+
+    @Test
+    fun `each observation carries the durations it actually measured`() {
+        val observations = extract(
+            listOf(
+                sample(0, 10),
+                sample(30_000, 11),
+                sample(75_000, 12),
+                sample(200_000, 13),
+            ),
+        )
+        observations.map { it.percentFrom to it.millis } shouldBe listOf(11 to 45_000L, 12 to 125_000L)
+    }
+}

--- a/app/src/test/java/eu/darken/amply/stats/core/ChargeStatsRepositoryLiveTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/ChargeStatsRepositoryLiveTest.kt
@@ -273,10 +273,42 @@ class ChargeStatsRepositoryLiveTest {
             dao.insertSample(sample(sessionId, elapsed = i * 60_000L, percent = 40 + i))
         }
 
-        val batch = repository.bandObservations()
+        val batch = repository.bandObservations(cutoffWallMillis = 0L)
         batch.observations.map { it.percentFrom } shouldBe listOf(41, 42, 43)
         batch.observations.map { it.chargingType }.distinct() shouldBe listOf(ChargingType.AC)
         batch.sessionPowerMilliwatts shouldBe mapOf(sessionId to 11_000)
+    }
+
+    @Test
+    fun `a session keeps its id while its early samples expire, so the cutoff applies to samples`() = runTest {
+        // Retention drops sessions by their end stamp but samples by their own, so a charge that sat
+        // at an OEM limit for days and ended recently survives with only its later samples. The fold
+        // must describe what is left, not what the row still implies.
+        val dao = database.statsDao()
+        val sessionId = dao.insertSession(
+            ChargeSessionEntity(
+                startedAtWallMillis = 0L,
+                startedElapsedRealtimeMillis = 0L,
+                endedAtWallMillis = 500_000L,
+                endedElapsedRealtimeMillis = 500_000L,
+                bootId = 7,
+                startPercent = 40,
+                endPercent = 45,
+                pluggedRaw = 1,
+                avgPowerMilliwatts = 11_000,
+            ),
+        )
+        (0..5).forEach { i ->
+            dao.insertSample(sample(sessionId, elapsed = i * 60_000L, percent = 40 + i))
+        }
+
+        // Everything before minute three is outside the window: the surviving samples are 43, 44 and
+        // 45, whose first step is dropped as unobserved like any other run start.
+        val batch = repository.bandObservations(cutoffWallMillis = 3 * 60_000L)
+        batch.observations.map { it.percentFrom } shouldBe listOf(44)
+        // The whole session is still there without the cutoff.
+        repository.bandObservations(cutoffWallMillis = 0L)
+            .observations.map { it.percentFrom } shouldBe listOf(41, 42, 43, 44)
     }
 
     private suspend fun awaitEmission(channel: Channel<List<Int?>>, expected: List<Int?>) {

--- a/app/src/test/java/eu/darken/amply/stats/core/ChargeStatsRepositoryLiveTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/ChargeStatsRepositoryLiveTest.kt
@@ -200,6 +200,10 @@ class ChargeStatsRepositoryLiveTest {
         val live = repository.currentSession().first()!!
         live.curve.map { it.voltageMillivolts } shouldBe listOf(4_000)
         live.curve.map { it.currentNowMicroamps } shouldBe listOf(2_000_000)
+        // ...and the live session states what it recorded, taken from the raw window.
+        live.availability.voltage shouldBe true
+        live.availability.current shouldBe true
+        live.availability.power shouldBe true
     }
 
     @Test
@@ -218,6 +222,25 @@ class ChargeStatsRepositoryLiveTest {
         metrics.aggregates.temperature!!.max shouldBe 480
         metrics.aggregates.level!!.min shouldBe 40
         metrics.aggregates.current!!.sampleCount shouldBe 3
+    }
+
+    @Test
+    fun `the recent curve reports a metric decimation dropped`() = runTest {
+        // Voltage is reported on the middle sample only. Decimating to two points keeps the pinned
+        // endpoints, so the drawn curve holds no voltage at all — but the session recorded one, and
+        // the hub's tile must stay tappable on that fact rather than on the survivors.
+        val id = insertOpenSession()
+        val dao = database.statsDao()
+        dao.insertSample(sample(id, elapsed = 1_000L, percent = 40, voltageMillivolts = null))
+        dao.insertSample(sample(id, elapsed = 2_000L, percent = 41, voltageMillivolts = 4_100))
+        dao.insertSample(sample(id, elapsed = 3_000L, percent = 42, voltageMillivolts = null))
+
+        val recent = repository.recentCurveFlow(id, maxPoints = 2).first()
+        recent.curve.size shouldBe 2
+        recent.curve.mapNotNull { it.voltageMillivolts } shouldBe emptyList()
+        recent.availability.voltage shouldBe true
+        recent.availability.level shouldBe true
+        recent.availability.temperature shouldBe true
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/stats/core/ChargeStatsRepositoryLiveTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/ChargeStatsRepositoryLiveTest.kt
@@ -104,6 +104,9 @@ class ChargeStatsRepositoryLiveTest {
         elapsed: Long,
         percent: Int,
         batteryStatus: Int? = BatteryManager.BATTERY_STATUS_CHARGING,
+        voltageMillivolts: Int? = 4_000,
+        currentNowMicroamps: Int? = 2_000_000,
+        temperatureTenthsC: Int? = 300,
     ) = BatterySampleEntity(
         sessionId = sessionId,
         wallMillis = elapsed,
@@ -112,7 +115,9 @@ class ChargeStatsRepositoryLiveTest {
         percent = percent,
         batteryStatus = batteryStatus,
         powerMilliwatts = 9_000,
-        temperatureTenthsC = 300,
+        temperatureTenthsC = temperatureTenthsC,
+        voltageMillivolts = voltageMillivolts,
+        currentNowMicroamps = currentNowMicroamps,
     )
 
     @Test
@@ -154,6 +159,63 @@ class ChargeStatsRepositoryLiveTest {
         curve.map { it.percent } shouldBe listOf(40, 41, 42)
         // Only the charging sample keeps its power; the other two report none rather than a wrong one.
         curve.map { it.powerMilliwatts } shouldBe listOf(9_000, null, null)
+    }
+
+    @Test
+    fun `voltage and current survive a sample that was not charging`() = runTest {
+        // Unlike power these are directional raw readings, valid in either direction, so the
+        // charging gate that withholds power must not touch them.
+        val id = insertOpenSession()
+        val dao = database.statsDao()
+        dao.insertSample(sample(id, elapsed = 1_000L, percent = 40))
+        dao.insertSample(
+            sample(
+                id,
+                elapsed = 2_000L,
+                percent = 40,
+                batteryStatus = BatteryManager.BATTERY_STATUS_DISCHARGING,
+                currentNowMicroamps = -450_000,
+            ),
+        )
+
+        val curve = repository.curveFlow(id).first()
+        curve.map { it.powerMilliwatts } shouldBe listOf(9_000, null)
+        curve.map { it.voltageMillivolts } shouldBe listOf(4_000, 4_000)
+        // The recorded sign is kept: a discharge reads negative rather than being made absolute.
+        curve.map { it.currentNowMicroamps } shouldBe listOf(2_000_000, -450_000)
+    }
+
+    @Test
+    fun `the live session curve carries voltage and current too`() = runTest {
+        Settings.Global.putInt(
+            ApplicationProvider.getApplicationContext<Context>().contentResolver,
+            Settings.Global.BOOT_COUNT,
+            7,
+        )
+        val id = insertOpenSession()
+        database.statsDao().insertSample(sample(id, elapsed = 1_000L, percent = 40))
+
+        val live = repository.currentSession().first()!!
+        live.curve.map { it.voltageMillivolts } shouldBe listOf(4_000)
+        live.curve.map { it.currentNowMicroamps } shouldBe listOf(2_000_000)
+    }
+
+    @Test
+    fun `session metrics aggregate the raw samples, not the decimated curve`() = runTest {
+        val id = insertOpenSession()
+        val dao = database.statsDao()
+        // A single-sample temperature spike between two pinned endpoints: decimating to two points
+        // drops it, so a max taken off the returned curve would be wrong.
+        dao.insertSample(sample(id, elapsed = 1_000L, percent = 40, temperatureTenthsC = 300))
+        dao.insertSample(sample(id, elapsed = 2_000L, percent = 41, temperatureTenthsC = 480))
+        dao.insertSample(sample(id, elapsed = 3_000L, percent = 42, temperatureTenthsC = 300))
+
+        val metrics = repository.sessionMetrics(id, maxPoints = 2).first()
+        metrics.curve.size shouldBe 2
+        metrics.curve.mapNotNull { it.temperatureTenthsC }.max() shouldBe 300
+        metrics.aggregates.temperature!!.max shouldBe 480
+        metrics.aggregates.level!!.min shouldBe 40
+        metrics.aggregates.current!!.sampleCount shouldBe 3
     }
 
     private suspend fun awaitEmission(channel: Channel<List<Int?>>, expected: List<Int?>) {

--- a/app/src/test/java/eu/darken/amply/stats/core/ChargeStatsRepositoryLiveTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/ChargeStatsRepositoryLiveTest.kt
@@ -13,8 +13,9 @@ import eu.darken.amply.stats.core.db.BatterySampleEntity
 import eu.darken.amply.stats.core.db.ChargeSessionEntity
 import eu.darken.amply.stats.core.db.StatsDatabase
 import io.kotest.matchers.nulls.shouldBeNull
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -51,6 +52,7 @@ class ChargeStatsRepositoryLiveTest {
 
     private lateinit var database: StatsDatabase
     private lateinit var repository: ChargeStatsRepository
+    private lateinit var recorder: ChargeStatsRecorder
     private lateinit var dataStoreScope: CoroutineScope
 
     @Before
@@ -63,7 +65,7 @@ class ChargeStatsRepositoryLiveTest {
         // app's real path would be shared with every other Robolectric class in the same JVM.
         dataStoreScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         val bootIdSource = BootIdSource(context)
-        val recorder = ChargeStatsRecorder(
+        recorder = ChargeStatsRecorder(
             context = context,
             database = { database },
             preferences = StatsPreferences(
@@ -216,6 +218,42 @@ class ChargeStatsRepositoryLiveTest {
         metrics.aggregates.temperature!!.max shouldBe 480
         metrics.aggregates.level!!.min shouldBe 40
         metrics.aggregates.current!!.sampleCount shouldBe 3
+    }
+
+    @Test
+    fun `band observations read the recent finished sessions and nothing before they are asked for`() = runTest {
+        // Constructing the repository must not touch Room: nothing here has run a query yet, and a
+        // user who never enabled capture must not get stats.db created by the model source existing.
+        val untouched = ChargeStatsRepository(
+            database = { error("stats database must not be opened before bandObservations is called") },
+            recorder = recorder,
+            bootIdSource = BootIdSource(ApplicationProvider.getApplicationContext()),
+        )
+        untouched shouldNotBe null
+
+        val dao = database.statsDao()
+        val sessionId = dao.insertSession(
+            ChargeSessionEntity(
+                startedAtWallMillis = 1_000L,
+                startedElapsedRealtimeMillis = 0L,
+                endedAtWallMillis = 500_000L,
+                endedElapsedRealtimeMillis = 500_000L,
+                bootId = 7,
+                startPercent = 40,
+                endPercent = 44,
+                pluggedRaw = 1,
+                avgPowerMilliwatts = 11_000,
+            ),
+        )
+        // 40 → 44 in even minutes: the first step is dropped as usual, leaving three observations.
+        (0..4).forEach { i ->
+            dao.insertSample(sample(sessionId, elapsed = i * 60_000L, percent = 40 + i))
+        }
+
+        val batch = repository.bandObservations()
+        batch.observations.map { it.percentFrom } shouldBe listOf(41, 42, 43)
+        batch.observations.map { it.chargingType }.distinct() shouldBe listOf(ChargingType.AC)
+        batch.sessionPowerMilliwatts shouldBe mapOf(sessionId to 11_000)
     }
 
     private suspend fun awaitEmission(channel: Channel<List<Int?>>, expected: List<Int?>) {

--- a/app/src/test/java/eu/darken/amply/stats/core/ChargeTimeEstimatorTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/ChargeTimeEstimatorTest.kt
@@ -43,7 +43,7 @@ class ChargeTimeEstimatorTest {
         val model = ChargeTimeEstimator.buildModel(
             steps(1L, 30, 40, 60_000) + steps(2L, 30, 40, 120_000) + steps(3L, 30, 40, 360_000),
         )
-        model.pooled.bands[30] shouldBe 120_000L
+        model.pooled.bands[30]!!.medianMillisPerPercent shouldBe 120_000L
     }
 
     @Test
@@ -115,18 +115,18 @@ class ChargeTimeEstimatorTest {
     @Test
     fun `average speed is the median of the contributing sessions' own averages`() {
         val model = ChargeTimeEstimator.buildModel(
-            observations = steps(1L, 40, 60, 60_000) + steps(2L, 40, 60, 60_000) + steps(3L, 40, 60, 60_000),
+            observations = steps(1L, 50, 80, 60_000) + steps(2L, 50, 80, 60_000) + steps(3L, 50, 80, 60_000),
             sessionPowerMilliwatts = mapOf(1L to 8_000, 2L to 12_000, 3L to 25_000),
         )
-        project(model, 40).shouldNotBeNull().estimate.avgSpeedMilliwatts shouldBe 12_000
+        project(model, 50).shouldNotBeNull().estimate.avgSpeedMilliwatts shouldBe 12_000
     }
 
     @Test
     fun `basedOnSessions counts distinct contributing sessions`() {
         val model = ChargeTimeEstimator.buildModel(
-            steps(1L, 40, 60, 60_000) + steps(2L, 40, 60, 60_000) + steps(3L, 40, 60, 60_000),
+            steps(1L, 50, 80, 60_000) + steps(2L, 50, 80, 60_000) + steps(3L, 50, 80, 60_000),
         )
-        project(model, 40).shouldNotBeNull().estimate.basedOnSessions shouldBe 3
+        project(model, 50).shouldNotBeNull().estimate.basedOnSessions shouldBe 3
         // The count is of contributors, not of everything the extractor ever saw.
         model.observedSessions shouldBe 3
     }
@@ -134,9 +134,50 @@ class ChargeTimeEstimatorTest {
     @Test
     fun `a band only one session reached contributes nobody to the count`() {
         val model = ChargeTimeEstimator.buildModel(
-            steps(1L, 40, 60, 60_000) + steps(2L, 40, 60, 60_000) + steps(9L, 80, 100, 60_000),
+            steps(1L, 50, 80, 60_000) + steps(2L, 50, 80, 60_000) + steps(9L, 80, 100, 60_000),
         )
-        project(model, 40).shouldNotBeNull().estimate.basedOnSessions shouldBe 2
+        project(model, 50).shouldNotBeNull().estimate.basedOnSessions shouldBe 2
+    }
+
+    @Test
+    fun `provenance counts only the charges behind the figures actually shown`() {
+        // Two sessions produced a usable band nothing on the card is drawn from (0-10), two others
+        // produced the 50-80 stretch every displayed figure comes from. "From N charges" must
+        // describe the second pair only, and so must the speed median.
+        val model = ChargeTimeEstimator.buildModel(
+            observations = steps(1L, 0, 10, 60_000) + steps(2L, 0, 10, 60_000) +
+                steps(3L, 50, 80, 60_000) + steps(4L, 50, 80, 60_000),
+            sessionPowerMilliwatts = mapOf(1L to 2_000, 2L to 2_000, 3L to 10_000, 4L to 20_000),
+        )
+        val estimate = project(model, 50).shouldNotBeNull().estimate
+        estimate.toEightyMillis shouldBe 30 * 60_000L
+        estimate.basedOnSessions shouldBe 2
+        estimate.avgSpeedMilliwatts shouldBe 15_000
+    }
+
+    @Test
+    fun `a stratum whose bands project nothing from here yields no projection at all`() {
+        // 40-60 is corroborated, but from 40% it reaches no target and completes no split segment.
+        // A card here would carry provenance for bands nothing displayed, so there is no card.
+        val model = ChargeTimeEstimator.buildModel(
+            steps(1L, 40, 60, 60_000) + steps(2L, 40, 60, 60_000),
+        )
+        model.hasData shouldBe true
+        project(model, 40).shouldBeNull()
+    }
+
+    @Test
+    fun `same-type history keeps the label when pooling cannot answer a target either`() {
+        // At 82% the 80-target is null by rule, and history that stops at 80 answers no full-charge
+        // target — but pooling adds nothing here, so the card must not claim to be drawn from every
+        // charger type. Observed on a device during QA.
+        val model = ChargeTimeEstimator.buildModel(
+            steps(1L, 40, 80, 60_000, ChargingType.AC) + steps(2L, 40, 80, 60_000, ChargingType.AC),
+        )
+        val projection = project(model, 82, ChargingType.AC).shouldNotBeNull()
+        projection.basis shouldBe ChargeTimeBasis.SAME_TYPE
+        projection.estimate.hasAnyTarget shouldBe false
+        projection.estimate.split.fiftyToEightyMillis shouldBe 30 * 60_000L
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/stats/core/ChargeTimeEstimatorTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/ChargeTimeEstimatorTest.kt
@@ -1,0 +1,158 @@
+package eu.darken.amply.stats.core
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class ChargeTimeEstimatorTest {
+
+    /** Every 1% step from [from] until [to] at [millis] each, as one session's observations. */
+    private fun steps(
+        sessionId: Long,
+        from: Int,
+        to: Int,
+        millis: Long,
+        type: ChargingType = ChargingType.AC,
+    ) = (from until to).map { percent ->
+        BandObservation(sessionId = sessionId, chargingType = type, percentFrom = percent, millis = millis)
+    }
+
+    private fun project(
+        model: ChargeTimeModel,
+        percent: Int,
+        type: ChargingType = ChargingType.AC,
+    ) = ChargeTimeEstimator.project(model, percent, type)
+
+    @Test
+    fun `a band is usable only once two distinct sessions have crossed it`() {
+        // One session crossing 40-60 produces twenty observations. Counting observations would call
+        // that corroborated; counting sessions does not.
+        val single = ChargeTimeEstimator.buildModel(steps(1L, 40, 60, 60_000))
+        single.pooled.bands.isEmpty() shouldBe true
+        single.hasData shouldBe false
+
+        val both = ChargeTimeEstimator.buildModel(steps(1L, 40, 60, 60_000) + steps(2L, 40, 60, 90_000))
+        both.pooled.bands.keys shouldBe setOf(40, 50)
+    }
+
+    @Test
+    fun `a band's rate is the median across sessions, not across observations`() {
+        // Three sessions crossing 30-40 at 1, 2 and 6 minutes per percent. The median session rate
+        // is 2 minutes; a mean would be pulled to 3 by the outlier.
+        val model = ChargeTimeEstimator.buildModel(
+            steps(1L, 30, 40, 60_000) + steps(2L, 30, 40, 120_000) + steps(3L, 30, 40, 360_000),
+        )
+        model.pooled.bands[30] shouldBe 120_000L
+    }
+
+    @Test
+    fun `a target is null as soon as one band between here and it is unusable`() {
+        // Two sessions covered 40-80, but only one ever went above 80.
+        val model = ChargeTimeEstimator.buildModel(
+            steps(1L, 40, 80, 60_000) + steps(2L, 40, 80, 60_000) + steps(1L, 80, 100, 180_000),
+        )
+        val projection = project(model, 40).shouldNotBeNull()
+        // 40 → 80 is 40 steps of a minute each.
+        projection.estimate.toEightyMillis shouldBe 40 * 60_000L
+        // The 80-100 stretch has one session behind it, so a full-charge figure would be a guess.
+        projection.estimate.toFullMillis.shouldBeNull()
+        projection.estimate.split.eightyToHundredMillis.shouldBeNull()
+    }
+
+    @Test
+    fun `at eighty percent and above there is nothing left to count down to`() {
+        val model = ChargeTimeEstimator.buildModel(
+            steps(1L, 40, 100, 60_000) + steps(2L, 40, 100, 60_000),
+        )
+        project(model, 80).shouldNotBeNull().estimate.toEightyMillis.shouldBeNull()
+        project(model, 92).shouldNotBeNull().estimate.toEightyMillis.shouldBeNull()
+        // ...but the full target is still real, and shorter from higher up.
+        project(model, 92).shouldNotBeNull().estimate.toFullMillis shouldBe 8 * 60_000L
+        project(model, 100).shouldNotBeNull().estimate.toFullMillis.shouldBeNull()
+    }
+
+    @Test
+    fun `the band split segments are independently nullable`() {
+        // A user who never drains below 50%: the lower segment is unknown, the rest is not.
+        val model = ChargeTimeEstimator.buildModel(
+            steps(1L, 50, 100, 60_000) + steps(2L, 50, 100, 60_000),
+        )
+        val split = project(model, 60).shouldNotBeNull().estimate.split
+        split.toFiftyMillis.shouldBeNull()
+        split.fiftyToEightyMillis shouldBe 30 * 60_000L
+        split.eightyToHundredMillis shouldBe 20 * 60_000L
+        split.hasAny shouldBe true
+    }
+
+    @Test
+    fun `projections are stratified by charger type`() {
+        val model = ChargeTimeEstimator.buildModel(
+            steps(1L, 40, 100, 60_000, ChargingType.AC) +
+                steps(2L, 40, 100, 60_000, ChargingType.AC) +
+                steps(3L, 40, 100, 240_000, ChargingType.WIRELESS) +
+                steps(4L, 40, 100, 240_000, ChargingType.WIRELESS),
+        )
+        val wired = project(model, 40, ChargingType.AC).shouldNotBeNull()
+        val wireless = project(model, 40, ChargingType.WIRELESS).shouldNotBeNull()
+
+        wired.basis shouldBe ChargeTimeBasis.SAME_TYPE
+        wireless.basis shouldBe ChargeTimeBasis.SAME_TYPE
+        wired.estimate.toFullMillis shouldBe 60 * 60_000L
+        wireless.estimate.toFullMillis shouldBe 60 * 240_000L
+    }
+
+    @Test
+    fun `an unseen charger type falls back to the pooled history and says so`() {
+        val model = ChargeTimeEstimator.buildModel(
+            steps(1L, 40, 100, 60_000, ChargingType.AC) + steps(2L, 40, 100, 60_000, ChargingType.AC),
+        )
+        val projection = project(model, 40, ChargingType.WIRELESS).shouldNotBeNull()
+        projection.basis shouldBe ChargeTimeBasis.POOLED
+        projection.estimate.toFullMillis shouldBe 60 * 60_000L
+    }
+
+    @Test
+    fun `average speed is the median of the contributing sessions' own averages`() {
+        val model = ChargeTimeEstimator.buildModel(
+            observations = steps(1L, 40, 60, 60_000) + steps(2L, 40, 60, 60_000) + steps(3L, 40, 60, 60_000),
+            sessionPowerMilliwatts = mapOf(1L to 8_000, 2L to 12_000, 3L to 25_000),
+        )
+        project(model, 40).shouldNotBeNull().estimate.avgSpeedMilliwatts shouldBe 12_000
+    }
+
+    @Test
+    fun `basedOnSessions counts distinct contributing sessions`() {
+        val model = ChargeTimeEstimator.buildModel(
+            steps(1L, 40, 60, 60_000) + steps(2L, 40, 60, 60_000) + steps(3L, 40, 60, 60_000),
+        )
+        project(model, 40).shouldNotBeNull().estimate.basedOnSessions shouldBe 3
+        // The count is of contributors, not of everything the extractor ever saw.
+        model.observedSessions shouldBe 3
+    }
+
+    @Test
+    fun `a band only one session reached contributes nobody to the count`() {
+        val model = ChargeTimeEstimator.buildModel(
+            steps(1L, 40, 60, 60_000) + steps(2L, 40, 60, 60_000) + steps(9L, 80, 100, 60_000),
+        )
+        project(model, 40).shouldNotBeNull().estimate.basedOnSessions shouldBe 2
+    }
+
+    @Test
+    fun `the projection changes with the level while the model stays the same`() {
+        val model = ChargeTimeEstimator.buildModel(
+            steps(1L, 0, 100, 60_000) + steps(2L, 0, 100, 60_000),
+        )
+        project(model, 20).shouldNotBeNull().estimate.toFullMillis shouldBe 80 * 60_000L
+        project(model, 60).shouldNotBeNull().estimate.toFullMillis shouldBe 40 * 60_000L
+        project(model, 99).shouldNotBeNull().estimate.toFullMillis shouldBe 60_000L
+    }
+
+    @Test
+    fun `an empty history projects nothing at all`() {
+        val model = ChargeTimeEstimator.buildModel(emptyList())
+        model.hasData shouldBe false
+        project(model, 40).shouldBeNull()
+    }
+}

--- a/app/src/test/java/eu/darken/amply/stats/core/ChargeTimeModelSourceTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/ChargeTimeModelSourceTest.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -36,9 +37,10 @@ import java.io.File
 
 /**
  * The shared charge-time fold. The property under test is the refresh trigger: Room invalidates per
- * *table*, so every per-tick write to the open session re-runs the finished-session count query and
- * re-emits an unchanged number. Without the explicit `distinctUntilChanged` the whole ten-session
- * extraction would rerun roughly every 20 seconds for the duration of a charge.
+ * *table*, so every per-tick write to the open session re-runs the finished-session query and
+ * re-emits an unchanged list. Without the explicit `distinctUntilChanged` the whole ten-session
+ * extraction would rerun roughly every 20 seconds for the duration of a charge. The second property
+ * is what a returning subscriber sees: a replayed `Ready` must not be followed by a fresh `Loading`.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -49,6 +51,7 @@ class ChargeTimeModelSourceTest {
 
     private lateinit var database: StatsDatabase
     private lateinit var repository: ChargeStatsRepository
+    private lateinit var preferences: StatsPreferences
     private lateinit var dataStoreScope: CoroutineScope
 
     @Before
@@ -59,16 +62,17 @@ class ChargeTimeModelSourceTest {
             .build()
         dataStoreScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         val bootIdSource = BootIdSource(context)
+        preferences = StatsPreferences(
+            AppDataStore(
+                PreferenceDataStoreFactory.create(scope = dataStoreScope) {
+                    File(tempFolder.root, "stats-${System.nanoTime()}.preferences_pb")
+                },
+            ),
+        )
         val recorder = ChargeStatsRecorder(
             context = context,
             database = { database },
-            preferences = StatsPreferences(
-                AppDataStore(
-                    PreferenceDataStoreFactory.create(scope = dataStoreScope) {
-                        File(tempFolder.root, "stats-${System.nanoTime()}.preferences_pb")
-                    },
-                ),
-            ),
+            preferences = preferences,
             bootIdSource = bootIdSource,
             batteryReader = BatteryReader(context, BatteryUnitCalibration(context)),
             dispatcher = Dispatchers.IO,
@@ -86,12 +90,17 @@ class ChargeTimeModelSourceTest {
         database.close()
     }
 
+    /**
+     * Wall stamps are anchored to *now*, not to the epoch: the fold applies the retention window to
+     * the samples, so epoch-relative stamps would all fall outside it and the model would be empty.
+     */
     private suspend fun insertFinishedSession(startPercent: Int, endPercent: Int): Long {
+        val nowWallMillis = System.currentTimeMillis()
         val id = database.statsDao().insertSession(
             ChargeSessionEntity(
-                startedAtWallMillis = 1_000L,
+                startedAtWallMillis = nowWallMillis,
                 startedElapsedRealtimeMillis = 0L,
-                endedAtWallMillis = 1_000_000L,
+                endedAtWallMillis = nowWallMillis + 1_000_000L,
                 endedElapsedRealtimeMillis = 1_000_000L,
                 bootId = 7,
                 startPercent = startPercent,
@@ -104,7 +113,7 @@ class ChargeTimeModelSourceTest {
             database.statsDao().insertSample(
                 BatterySampleEntity(
                     sessionId = id,
-                    wallMillis = i * 60_000L,
+                    wallMillis = nowWallMillis + i * 60_000L,
                     elapsedRealtimeMillis = i * 60_000L,
                     bootId = 7,
                     percent = startPercent + i,
@@ -141,6 +150,7 @@ class ChargeTimeModelSourceTest {
                 ),
                 bootIdSource = BootIdSource(context),
             ),
+            statsPreferences = preferences,
             dispatcher = Dispatchers.IO,
         )
         // Reading the property builds the cold flow; the trigger query lives inside it.
@@ -148,10 +158,10 @@ class ChargeTimeModelSourceTest {
     }
 
     @Test
-    fun `an unchanged session count never re-folds the history`() = runBlocking {
+    fun `an open session's ticks never re-fold the history`() = runBlocking {
         insertFinishedSession(startPercent = 40, endPercent = 50)
         insertFinishedSession(startPercent = 40, endPercent = 50)
-        val source = ChargeTimeModelSource(repository, Dispatchers.IO)
+        val source = ChargeTimeModelSource(repository, preferences, Dispatchers.IO)
 
         val emissions = Channel<ChargeTimeModelState>(Channel.UNLIMITED)
         val collector = launch(Dispatchers.IO) { source.states.collect { emissions.send(it) } }
@@ -161,10 +171,10 @@ class ChargeTimeModelSourceTest {
                 while (next !is ChargeTimeModelState.Ready) next = emissions.receive()
                 next
             }
-            ready.model.pooled.bands[40] shouldBe 60_000L
+            ready.model.pooled.bands[40]!!.medianMillisPerPercent shouldBe 60_000L
 
-            // Exactly what a recorder tick does: rewrite the open session row. The count query is
-            // invalidated and re-runs, but the number it returns has not changed.
+            // Exactly what a recorder tick does: rewrite the open session row. The trigger query is
+            // invalidated and re-runs, but an open session is not in the finished list it returns.
             val open = database.statsDao().insertSession(
                 ChargeSessionEntity(
                     startedAtWallMillis = 2_000L,
@@ -188,7 +198,7 @@ class ChargeTimeModelSourceTest {
     fun `a newly finished session does re-fold the history`(): Unit = runBlocking {
         insertFinishedSession(startPercent = 40, endPercent = 50)
         insertFinishedSession(startPercent = 40, endPercent = 50)
-        val source = ChargeTimeModelSource(repository, Dispatchers.IO)
+        val source = ChargeTimeModelSource(repository, preferences, Dispatchers.IO)
 
         val emissions = Channel<ChargeTimeModelState>(Channel.UNLIMITED)
         val collector = launch(Dispatchers.IO) { source.states.collect { emissions.send(it) } }
@@ -212,8 +222,43 @@ class ChargeTimeModelSourceTest {
         }
     }
 
+    @Test
+    fun `a resubscription after the stop timeout never shows Loading between two Ready values`(): Unit =
+        runBlocking {
+            // `onStart` upstream of `shareIn` re-runs whenever the upstream restarts, so a returning
+            // subscriber would get the replayed Ready followed by a fresh Loading — the charge-time
+            // card blinking back to its loading line every time the app is reopened.
+            insertFinishedSession(startPercent = 40, endPercent = 50)
+            insertFinishedSession(startPercent = 40, endPercent = 50)
+            val source = ChargeTimeModelSource(repository, preferences, Dispatchers.IO)
+
+            val first = Channel<ChargeTimeModelState>(Channel.UNLIMITED)
+            val warmUp = launch(Dispatchers.IO) { source.states.collect { first.send(it) } }
+            withTimeout(TIMEOUT_MS) {
+                var next = first.receive()
+                while (next !is ChargeTimeModelState.Ready) next = first.receive()
+            }
+            warmUp.cancelAndJoin()
+
+            // Past the stop timeout the upstream is cancelled while the replay cache keeps its Ready.
+            delay(STOP_TIMEOUT_MS + 1_000L)
+
+            val second = Channel<ChargeTimeModelState>(Channel.UNLIMITED)
+            val collector = launch(Dispatchers.IO) { source.states.collect { second.send(it) } }
+            try {
+                val seen = withTimeout(TIMEOUT_MS) { List(2) { second.receive() } }
+                seen.filterIsInstance<ChargeTimeModelState.Loading>() shouldBe emptyList()
+                seen.all { it is ChargeTimeModelState.Ready } shouldBe true
+            } finally {
+                collector.cancelAndJoin()
+            }
+        }
+
     private companion object {
         const val TIMEOUT_MS = 10_000L
         const val QUIET_MS = 1_000L
+
+        /** Mirrors `ChargeTimeModelSource.STOP_TIMEOUT_MILLIS`, which is private. */
+        const val STOP_TIMEOUT_MS = 5_000L
     }
 }

--- a/app/src/test/java/eu/darken/amply/stats/core/ChargeTimeModelSourceTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/ChargeTimeModelSourceTest.kt
@@ -1,0 +1,219 @@
+package eu.darken.amply.stats.core
+
+import android.content.Context
+import android.os.BatteryManager
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.battery.core.BatteryReader
+import eu.darken.amply.battery.core.BatteryUnitCalibration
+import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.stats.core.db.BatterySampleEntity
+import eu.darken.amply.stats.core.db.ChargeSessionEntity
+import eu.darken.amply.stats.core.db.StatsDatabase
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+/**
+ * The shared charge-time fold. The property under test is the refresh trigger: Room invalidates per
+ * *table*, so every per-tick write to the open session re-runs the finished-session count query and
+ * re-emits an unchanged number. Without the explicit `distinctUntilChanged` the whole ten-session
+ * extraction would rerun roughly every 20 seconds for the duration of a charge.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ChargeTimeModelSourceTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private lateinit var database: StatsDatabase
+    private lateinit var repository: ChargeStatsRepository
+    private lateinit var dataStoreScope: CoroutineScope
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, StatsDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dataStoreScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        val bootIdSource = BootIdSource(context)
+        val recorder = ChargeStatsRecorder(
+            context = context,
+            database = { database },
+            preferences = StatsPreferences(
+                AppDataStore(
+                    PreferenceDataStoreFactory.create(scope = dataStoreScope) {
+                        File(tempFolder.root, "stats-${System.nanoTime()}.preferences_pb")
+                    },
+                ),
+            ),
+            bootIdSource = bootIdSource,
+            batteryReader = BatteryReader(context, BatteryUnitCalibration(context)),
+            dispatcher = Dispatchers.IO,
+        )
+        repository = ChargeStatsRepository(
+            database = { database },
+            recorder = recorder,
+            bootIdSource = bootIdSource,
+        )
+    }
+
+    @After
+    fun teardown() {
+        dataStoreScope.cancel()
+        database.close()
+    }
+
+    private suspend fun insertFinishedSession(startPercent: Int, endPercent: Int): Long {
+        val id = database.statsDao().insertSession(
+            ChargeSessionEntity(
+                startedAtWallMillis = 1_000L,
+                startedElapsedRealtimeMillis = 0L,
+                endedAtWallMillis = 1_000_000L,
+                endedElapsedRealtimeMillis = 1_000_000L,
+                bootId = 7,
+                startPercent = startPercent,
+                endPercent = endPercent,
+                pluggedRaw = 1,
+                avgPowerMilliwatts = 11_000,
+            ),
+        )
+        (0..(endPercent - startPercent)).forEach { i ->
+            database.statsDao().insertSample(
+                BatterySampleEntity(
+                    sessionId = id,
+                    wallMillis = i * 60_000L,
+                    elapsedRealtimeMillis = i * 60_000L,
+                    bootId = 7,
+                    percent = startPercent + i,
+                    batteryStatus = BatteryManager.BATTERY_STATUS_CHARGING,
+                ),
+            )
+        }
+        return id
+    }
+
+    @Test
+    fun `nothing is read until the flow is collected`() {
+        // Every ViewModel that shows an estimate injects this singleton, so merely constructing it —
+        // and touching its flow property — must not create stats.db for a user who never enabled
+        // recording. The injected repository throws on any database access at all.
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val exploding = dagger.Lazy<StatsDatabase> { error("stats database must not be opened here") }
+        val source = ChargeTimeModelSource(
+            repository = ChargeStatsRepository(
+                database = exploding,
+                recorder = ChargeStatsRecorder(
+                    context = context,
+                    database = exploding,
+                    preferences = StatsPreferences(
+                        AppDataStore(
+                            PreferenceDataStoreFactory.create(scope = dataStoreScope) {
+                                File(tempFolder.root, "unused-${System.nanoTime()}.preferences_pb")
+                            },
+                        ),
+                    ),
+                    bootIdSource = BootIdSource(context),
+                    batteryReader = BatteryReader(context, BatteryUnitCalibration(context)),
+                    dispatcher = Dispatchers.IO,
+                ),
+                bootIdSource = BootIdSource(context),
+            ),
+            dispatcher = Dispatchers.IO,
+        )
+        // Reading the property builds the cold flow; the trigger query lives inside it.
+        source.states shouldNotBe null
+    }
+
+    @Test
+    fun `an unchanged session count never re-folds the history`() = runBlocking {
+        insertFinishedSession(startPercent = 40, endPercent = 50)
+        insertFinishedSession(startPercent = 40, endPercent = 50)
+        val source = ChargeTimeModelSource(repository, Dispatchers.IO)
+
+        val emissions = Channel<ChargeTimeModelState>(Channel.UNLIMITED)
+        val collector = launch(Dispatchers.IO) { source.states.collect { emissions.send(it) } }
+        try {
+            val ready = withTimeout(TIMEOUT_MS) {
+                var next = emissions.receive()
+                while (next !is ChargeTimeModelState.Ready) next = emissions.receive()
+                next
+            }
+            ready.model.pooled.bands[40] shouldBe 60_000L
+
+            // Exactly what a recorder tick does: rewrite the open session row. The count query is
+            // invalidated and re-runs, but the number it returns has not changed.
+            val open = database.statsDao().insertSession(
+                ChargeSessionEntity(
+                    startedAtWallMillis = 2_000L,
+                    startedElapsedRealtimeMillis = 2_000L,
+                    bootId = 7,
+                    startPercent = 60,
+                ),
+            )
+            repeat(3) { tick ->
+                val row = database.statsDao().sessionById(open)!!
+                database.statsDao().updateSession(row.copy(runningSampleCount = tick + 1))
+            }
+
+            withTimeoutOrNull(QUIET_MS) { emissions.receive() }.shouldBeNull()
+        } finally {
+            collector.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `a newly finished session does re-fold the history`(): Unit = runBlocking {
+        insertFinishedSession(startPercent = 40, endPercent = 50)
+        insertFinishedSession(startPercent = 40, endPercent = 50)
+        val source = ChargeTimeModelSource(repository, Dispatchers.IO)
+
+        val emissions = Channel<ChargeTimeModelState>(Channel.UNLIMITED)
+        val collector = launch(Dispatchers.IO) { source.states.collect { emissions.send(it) } }
+        try {
+            withTimeout(TIMEOUT_MS) {
+                var next = emissions.receive()
+                while (next !is ChargeTimeModelState.Ready) next = emissions.receive()
+            }
+            insertFinishedSession(startPercent = 60, endPercent = 70)
+
+            val refolded = withTimeout(TIMEOUT_MS) {
+                var next = emissions.receive()
+                while (next !is ChargeTimeModelState.Ready || next.model.observedSessions < 3) {
+                    next = emissions.receive()
+                }
+                next
+            }
+            (refolded as ChargeTimeModelState.Ready).model.observedSessions shouldBe 3
+        } finally {
+            collector.cancelAndJoin()
+        }
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 10_000L
+        const val QUIET_MS = 1_000L
+    }
+}

--- a/app/src/test/java/eu/darken/amply/stats/core/CurveAggregatesTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/core/CurveAggregatesTest.kt
@@ -1,0 +1,121 @@
+package eu.darken.amply.stats.core
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class CurveAggregatesTest {
+
+    private fun point(
+        elapsed: Long,
+        percent: Int? = null,
+        power: Int? = null,
+        voltage: Int? = null,
+        current: Int? = null,
+        temperature: Int? = null,
+    ) = ChargeCurvePoint(
+        elapsedFromStartMillis = elapsed,
+        percent = percent,
+        powerMilliwatts = power,
+        temperatureTenthsC = temperature,
+        voltageMillivolts = voltage,
+        currentNowMicroamps = current,
+    )
+
+    @Test
+    fun `an extreme the decimator would drop is still the maximum`() {
+        // Decimation pins the first and last point and thins the interior, so a one-sample spike in
+        // between simply isn't in the plotted curve. Aggregating the raw list must still see it.
+        val points = listOf(
+            point(elapsed = 0L, temperature = 300),
+            point(elapsed = 60_000L, temperature = 480),
+            point(elapsed = 120_000L, temperature = 300),
+        )
+        StatsDownsampler.decimate(points, 2).mapNotNull { it.temperatureTenthsC }.max() shouldBe 300
+
+        val stats = CurveAggregates.of(points).temperature!!
+        stats.max shouldBe 480
+        stats.min shouldBe 300
+        stats.sampleCount shouldBe 3
+    }
+
+    @Test
+    fun `the average is time-weighted, not a plain mean`() {
+        // Three dense samples while charging fast at 10 W, then a sparse 2 W tail — exactly what the
+        // recorder's level-change cadence produces. The plain mean of the five samples is 6.8 W; the
+        // time-weighted answer over the same 12 minutes is 4.0 W.
+        val points = listOf(
+            point(elapsed = 0L, power = 10_000),
+            point(elapsed = 60_000L, power = 10_000),
+            point(elapsed = 120_000L, power = 10_000),
+            point(elapsed = 180_000L, power = 2_000),
+            point(elapsed = 720_000L, power = 2_000),
+        )
+        val stats = CurveAggregates.of(points).power!!
+        stats.avg shouldBe 4_000
+        stats.min shouldBe 2_000
+        stats.max shouldBe 10_000
+        stats.sampleCount shouldBe 5
+    }
+
+    @Test
+    fun `a gap longer than the weight cap cannot dominate the average`() {
+        // A 10h stall on 1 mA followed by a normal 5 min interval at 2 A. Uncapped, the stale
+        // reading would own 99% of the weight; the cap credits it at most 10 minutes.
+        val points = listOf(
+            point(elapsed = 0L, current = 1_000),
+            point(elapsed = 36_000_000L, current = 2_000_000),
+            point(elapsed = 36_300_000L, current = 2_000_000),
+        )
+        val stats = CurveAggregates.of(points).current!!
+        // (1_000 * 600_000 + 2_000_000 * 300_000) / 900_000
+        stats.avg shouldBe 667_333
+    }
+
+    @Test
+    fun `current sums accumulate beyond the range of an Int`() {
+        // 1000 samples at 2.1 A: the raw sum is 2.1e9, past Int.MAX_VALUE. A naive Int accumulator
+        // would wrap negative here.
+        val points = (0 until 1_000).map { i -> point(elapsed = i * 20_000L, current = 2_100_000) }
+        val stats = CurveAggregates.of(points).current!!
+        stats.avg shouldBe 2_100_000
+        stats.min shouldBe 2_100_000
+        stats.max shouldBe 2_100_000
+        stats.sampleCount shouldBe 1_000
+    }
+
+    @Test
+    fun `a metric nothing reported has no statistics at all`() {
+        val points = (0..5).map { i -> point(elapsed = i * 20_000L, percent = 40 + i) }
+        val aggregates = CurveAggregates.of(points)
+        aggregates.voltage.shouldBeNull()
+        aggregates.current.shouldBeNull()
+        aggregates.power.shouldBeNull()
+        aggregates.level!!.sampleCount shouldBe 6
+    }
+
+    @Test
+    fun `a single sample reports itself as min, avg and max`() {
+        val stats = CurveAggregates.of(listOf(point(elapsed = 0L, voltage = 4_185))).voltage!!
+        stats shouldBe MetricStats(min = 4_185, avg = 4_185, max = 4_185, sampleCount = 1)
+    }
+
+    @Test
+    fun `an empty curve aggregates to nothing`() {
+        CurveAggregates.of(emptyList()) shouldBe CurveAggregates.EMPTY
+    }
+
+    @Test
+    fun `an interval whose leading sample is missing the metric is not credited`() {
+        // The 2 A reading is only ever the *trailing* sample of an interval, so it carries no weight
+        // — a null reading must not have its neighbour's value carried forward across the gap.
+        val points = listOf(
+            point(elapsed = 0L, current = 1_000_000),
+            point(elapsed = 60_000L, current = null),
+            point(elapsed = 120_000L, current = 2_000_000),
+        )
+        val stats = CurveAggregates.of(points).current!!
+        stats.avg shouldBe 1_000_000
+        stats.sampleCount shouldBe 2
+    }
+}

--- a/app/src/test/java/eu/darken/amply/stats/ui/ChargeTimeStatesTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/ui/ChargeTimeStatesTest.kt
@@ -1,0 +1,142 @@
+package eu.darken.amply.stats.ui
+
+import android.os.BatteryManager
+import eu.darken.amply.battery.core.BatteryReadout
+import eu.darken.amply.stats.core.BandObservation
+import eu.darken.amply.stats.core.ChargeTimeBasis
+import eu.darken.amply.stats.core.ChargeTimeEstimator
+import eu.darken.amply.stats.core.ChargeTimeModelState
+import eu.darken.amply.stats.core.ChargingType
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * The estimate is folded once and projected many times, so these cover the seam: the model provider
+ * must not be touched while recording is off, and the projection must follow the live level.
+ */
+class ChargeTimeStatesTest {
+
+    private fun steps(sessionId: Long, from: Int, to: Int, millis: Long) =
+        (from until to).map { percent ->
+            BandObservation(
+                sessionId = sessionId,
+                chargingType = ChargingType.AC,
+                percentFrom = percent,
+                millis = millis,
+            )
+        }
+
+    private val model = ChargeTimeEstimator.buildModel(
+        steps(1L, 0, 100, 60_000) + steps(2L, 0, 100, 60_000),
+        sessionPowerMilliwatts = mapOf(1L to 10_000, 2L to 12_000),
+    )
+
+    private fun readout(percent: Int, status: Int, plugged: Int) = BatteryReadout(
+        levelPercent = percent,
+        status = status,
+        plugged = plugged,
+    )
+
+    private val charging = readout(
+        percent = 40,
+        status = BatteryManager.BATTERY_STATUS_CHARGING,
+        plugged = BatteryManager.BATTERY_PLUGGED_AC,
+    )
+
+    @Test
+    fun `with recording off the model provider is never invoked`() = runTest {
+        var invocations = 0
+        val provider: () -> Flow<ChargeTimeModelState> = {
+            invocations++
+            flowOf(ChargeTimeModelState.Ready(model))
+        }
+
+        val state = chargeTimeStates(
+            captureEnabled = flowOf(false),
+            readouts = flowOf(charging),
+            model = provider,
+        ).first()
+
+        state shouldBe ChargeTimeState.Loading
+        // Not a style point: the provider's flow opens stats.db, and a user who never enabled
+        // recording must never get one created for them.
+        invocations shouldBe 0
+    }
+
+    @Test
+    fun `the estimate follows the live level without the model changing`() = runTest {
+        val readouts = MutableStateFlow(charging)
+        val states = chargeTimeStates(
+            captureEnabled = flowOf(true),
+            readouts = readouts,
+            model = { flowOf(ChargeTimeModelState.Ready(model)) },
+        )
+
+        val atForty = states.first().shouldBeInstanceOf<ChargeTimeState.Ready>()
+        atForty.estimate.toFullMillis shouldBe 60 * 60_000L
+        atForty.charging shouldBe true
+        atForty.basis shouldBe ChargeTimeBasis.SAME_TYPE
+
+        readouts.value = charging.copy(levelPercent = 90)
+        val atNinety = states.first().shouldBeInstanceOf<ChargeTimeState.Ready>()
+        atNinety.estimate.toFullMillis shouldBe 10 * 60_000L
+    }
+
+    @Test
+    fun `a device held at a limit is not counting down`() = runTest {
+        val state = chargeTimeStates(
+            captureEnabled = flowOf(true),
+            readouts = flowOf(charging.copy(status = BatteryManager.BATTERY_STATUS_NOT_CHARGING)),
+            model = { flowOf(ChargeTimeModelState.Ready(model)) },
+        ).first().shouldBeInstanceOf<ChargeTimeState.Ready>()
+
+        state.charging shouldBe false
+    }
+
+    @Test
+    fun `an unplugged device is not counting down either`() = runTest {
+        val state = chargeTimeStates(
+            captureEnabled = flowOf(true),
+            readouts = flowOf(
+                readout(percent = 64, status = BatteryManager.BATTERY_STATUS_DISCHARGING, plugged = 0),
+            ),
+            model = { flowOf(ChargeTimeModelState.Ready(model)) },
+        ).first().shouldBeInstanceOf<ChargeTimeState.Ready>()
+
+        state.charging shouldBe false
+    }
+
+    @Test
+    fun `an empty history is not enough data, an outage is unavailable`() = runTest {
+        val empty = chargeTimeStates(
+            captureEnabled = flowOf(true),
+            readouts = flowOf(charging),
+            model = { flowOf(ChargeTimeModelState.Ready(ChargeTimeEstimator.buildModel(emptyList()))) },
+        ).first()
+        empty shouldBe ChargeTimeState.NotEnoughData(sessions = 0)
+
+        val broken = chargeTimeStates(
+            captureEnabled = flowOf(true),
+            readouts = flowOf(charging),
+            model = { flowOf(ChargeTimeModelState.Unavailable) },
+        ).first()
+        broken shouldBe ChargeTimeState.Unavailable
+    }
+
+    @Test
+    fun `an unreadable battery cannot be projected from`() = runTest {
+        val state = chargeTimeStates(
+            captureEnabled = flowOf(true),
+            readouts = flowOf(null),
+            model = { flowOf(ChargeTimeModelState.Ready(model)) },
+        ).first()
+
+        state.shouldBeInstanceOf<ChargeTimeState.NotEnoughData>()
+    }
+}

--- a/app/src/test/java/eu/darken/amply/stats/ui/StatsViewModelMetricSelectionTest.kt
+++ b/app/src/test/java/eu/darken/amply/stats/ui/StatsViewModelMetricSelectionTest.kt
@@ -1,0 +1,170 @@
+package eu.darken.amply.stats.ui
+
+import android.content.Context
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.battery.core.BatteryReader
+import eu.darken.amply.battery.core.BatteryUnitCalibration
+import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.main.ui.battery.BatteryMetric
+import eu.darken.amply.stats.core.BootIdSource
+import eu.darken.amply.stats.core.CaptureServiceHealth
+import eu.darken.amply.stats.core.ChargeStatsRecorder
+import eu.darken.amply.stats.core.ChargeStatsRepository
+import eu.darken.amply.stats.core.StatsPreferences
+import eu.darken.amply.stats.core.db.StatsDatabase
+import eu.darken.amply.upgrade.core.UpgradeRepo
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.time.Instant
+
+/**
+ * The metric-detail selection is the pair (session, metric), and it has to survive a restore without
+ * ever resolving half of itself: a metric restored beside whatever session the hub happens to point
+ * at would silently retitle another charge's data.
+ *
+ * The injected database throws on access, so any resolution attempt that reached Room would fail the
+ * test rather than quietly opening stats.db.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class StatsViewModelMetricSelectionTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private val storeScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    private class FakeInfo : UpgradeRepo.Info {
+        override val type: UpgradeRepo.Type = UpgradeRepo.Type.FOSS
+        override val isPro: Boolean = true
+        override val isSettled: Boolean = true
+        override val error: Throwable? = null
+        override val upgradedAt: Instant? = null
+    }
+
+    private class FakeUpgradeRepo : UpgradeRepo {
+        override val storeSite: String = ""
+        override val upgradeSite: String = ""
+        override val betaSite: String = ""
+        override val upgradeInfo: Flow<UpgradeRepo.Info> = MutableStateFlow(FakeInfo())
+        override suspend fun refresh() = Unit
+    }
+
+    @Before fun setup() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
+
+    @After fun teardown() {
+        Dispatchers.resetMain()
+        storeScope.cancel()
+    }
+
+    private fun viewModel(savedState: SavedStateHandle): StatsViewModel {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val store = PreferenceDataStoreFactory.create(scope = storeScope) {
+            File(tempFolder.newFolder(), "test.preferences_pb")
+        }
+        val preferences = StatsPreferences(AppDataStore(store))
+        val database = object : dagger.Lazy<StatsDatabase> {
+            override fun get(): StatsDatabase = error("stats database must not be opened here")
+        }
+        val bootIdSource = BootIdSource(context)
+        val recorder = ChargeStatsRecorder(
+            context = context,
+            database = database,
+            preferences = preferences,
+            bootIdSource = bootIdSource,
+            batteryReader = BatteryReader(context, BatteryUnitCalibration(context)),
+            dispatcher = Dispatchers.IO,
+        )
+        return StatsViewModel(
+            context = context,
+            preferences = preferences,
+            repository = ChargeStatsRepository(database, recorder, bootIdSource),
+            recorder = recorder,
+            serviceHealth = CaptureServiceHealth(),
+            upgradeRepo = FakeUpgradeRepo(),
+            savedStateHandle = savedState,
+        )
+    }
+
+    @Test fun `an unknown saved metric name clears the selection instead of throwing`(): Unit = runBlocking {
+        // A record written by a build that knew a metric this one doesn't.
+        val savedState = SavedStateHandle(
+            mapOf(
+                StatsViewModel.KEY_METRIC_SESSION to 42L,
+                StatsViewModel.KEY_METRIC_NAME to "CHARGE_COUNTER",
+            ),
+        )
+        val vm = viewModel(savedState)
+
+        val collector = launch { vm.metricDetailState.collect { } }
+        try {
+            withTimeout(TIMEOUT_MS) {
+                while (savedState.get<String>(StatsViewModel.KEY_METRIC_NAME) != null) delay(10)
+            }
+        } finally {
+            collector.cancelAndJoin()
+        }
+        // Both halves go, so nothing is left to resolve against a session it can't label.
+        savedState.get<Long>(StatsViewModel.KEY_METRIC_SESSION).shouldBeNull()
+        vm.metricDetailState.value.shouldBeNull()
+    }
+
+    @Test fun `opening and closing writes and clears both keys together`(): Unit = runBlocking {
+        val savedState = SavedStateHandle()
+        val vm = viewModel(savedState)
+
+        vm.openMetric(sessionId = 7L, metric = BatteryMetric.VOLTAGE)
+        savedState.get<Long>(StatsViewModel.KEY_METRIC_SESSION) shouldBe 7L
+        savedState.get<String>(StatsViewModel.KEY_METRIC_NAME) shouldBe "VOLTAGE"
+
+        vm.closeMetric()
+        savedState.get<Long>(StatsViewModel.KEY_METRIC_SESSION).shouldBeNull()
+        savedState.get<String>(StatsViewModel.KEY_METRIC_NAME).shouldBeNull()
+    }
+
+    @Test fun `a session id without a metric name resolves to nothing`(): Unit = runBlocking {
+        // Half a selection is no selection: it must not resolve against the session alone, and it
+        // must not reach the database to find that out.
+        val savedState = SavedStateHandle(mapOf(StatsViewModel.KEY_METRIC_SESSION to 42L))
+        val vm = viewModel(savedState)
+
+        val collector = launch { vm.metricDetailState.collect { } }
+        try {
+            withTimeoutOrNull(QUIET_MS) { vm.metricDetailState.first { it != null } }.shouldBeNull()
+        } finally {
+            collector.cancelAndJoin()
+        }
+    }
+
+    private companion object {
+        const val TIMEOUT_MS = 5_000L
+        const val QUIET_MS = 300L
+    }
+}


### PR DESCRIPTION
## What changed

Three additions to the "Battery & charging" screen, built on the charge data Amply already records, so the app is useful on devices where charge control isn't supported:

- **Charge-time estimates** from your own recorded charges: time to 80% and 100%, average speed, and a breakdown of where the time goes. A one-line remaining-time estimate also appears in the dashboard's charging card while a charge is running.
- **A tile grid with sparklines** for the live readings, replacing the plain label/value list. Every reading that was on the screen before is still there.
- **A per-metric detail screen**, opened by tapping a tile: the full charge curve for that reading, its minimum, average and maximum, and a plain-language explanation of what it means.

Estimates come only from charges Amply has actually recorded, so they appear once recording is on and a couple of charges cover the same range. A target Amply has never observed says so instead of guessing, and figures read as a countdown only while the battery is genuinely taking charge.

The detail rows below the tiles are now grouped as "This battery" and "This charger" instead of "Charging"/"Health"/"Electrical", and the row previously labelled "Charge counter" is now "Charge remaining" — it's the charge currently in the cell, not the battery's capacity.

## Technical Context

- Metric minimum/average/maximum come from raw samples before decimation, not from the drawn curve: the downsampler keeps a uniform stride, so an extreme lasting a few samples never survives into the chart. The average is time-weighted to match how `ChargeSessionSummary.avgPowerMilliwatts` is already folded, so one session can't show two different averages on two screens.
- A 10% band is usable only once **two distinct sessions** have crossed it. Counting observations instead would let a single charge corroborate itself, since one charge produces ~10 observations per band. Provenance and average speed count only the sessions behind the figures actually displayed.
- Band extraction ignores any 1% step spanning a non-`BATTERY_STATUS_CHARGING` sample. That, not a duration cutoff, is what stops an OEM limit hold from being recorded as a very slow charge — a cutoff would also discard genuinely slow trickle charging, biasing estimates optimistic in exactly the 80-100% stretch this feature explains.
- The shared history model refreshes on the **identities** of recent finished sessions plus the retention window, and the fold filters samples by the retention cutoff. Sessions expire by `endedAtWallMillis` while samples expire by their own `wallMillis`, so a session held at a limit for days and ended recently keeps its id while losing its early samples.
- The hub reads a bounded curve, never the unbounded one — a session at an OEM limit stays open for days. Tile tappability is derived from availability computed before decimation, so a metric whose samples all land on dropped indices is still openable.
- Worth close review: `ChargeBandExtractor`'s state machine (first step of a run discarded as it starts mid-level, plus jump/decrease/backwards-time handling) and `ChargeTimeEstimator.project`'s same-type-versus-pooled fallback.
- No changes to any charge-control adapter, the capability gate, or the Shizuku/WSS paths.
