### PR TITLE
FullCharge: Offer the reconnect gesture on adapters without a hold signal

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -21,7 +21,7 @@ single shared store, every write reaches every collector, so the deduplication h
 
 - `AdapterRegistry` selects an OEM adapter from **immutable device information**. Live adapters declare a
   capability surface (`sessionOverridePolicy`, `defaultProtectivePolicy`, `verification`,
-  `reconnectGestureSupported`) that the session/recovery/UI layers consume instead of hardcoding Pixel behavior.
+  `reconnectGestureSupport`) that the session/recovery/UI layers consume instead of hardcoding Pixel behavior.
 - `AccessResolver` independently probes direct WSS and Shizuku.
 - `ChargingRepository` selects the strongest backend per operation: **Shizuku for reads, direct WSS for durable
   writes, then Shizuku for verification** when both are available.
@@ -89,10 +89,29 @@ Opt-in, with two arming bases:
 - **Limit hold (default)**: the public battery broadcast **simultaneously** reports external power, charging-policy
   hardware state `4`, a non-charging battery status, and an expected limit-range level. Once latched during a plug
   period it survives option flips (the evidence was the hardware hold itself).
-- **Any level (opt-in sub-option)**: plugged AND Amply's *persistent* configured policy
-  (`ChargingPreferences.lastPersistentPolicy`, never updated by temporary session writes) is protective. Percent,
-  battery status, and hardware hold are deliberately ignored. This basis is revoked immediately — including an open
-  reconnect window — when the option is switched off or the persistent policy stops being protective.
+- **Any level (opt-in sub-option)**: plugged AND the configured policy is conclusively protective. Evidence comes
+  from `GestureBasis.evidence()` in order: the hardware decode, then the synchronous settings readback
+  (`ChargingRepository.syncReadback()`, null on async-hardware adapters), then Amply's *persistent* write journal
+  (`ChargingPreferences.lastPersistentPolicy`, never updated by temporary session writes). Percent, battery status,
+  and hardware hold are deliberately ignored. This basis is revoked immediately — including an open reconnect
+  window — when the option is switched off or the policy stops being conclusively protective.
+
+Which bases exist is per-adapter, via `ChargingAdapter.reconnectGestureSupport` (`ReconnectSupport`):
+
+- `FULL` — Pixel only. It is the only adapter reporting the charging-policy hardware state the limit-hold basis
+  needs while also applying writes mid-plug-session.
+- `ANY_LEVEL_ONLY` — Samsung (both generations), OnePlus/ColorOS, Xiaomi HyperOS 3, LineageOS. A real cap that
+  reads back synchronously, but no observable hold signal, so the limit-hold basis can never arm. The any-level
+  basis is **implied on** here: the sub-option is not consulted and the settings screen hides it, because honouring
+  an "off" would leave the master switch on with no basis that could ever arm. The settings readback is what keeps
+  these off journal-only evidence, so a limit removed in the OEM's own settings revokes the basis.
+- `NONE` — everything else, for two distinct reasons. GrapheneOS (and any future `policyLatchesAtPlug` adapter)
+  because the gesture's write lands strictly after the replug the ROM already sampled, so it cannot take effect
+  until the *next* replug. Xiaomi HyperOS 2 because Adaptive is its only protective mode *and* that
+  mode's hold is unobserved on the generation (13T, 59%→100% with it configured), so the gesture
+  would have nothing to lift on every tick. Being `enforcementIsConditional` is NOT itself
+  disqualifying: Pixel arms on Adaptive today, and OnePlus/HyperOS 3 will too, since adaptive
+  charging does hold below full before the usual unplug.
 
 A powered→unpowered transition opens a reconnect window of **2–10 seconds** (`elapsedRealtime`-based): the 2s
 debounce floor filters momentary power cuts (car ignition, connector jostle), and a rejected too-fast/too-late replug

--- a/.claude/skills/oem-adapters/SKILL.md
+++ b/.claude/skills/oem-adapters/SKILL.md
@@ -24,7 +24,9 @@ Two live adapters, gated by `ro.build.version.oneui` ranges plus `protect_batter
 
 Writes apply **synchronously** (`VerificationStrategy.SYNC_READBACK`): `apply()` requires read-back equality, no
 pending-settle window, boot recovery converges on settings readback, and no reapply-inversion trick is needed.
-The reconnect gesture is Pixel-only (`reconnectGestureSupported`). One UI 6/7 and 9+ fall through to the
+The reconnect gesture runs in `ReconnectSupport.ANY_LEVEL_ONLY` mode: One UI publishes no charging-policy hold
+signal, so the limit-hold basis can never arm and the any-level basis is implied on (the sub-option is hidden).
+One UI 6/7 and 9+ fall through to the
 diagnostics-only lab adapter. An external `protect_battery=0` makes One UI forget the user's prior mode (it falls back
 to the OEM default on re-enable), so Amply restores the exact prior policy itself rather than trusting Samsung's
 bookkeeping. Verified devices + coverage: see the qualification ledger (`device-qualification` skill).
@@ -92,7 +94,8 @@ NOT any AOSP `settings` namespace: `charging_control_enabled` (0/1), `charging_c
 unprivileged** (`LineageSettingsClient` via ContentResolver, shared by both backends); **writes require Shizuku**
 (`content insert`; the shell UID holds `lineageos.permission.WRITE_SETTINGS`, which `WRITE_SECURE_SETTINGS` cannot
 cover — `preferShizukuForWrites`, and the WSS auto-grant is skipped). `SYNC_READBACK` with read-back equality;
-session override = Unrestricted; protective default = FixedLimit(80); reconnect gesture unsupported.
+session override = Unrestricted; protective default = FixedLimit(80); reconnect gesture
+`ANY_LEVEL_ONLY` (reachable only once the enforcement gate enables control, since it rides `canApply`).
 
 LineageOS's own `ChargingControlController` observes these keys and re-drives the `vendor.lineage.health.
 IChargingControl` HAL, so an external write is honored. But the HAL is **device-dependent** (the setting can flip

--- a/app/src/debug/java/eu/darken/amply/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/amply/screenshots/ScreenshotContent.kt
@@ -117,6 +117,8 @@ internal fun ReconnectGestureContent() = PreviewWrapper {
     ChargingSettingsScreen(
         gestureEnabled = true,
         anyLevelEnabled = false,
+        // The Play Store shot shows a Pixel, which has both arming bases, so the sub-option renders.
+        anyLevelOnly = false,
         canEnableGesture = true,
         // A two-policy device, so the shot stays on the gesture options themselves.
         availablePolicies = listOf(ChargePolicy.FixedLimit(80), ChargePolicy.Unrestricted),

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -79,6 +79,8 @@ data class ChargingState(
      */
     val defaultProtectivePolicy: ChargePolicy? = null,
     val reconnectSupported: Boolean = false,
+    /** The limit-hold basis cannot arm here, so surfaces must not offer it as a choice. */
+    val reconnectAnyLevelOnly: Boolean = false,
     /** True when the adapter's configured state is directly readable — Shizuku adds nothing for verification. */
     val syncVerification: Boolean = false,
     /** True when applying a policy needs Shizuku (system-namespace adapter WSS can't write). */
@@ -740,7 +742,8 @@ class ChargingRepository @Inject constructor(
             supportedPolicies = selection.support.licensedPolicies
                 ?: adapter?.supportedPolicies.orEmpty(),
             defaultProtectivePolicy = adapter?.defaultProtectivePolicy,
-            reconnectSupported = adapter?.reconnectGestureSupported == true,
+            reconnectSupported = adapter?.reconnectGestureSupport?.available == true,
+            reconnectAnyLevelOnly = adapter?.reconnectGestureSupport?.impliesAnyLevel == true,
             syncVerification = adapter?.verification == VerificationStrategy.SYNC_READBACK,
             writeRequiresShizuku = adapter?.preferShizukuForWrites == true,
             controlEnabled = selection.support.controlEnabled,

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/ChargingAdapter.kt
@@ -62,6 +62,30 @@ enum class VerificationStrategy {
     SYNC_READBACK,
 }
 
+/**
+ * How much of the reconnect gesture an adapter can support.
+ *
+ * [ANY_LEVEL_ONLY] is not a degraded [FULL]: it is the honest description of a device that enforces
+ * a cap but publishes no observable hold signal, so Amply can know the cap is *configured* and never
+ * that it is *holding right now*. Surfaces must not offer the limit-hold sub-option there — it
+ * could never arm — and the gesture runs on the any-level basis regardless of the user's setting.
+ */
+enum class ReconnectSupport {
+    /** No gesture. Either no cap to lift (Adaptive-only adapters) or the write cannot land in time
+     * (adapters with `policyLatchesAtPlug`, where the gesture's write always misses the plug event). */
+    NONE,
+
+    /** Any-level arming only — the hardware hold signal this adapter cannot report is not required. */
+    ANY_LEVEL_ONLY,
+
+    /** Both bases, including arming off an observed hardware limit hold. */
+    FULL,
+    ;
+
+    val available: Boolean get() = this != NONE
+    val impliesAnyLevel: Boolean get() = this == ANY_LEVEL_ONLY
+}
+
 interface ChargingAdapter {
     val id: String
     val displayName: CaString
@@ -76,8 +100,18 @@ interface ChargingAdapter {
 
     val verification: VerificationStrategy get() = VerificationStrategy.ASYNC_HARDWARE
 
-    /** Whether the powered→unpowered reconnect gesture's hardware preconditions exist on this adapter. */
-    val reconnectGestureSupported: Boolean get() = false
+    /**
+     * Which arming bases the powered→unpowered reconnect gesture can actually use here.
+     *
+     * The gesture's *limit-hold* basis reads Android's charging-policy hardware state
+     * (`EXTRA_CHARGING_STATUS` == 4), which only [PixelChargingAdapter] and
+     * [GrapheneOsChargingAdapter] decode at all — every other adapter inherits
+     * [decodeHardware]'s null and can never satisfy it. That is why this started life as a
+     * Pixel-only boolean. The *any-level* basis needs no hardware signal (see [GestureBasis]), so
+     * on an adapter whose protective policy is a real cap it works fine; three states instead of
+     * two is what lets those devices have the gesture without claiming a hold they cannot observe.
+     */
+    val reconnectGestureSupport: ReconnectSupport get() = ReconnectSupport.NONE
 
     /**
      * Prefer Shizuku over direct WSS for writes. Two adapter classes set it: keys in the `system`

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapter.kt
@@ -73,6 +73,11 @@ class GrapheneOsChargingAdapter @Inject constructor() : ChargingAdapter {
     override val verification = VerificationStrategy.SYNC_READBACK
     override val policyLatchesAtPlug = true
 
+    // Structural, not a missing signal: this ROM samples the key at plug-session start, and the
+    // gesture's override write lands strictly after the replug broadcast it would have to beat. It
+    // would read back correctly and change nothing until the *next* replug. See the class doc.
+    override val reconnectGestureSupport = ReconnectSupport.NONE
+
     // Not because the namespace needs it (global is WSS-writable elsewhere) but because the key is
     // @Protected: a direct write throws SecurityException no matter which permissions Amply holds,
     // while the shell UID is exempt. Reads share the restriction; readSyncDirectFirst's direct

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapter.kt
@@ -78,6 +78,10 @@ class LineageChargingAdapter @Inject constructor(
     override val defaultProtectivePolicy = ChargePolicy.FixedLimit(80)
     override val sessionOverridePolicy = ChargePolicy.Unrestricted
     override val verification = VerificationStrategy.SYNC_READBACK
+
+    // Reachability is still decided by the enforcement gate: with control off, `canApply` is
+    // false and no surface offers the gesture, so this never widens what an unqualified build does.
+    override val reconnectGestureSupport = ReconnectSupport.ANY_LEVEL_ONLY
     override val preferShizukuForWrites = true
     override val enforcementEvidenceRequired = true
 

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/OnePlusChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/OnePlusChargingAdapter.kt
@@ -48,6 +48,9 @@ class OnePlusChargingAdapter @Inject constructor() : ChargingAdapter {
 
     override val defaultProtectivePolicy = ChargePolicy.FixedLimit(LIMIT_PERCENT)
     override val verification = VerificationStrategy.SYNC_READBACK
+
+    // FixedLimit(80) is a real cap and reads back synchronously; ColorOS publishes no hold signal.
+    override val reconnectGestureSupport = ReconnectSupport.ANY_LEVEL_ONLY
     override val preferShizukuForWrites = true
 
     override fun probe(device: DeviceInfo): AdapterSupport {

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/PixelChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/PixelChargingAdapter.kt
@@ -28,7 +28,7 @@ class PixelChargingAdapter @Inject constructor() : ChargingAdapter {
         ChargePolicy.Adaptive,
         ChargePolicy.Unrestricted,
     )
-    override val reconnectGestureSupported = true
+    override val reconnectGestureSupport = ReconnectSupport.FULL
     override val observedSettingUris
         get() = listOf(
             Settings.Secure.getUriFor(KEY_MODE),

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/SamsungChargingAdapters.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/SamsungChargingAdapters.kt
@@ -28,6 +28,10 @@ abstract class SamsungChargingAdapter : ChargingAdapter {
 
     override val verification = VerificationStrategy.SYNC_READBACK
 
+    // No `EXTRA_CHARGING_STATUS` hold signal on One UI, so the limit-hold basis could never
+    // arm; the cap itself is real and read-backable, which is all the any-level basis needs.
+    override val reconnectGestureSupport = ReconnectSupport.ANY_LEVEL_ONLY
+
     override fun probe(device: DeviceInfo): AdapterSupport {
         val oneUi = device.oneUiVersion
         val matched = device.manufacturer.equals("Samsung", ignoreCase = true) &&

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/XiaomiChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/XiaomiChargingAdapter.kt
@@ -55,6 +55,17 @@ class XiaomiChargingAdapter @Inject constructor() : ChargingAdapter {
     override val defaultProtectivePolicy = ChargePolicy.Adaptive
     override val verification = VerificationStrategy.SYNC_READBACK
 
+    // NOT because Adaptive is `enforcementIsConditional` — Amply deliberately arms the gesture on a
+    // conditional policy elsewhere (Pixel does today, and OnePlus/HyperOS 3 will), because adaptive
+    // charging really does hold below full before the usual unplug, which is precisely when a user
+    // would reach for the gesture. The reason is narrower and specific to HyperOS 2: Adaptive is the
+    // ONLY protective mode this key domain offers, and its hold is unobserved on this generation (a
+    // 13T with Intelligent charging configured and verified charged 59%→100% with no hold at all,
+    // 2026-08-16). So the gesture would have nothing to lift on EVERY tick, not merely on some
+    // configurations, and a permanent foreground notification for a feature that can never do
+    // anything is worse than not offering it.
+    override val reconnectGestureSupport = ReconnectSupport.NONE
+
     override fun probe(device: DeviceInfo): AdapterSupport {
         val matched = device.manufacturer.equals("Xiaomi", ignoreCase = true) &&
             device.hyperOsVersion == QUALIFIED_HYPEROS_VERSION
@@ -149,6 +160,10 @@ class XiaomiHyperOs3ChargingAdapter @Inject constructor() : ChargingAdapter {
     // Intelligent charging's hold remains unobserved on both HyperOS generations.
     override val defaultProtectivePolicy = ChargePolicy.FixedLimit(CAP_PERCENT)
     override val verification = VerificationStrategy.SYNC_READBACK
+
+    // Unlike HyperOS 2 above, mode 2 is a real hard cap with demonstrated hardware enforcement, so
+    // there is something for the gesture to lift. No hold signal exists in `dumpsys battery`.
+    override val reconnectGestureSupport = ReconnectSupport.ANY_LEVEL_ONLY
 
     override fun probe(device: DeviceInfo): AdapterSupport {
         val matched = device.manufacturer.equals("Xiaomi", ignoreCase = true) &&

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/BootReceiver.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/BootReceiver.kt
@@ -47,7 +47,7 @@ class BootReceiver : BroadcastReceiver() {
                     adapterRegistry.select(
                         evidenceState = EnforcementEvidenceState.Loading,
                         qualification = QualificationEvidenceState.Loading,
-                    ).adapter?.reconnectGestureSupported == true
+                    ).adapter?.reconnectGestureSupport?.available == true
                 val mandatory = sessionExists || pendingRecovery || gestureEnabled
                 val action = ServiceDispatch.startAction(
                     trigger = trigger,

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/ChargeSessionService.kt
@@ -16,6 +16,9 @@ import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.amply.R
+import eu.darken.amply.common.ca.toCaString
+import eu.darken.amply.charging.core.ChargeObservation
+import eu.darken.amply.charging.core.adapter.VerificationStrategy
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.ChargingPreferences
 import eu.darken.amply.charging.core.ChargingRepository
@@ -574,7 +577,7 @@ class ChargeSessionService : Service() {
         // reuses this one.
         val gestureEnabled = fullChargeStore.isQuickFullChargeEnabled()
         val adapter = if (gestureEnabled) capabilityAdapter() else null
-        if (!gestureEnabled || adapter?.reconnectGestureSupported != true) {
+        if (!gestureEnabled || adapter?.reconnectGestureSupport?.available != true) {
             evaluateRules(plugged, plugKind, sessionActive = false)
             dispatchWatchers(plugged, percent, status, sessionOwned = false, battery, observedAtElapsed)
             // Gesture inactive: keep running only if a watcher still wants the service, showing the
@@ -599,16 +602,57 @@ class ChargeSessionService : Service() {
             return
         }
 
-        val anyLevel = fullChargeStore.isQuickFullChargeAnyLevel()
+        // On an ANY_LEVEL_ONLY adapter the limit-hold basis is unreachable by construction (no
+        // hardware hold signal), so the user's sub-option is not consulted: honouring an "off" there
+        // would leave the master switch on with no basis that can ever arm. Surfaces hide the
+        // sub-option on these adapters for the same reason.
+        val anyLevel = adapter.reconnectGestureSupport.impliesAnyLevel ||
+            fullChargeStore.isQuickFullChargeAnyLevel()
         // The live charging-policy hardware state, freshly decoded on every tick. It is the
         // authoritative source for the any-level basis: a limit set natively (or by a previous
         // install) leaves Amply's own journal empty, and gating on the journal alone meant the
         // basis never armed on such a device. The hardware signal is only reported while powered,
         // so unplugged ticks yield inconclusive evidence, which the engine treats as "no change".
         val hardware = adapter.decodeHardware(chargingStatus, plugged)
+        // Only sync-readback adapters answer (null elsewhere, so Pixel is untouched), and it is
+        // read only once the gesture is known to be enabled and available, keeping it off the
+        // session and watcher-only tick paths that the early returns above already left.
+        //
+        // A failed readback must degrade to "no settings evidence", never propagate: this runs on
+        // the dispatch path, and a thrown timeout would abort the whole battery evaluation — losing
+        // the plug edge that this very tick may be carrying, which is the one thing the gesture
+        // cannot reconstruct later. Falling through to the journal below is exactly the behaviour
+        // that shipped before this source existed, so degrading costs nothing that was ever there.
+        //
+        // `null` and "read failed" must NOT collapse into the same value here. `syncReadback()`
+        // returns null both for an adapter that has no sync source at all AND for one whose read
+        // threw or came back unreadable (`readObservationOrNull` swallows the failure), and those
+        // two mean opposite things downstream: the first legitimately hands the question to the
+        // write journal, while the second is a failure that must never be answered from a journal
+        // the readback exists to override. So a sync-readback adapter always contributes a non-null
+        // observation, falling back to an explicit Unknown, and only a non-sync adapter passes null.
+        val settings = if (anyLevel && adapter.verification == VerificationStrategy.SYNC_READBACK) {
+            val read = try {
+                repository.syncReadback()
+            } catch (e: TimeoutCancellationException) {
+                // Ordered before CancellationException on purpose: a Shizuku bind/command timeout
+                // IS one, and rethrowing it would reach DispatchCoordinator's cancellation rethrow
+                // and kill the battery-evaluation consumer for the rest of the service's life.
+                log(TAG, Logging.Priority.WARN) { "Gesture settings readback timed out" }
+                null
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, Logging.Priority.WARN) { "Gesture settings readback failed: ${e.message}" }
+                null
+            }
+            read ?: ChargeObservation.Unknown(R.string.charging_reason_settings_unreadable.toCaString())
+        } else {
+            null
+        }
         val lastPersistent = preferences.lastPersistentPolicyNow()
         val policyEvidence = if (anyLevel) {
-            GestureBasis.evidence(hardware, lastPersistent)
+            GestureBasis.evidence(hardware, settings, lastPersistent)
         } else {
             PolicyEvidence.UNKNOWN
         }
@@ -1099,10 +1143,11 @@ class ChargeSessionService : Service() {
             qualification = QualificationEvidenceState.Loading,
         ).adapter
 
-    // The gesture's arming preconditions (hardware charging-state 4) are Pixel-specific; on
-    // adapters without that signal the monitor would never arm and must not run.
+    // An adapter with no reachable arming basis would run the monitor forever without ever arming,
+    // so it must not run at all. NONE covers both reasons: nothing to lift (Adaptive-only) and a
+    // write that cannot land in time (policyLatchesAtPlug).
     private fun reconnectGestureAvailable() =
-        capabilityAdapter()?.reconnectGestureSupported == true
+        capabilityAdapter()?.reconnectGestureSupport?.available == true
 
     // Resolved once per service lifetime: adapter selection is immutable device information, and
     // per-tick selection is deliberately avoided in the session branch (see the note in

--- a/app/src/main/java/eu/darken/amply/fullcharge/core/GestureBasis.kt
+++ b/app/src/main/java/eu/darken/amply/fullcharge/core/GestureBasis.kt
@@ -7,13 +7,27 @@ import eu.darken.amply.charging.core.ChargePolicy
  * Turns what is actually known about the current charge configuration into the any-level gesture's
  * arming evidence, plus the limit to name in the waiting notification.
  *
- * [evidence] has two sources, in order ([limitPercent] has only the first — see below):
- * 1. [ChargeObservation.Verified] — the live hardware/settings readback. Conclusive on its own; the
- *    journal is not consulted at all, so a native change Amply never made still decides.
- * 2. `lastPersistentPolicy` — Amply's own journal of persistent writes. Null until Amply's first
+ * [evidence] has three sources, in order ([limitPercent] has only the first — see below):
+ * 1. `hardware` — the battery broadcast's charging-policy decode. Conclusive on its own; the
+ *    journal is not consulted at all, so a native change Amply never made still decides. Null on
+ *    every adapter that does not implement `decodeHardware`, i.e. everything but Pixel/GrapheneOS.
+ * 2. `settings` — the synchronous settings readback, and the ONLY conclusive source on the
+ *    `ReconnectSupport.ANY_LEVEL_ONLY` adapters, which publish no hold signal at all. Without it
+ *    those devices would arm purely off the journal below, so a limit removed in the OEM's own
+ *    settings would keep arming the gesture off a write Amply merely remembers making.
+ *
+ *    Null means "this adapter has NO sync source" — never "the read failed". The caller must keep
+ *    those apart, because `ChargingRepository.syncReadback()` itself returns null for both
+ *    (`readObservationOrNull` swallows a failed read), and they take opposite branches here: no
+ *    source hands the question to the journal, a failed read must not. Callers with a sync source
+ *    therefore substitute an explicit [ChargeObservation.Unknown] rather than passing null on.
+ * 3. `lastPersistentPolicy` — Amply's own journal of persistent writes. Null until Amply's first
  *    persistent write, which is exactly why it cannot be the only source: a limit set natively (or
  *    by a previous install) leaves it absent, and the any-level basis would never arm even though
  *    the limit genuinely is set.
+ *
+ * Sources 1 and 2 are never both present in practice (an adapter is either hardware-decoding or
+ * sync-readback), so their relative order is a formality rather than a policy choice.
  *
  * "Protective" is `!allowsFullCharge`, never `!= Unrestricted` — `PauseAtFull` and `FixedLimit(100)`
  * both reach 100 % and must not arm a gesture whose whole purpose is to lift a cap.
@@ -27,11 +41,12 @@ import eu.darken.amply.charging.core.ChargePolicy
  * configured now. A user who applied 80 % through Amply and then set the native charging setting to
  * unrestricted decodes as [ChargeObservation.Unknown] on Pixel's powered NORMAL state, so a journal
  * fallback would keep claiming a limit that no longer exists. Only a [ChargeObservation.Verified]
- * fixed limit may be named. In practice nothing loses a percentage it legitimately had: only the
- * Pixel and GrapheneOS adapters implement `decodeHardware`, and only Pixel supports the reconnect
- * gesture (GrapheneOS latches the setting at plug-session start, so the gesture's write-after-replug
- * can never take effect there) — an unverified state simply falls back to the generic "while your
- * charge limit is holding" copy.
+ * fixed limit may be named. It deliberately does NOT take the `settings` source [evidence] gained:
+ * every adapter that has one is `ReconnectSupport.ANY_LEVEL_ONLY`, where the notification renders
+ * the any-level copy and never names a percent, so feeding it here would add a value nothing reads
+ * while widening the input to the limit-hold basis's `verifiedLimitPercent`. On Pixel, where that
+ * basis does run, `syncReadback()` returns null anyway — an unverified state simply falls back to
+ * the generic "while your charge limit is holding" copy.
  *
  * Accepted residual (arming only, distinct from the above): with any-level ON, inconclusive hardware
  * evidence plus a stale protective journal still arms even if charging was since set unrestricted
@@ -42,20 +57,30 @@ import eu.darken.amply.charging.core.ChargePolicy
  */
 object GestureBasis {
 
-    fun evidence(hardware: ChargeObservation?, lastPersistent: ChargePolicy?): PolicyEvidence {
-        if (hardware is ChargeObservation.Verified) {
-            return if (hardware.policy.allowsFullCharge) {
-                PolicyEvidence.UNRESTRICTED
-            } else {
-                PolicyEvidence.PROTECTIVE
-            }
-        }
+    fun evidence(
+        hardware: ChargeObservation?,
+        settings: ChargeObservation?,
+        lastPersistent: ChargePolicy?,
+    ): PolicyEvidence {
+        (hardware as? ChargeObservation.Verified)?.let { return it.classify() }
+        // Asymmetric with `hardware` on purpose. A non-Verified hardware decode is an ORDINARY
+        // reading — the charging-policy state is absent while unplugged and ambiguous in the NORMAL
+        // state — so it falls through and the journal still answers, exactly as it did before this
+        // parameter existed. A non-null `settings` means the caller HAS a sync source and attempted
+        // it, so a non-Verified result there is a genuine failure, and answering a failed readback
+        // from the journal the readback exists to override is what would let a limit removed in the
+        // OEM's own settings keep arming the gesture. Inconclusive is the honest answer, and the
+        // engine already tolerates it everywhere it must (unplugged ticks and open windows).
+        settings?.let { return (it as? ChargeObservation.Verified)?.classify() ?: PolicyEvidence.UNKNOWN }
         return when {
             lastPersistent == null -> PolicyEvidence.UNKNOWN
             lastPersistent.allowsFullCharge -> PolicyEvidence.UNRESTRICTED
             else -> PolicyEvidence.PROTECTIVE
         }
     }
+
+    private fun ChargeObservation.Verified.classify(): PolicyEvidence =
+        if (policy.allowsFullCharge) PolicyEvidence.UNRESTRICTED else PolicyEvidence.PROTECTIVE
 
     /**
      * The limit percent to name in the waiting notification, or null when nothing *verified* says

--- a/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/MainActivity.kt
@@ -621,6 +621,7 @@ class MainActivity : ComponentActivity() {
                             // Exactly the dashboard card's gate, so settings can never switch the
                             // gesture on where the card correctly forbids it.
                             canEnableGesture = state.charging.reconnectSupported && state.charging.canApply,
+                            anyLevelOnly = state.charging.reconnectAnyLevelOnly,
                             availablePolicies = state.notificationActionPolicies,
                             selectedPolicyIds = state.notificationActionSelection,
                             onBack = { destination = SettingsDestination.SETTINGS },

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -329,13 +329,17 @@ fun DashboardScreen(
                             onOpen = onOpenConditions,
                         )
                     }
-                    // Hidden where the adapter lacks the gesture's hardware signal (non-Pixel) —
-                    // unless it is still switched on and needs a way to be turned off.
+                    // Hidden where the adapter has no reachable arming basis at all — unless it is
+                    // still switched on and needs a way to be turned off.
                     if (state.charging.reconnectSupported || state.quickFullChargeEnabled) {
                         item(key = "dashboard.reconnect") {
                             QuickFullChargeCard(
                                 enabled = state.quickFullChargeEnabled,
-                                anyLevel = state.quickFullChargeAnyLevel,
+                                // The *effective* basis, not the stored sub-option: where the
+                                // limit-hold basis cannot arm, the gesture runs any-level whatever
+                                // the setting says, and the body copy has to describe that.
+                                anyLevel = state.quickFullChargeAnyLevel ||
+                                    state.charging.reconnectAnyLevelOnly,
                                 canControl = state.charging.reconnectSupported && state.charging.canApply,
                                 onEnabledChange = onQuickFullChargeChange,
                             )

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -839,6 +839,11 @@ private fun QuickFullChargeCard(
             when {
                 enabled && anyLevel -> stringResource(R.string.dashboard_reconnect_body_on_any_level)
                 enabled -> stringResource(R.string.dashboard_reconnect_body_on)
+                // The off-state has to describe the basis this device would actually use. Naming
+                // the hold where it can never happen was wrong twice over on a legacy Samsung: it
+                // promised a hold the ROM does not report, and named 80% next to that device's
+                // real 85% limit shown one card above.
+                anyLevel -> stringResource(R.string.dashboard_reconnect_body_off_any_level)
                 else -> stringResource(R.string.dashboard_reconnect_body_off)
             },
             style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/eu/darken/amply/main/ui/settings/ChargingSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/settings/ChargingSettingsScreen.kt
@@ -41,6 +41,7 @@ import eu.darken.amply.common.settings.SettingsSwitchItem
 fun ChargingSettingsScreen(
     gestureEnabled: Boolean,
     anyLevelEnabled: Boolean,
+    anyLevelOnly: Boolean,
     canEnableGesture: Boolean,
     availablePolicies: List<ChargePolicy>,
     selectedPolicyIds: List<String>,
@@ -83,20 +84,34 @@ fun ChargingSettingsScreen(
                 icon = Icons.TwoTone.Bolt,
                 enabled = masterInteractive,
             )
-            SettingsSwitchItem(
-                title = stringResource(R.string.settings_reconnect_any_level_title),
-                subtitle = stringResource(R.string.settings_reconnect_any_level_body),
-                checked = anyLevelEnabled,
-                onCheckedChange = onAnyLevelChange,
-                icon = Icons.TwoTone.BatteryChargingFull,
-                enabled = gestureEnabled,
-            )
-            Text(
-                stringResource(R.string.settings_reconnect_any_level_hint),
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            // On an any-level-only adapter this is not a choice: the limit-hold alternative needs a
+            // hardware hold signal the device never reports, so the gesture already runs any-level.
+            // Offering a switch that changes nothing (and whose "off" position describes a mode that
+            // cannot arm) would be worse than a shorter screen, so the row and its hint go away and
+            // a single line states the behaviour instead.
+            if (anyLevelOnly) {
+                Text(
+                    stringResource(R.string.settings_reconnect_any_level_only_hint),
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                SettingsSwitchItem(
+                    title = stringResource(R.string.settings_reconnect_any_level_title),
+                    subtitle = stringResource(R.string.settings_reconnect_any_level_body),
+                    checked = anyLevelEnabled,
+                    onCheckedChange = onAnyLevelChange,
+                    icon = Icons.TwoTone.BatteryChargingFull,
+                    enabled = gestureEnabled,
+                )
+                Text(
+                    stringResource(R.string.settings_reconnect_any_level_hint),
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             if (availablePolicies.size > 2 && masterInteractive) {
                 SettingsCategoryHeader(
                     stringResource(R.string.settings_reconnect_notification_actions_category),
@@ -129,6 +144,7 @@ private fun ChargingSettingsScreenPreview() = PreviewWrapper {
     ChargingSettingsScreen(
         gestureEnabled = true,
         anyLevelEnabled = true,
+        anyLevelOnly = false,
         canEnableGesture = true,
         availablePolicies = binaryPolicies,
         selectedPolicyIds = binaryPolicies.map { it.stableId },
@@ -145,6 +161,7 @@ private fun ChargingSettingsScreenDisabledPreview() = PreviewWrapper {
     ChargingSettingsScreen(
         gestureEnabled = false,
         anyLevelEnabled = false,
+        anyLevelOnly = false,
         canEnableGesture = true,
         availablePolicies = binaryPolicies,
         selectedPolicyIds = binaryPolicies.map { it.stableId },
@@ -161,6 +178,7 @@ private fun ChargingSettingsScreenUnavailablePreview() = PreviewWrapper {
     ChargingSettingsScreen(
         gestureEnabled = false,
         anyLevelEnabled = false,
+        anyLevelOnly = false,
         canEnableGesture = false,
         availablePolicies = emptyList(),
         selectedPolicyIds = emptyList(),
@@ -178,6 +196,7 @@ private fun ChargingSettingsScreenWithNotificationButtonsPreview() = PreviewWrap
     ChargingSettingsScreen(
         gestureEnabled = true,
         anyLevelEnabled = false,
+        anyLevelOnly = false,
         canEnableGesture = true,
         availablePolicies = listOf(
             ChargePolicy.FixedLimit(80),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -549,6 +549,7 @@
     <string name="settings_reconnect_notification_actions_category">Notification buttons</string>
     <string name="settings_reconnect_notification_actions_hint">Pick up to three charge modes. They appear as buttons on the reconnect-gesture notification and switch your charging permanently.</string>
     <string name="settings_reconnect_any_level_hint">More sensitive: any unplug/replug of 2–10 seconds starts a full charge, e.g. also below 80%. Momentary power cuts shorter than 2 seconds, like a car cutting USB power while starting, never trigger.</string>
+    <string name="settings_reconnect_any_level_only_hint">This device reports when a charge limit is set, but not when it is actively holding, so the gesture works at any charge level while a limit is active.</string>
     <string name="dashboard_shizuku_title">Better with Shizuku</string>
     <string name="dashboard_shizuku_body">Shizuku gives Amply exact policy readback instead of relying on hardware state and the last request.</string>
     <string name="dashboard_shizuku_required_title">Shizuku required to change charging</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,7 +64,7 @@
     <string name="onboarding_feature_fullcharge_title">Charge fully once</string>
     <string name="onboarding_feature_fullcharge_body">Protection returns automatically at full or when unplugged.</string>
     <string name="onboarding_feature_shortcut_title">Optional reconnect gesture</string>
-    <string name="onboarding_feature_shortcut_body" formatted="false">Reconnect at the 80% hold to request one full charge.</string>
+    <string name="onboarding_feature_shortcut_body">Unplug and reconnect quickly to request one full charge.</string>
     <string name="onboarding_next_action">Next</string>
     <string name="onboarding_continue_action">Get started</string>
     <string name="onboarding_caveats_title">Before you start</string>
@@ -536,7 +536,8 @@
     <string name="dashboard_reconnect_title">Reconnect gesture</string>
     <string name="dashboard_reconnect_body_on" formatted="false">At the 80% limit, unplug for at least 2 seconds and reconnect within 10. An ongoing notification keeps the gesture reliable.</string>
     <string name="dashboard_reconnect_body_on_any_level">At any charge level while a protective policy is set, unplug for at least 2 seconds and reconnect within 10. An ongoing notification keeps the gesture reliable.</string>
-    <string name="dashboard_reconnect_body_off" formatted="false">Optionally use a quick unplug/replug at the 80% limit to charge fully once.</string>
+    <string name="dashboard_reconnect_body_off">Optionally use a quick unplug/replug while your charge limit is holding to charge fully once.</string>
+    <string name="dashboard_reconnect_body_off_any_level">Optionally use a quick unplug/replug at any charge level to charge fully once.</string>
     <string name="settings_charging_title">Charging</string>
     <string name="settings_charging_subtitle_on">Reconnect gesture on</string>
     <string name="settings_charging_subtitle_off">Reconnect gesture off</string>

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapterTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapterTest.kt
@@ -177,7 +177,7 @@ class GrapheneOsChargingAdapterTest {
         adapter.defaultProtectivePolicy shouldBe ChargePolicy.FixedLimit(80)
         adapter.verification shouldBe VerificationStrategy.SYNC_READBACK
         adapter.policyLatchesAtPlug shouldBe true
-        adapter.reconnectGestureSupported shouldBe false
+        adapter.reconnectGestureSupport shouldBe ReconnectSupport.NONE
         // Not a namespace need: the key is @Protected and only the shell UID (Shizuku) may touch it.
         adapter.preferShizukuForWrites shouldBe true
     }

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapterTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/LineageChargingAdapterTest.kt
@@ -166,7 +166,7 @@ class LineageChargingAdapterTest {
         adapter.defaultProtectivePolicy shouldBe ChargePolicy.FixedLimit(80)
         adapter.verification shouldBe VerificationStrategy.SYNC_READBACK
         adapter.preferShizukuForWrites shouldBe true
-        adapter.reconnectGestureSupported shouldBe false
+        adapter.reconnectGestureSupport shouldBe ReconnectSupport.ANY_LEVEL_ONLY
     }
 
     /** One fake serving BOTH the write backend and the read snapshot from a shared map — mirrors the real

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/OnePlusChargingAdapterTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/OnePlusChargingAdapterTest.kt
@@ -138,7 +138,7 @@ class OnePlusChargingAdapterTest {
         adapter.defaultProtectivePolicy shouldBe ChargePolicy.FixedLimit(80)
         adapter.verification shouldBe VerificationStrategy.SYNC_READBACK
         adapter.preferShizukuForWrites shouldBe true
-        adapter.reconnectGestureSupported shouldBe false
+        adapter.reconnectGestureSupport shouldBe ReconnectSupport.ANY_LEVEL_ONLY
         // ColorOS exposes Smart charging (adaptive) too, but the default is the unconditional cap.
         adapter.defaultProtectivePolicy.enforcementIsConditional shouldBe false
     }

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/SamsungChargingAdaptersTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/SamsungChargingAdaptersTest.kt
@@ -229,8 +229,8 @@ class SamsungChargingAdaptersTest {
         legacy.defaultProtectivePolicy shouldBe ChargePolicy.FixedLimit(85)
         modern.verification shouldBe VerificationStrategy.SYNC_READBACK
         legacy.verification shouldBe VerificationStrategy.SYNC_READBACK
-        modern.reconnectGestureSupported shouldBe false
-        legacy.reconnectGestureSupported shouldBe false
+        modern.reconnectGestureSupport shouldBe ReconnectSupport.ANY_LEVEL_ONLY
+        legacy.reconnectGestureSupport shouldBe ReconnectSupport.ANY_LEVEL_ONLY
     }
 
     private class FakeBackend(

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/XiaomiChargingAdapterTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/XiaomiChargingAdapterTest.kt
@@ -128,7 +128,7 @@ class XiaomiChargingAdapterTest {
         adapter.sessionOverridePolicy shouldBe ChargePolicy.Unrestricted
         adapter.defaultProtectivePolicy shouldBe ChargePolicy.Adaptive
         adapter.verification shouldBe VerificationStrategy.SYNC_READBACK
-        adapter.reconnectGestureSupported shouldBe false
+        adapter.reconnectGestureSupport shouldBe ReconnectSupport.NONE
         // The only adapter whose protective default is conditional, and unavoidably so: HyperOS 2's
         // {0,1} domain offers no unconditional protective mode. Presentation carries the honesty.
         adapter.defaultProtectivePolicy.enforcementIsConditional shouldBe true

--- a/app/src/test/java/eu/darken/amply/charging/core/adapter/XiaomiHyperOs3ChargingAdapterTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/adapter/XiaomiHyperOs3ChargingAdapterTest.kt
@@ -143,7 +143,7 @@ class XiaomiHyperOs3ChargingAdapterTest {
         adapter.sessionOverridePolicy shouldBe ChargePolicy.Unrestricted
         adapter.defaultProtectivePolicy shouldBe ChargePolicy.FixedLimit(80)
         adapter.verification shouldBe VerificationStrategy.SYNC_READBACK
-        adapter.reconnectGestureSupported shouldBe false
+        adapter.reconnectGestureSupport shouldBe ReconnectSupport.ANY_LEVEL_ONLY
         adapter.preferShizukuForWrites shouldBe false
         adapter.policyLatchesAtPlug shouldBe false
         // Unlike HyperOS 2, this ROM has an unconditional protective mode (Battery protection), so

--- a/app/src/test/java/eu/darken/amply/fullcharge/core/GestureBasisTest.kt
+++ b/app/src/test/java/eu/darken/amply/fullcharge/core/GestureBasisTest.kt
@@ -12,33 +12,91 @@ class GestureBasisTest {
     private fun verified(policy: ChargePolicy) =
         ChargeObservation.Verified(policy, BackendKind.BATTERY_HARDWARE)
 
+    /** What a sync-readback adapter (Samsung/OnePlus/Xiaomi HyperOS 3/LineageOS) contributes. */
+    private fun readback(policy: ChargePolicy) =
+        ChargeObservation.Verified(policy, BackendKind.DIRECT_WSS)
+
     @Test
     fun `a verified observation decides on its own`() {
         val staleJournal = ChargePolicy.FixedLimit(80)
-        GestureBasis.evidence(verified(ChargePolicy.FixedLimit(80)), null) shouldBe PolicyEvidence.PROTECTIVE
-        GestureBasis.evidence(verified(ChargePolicy.Adaptive), null) shouldBe PolicyEvidence.PROTECTIVE
+        GestureBasis.evidence(verified(ChargePolicy.FixedLimit(80)), null, null) shouldBe PolicyEvidence.PROTECTIVE
+        GestureBasis.evidence(verified(ChargePolicy.Adaptive), null, null) shouldBe PolicyEvidence.PROTECTIVE
         // The journal must not rescue an observation that conclusively reaches 100%.
-        GestureBasis.evidence(verified(ChargePolicy.Unrestricted), staleJournal) shouldBe
+        GestureBasis.evidence(verified(ChargePolicy.Unrestricted), null, staleJournal) shouldBe
             PolicyEvidence.UNRESTRICTED
-        GestureBasis.evidence(verified(ChargePolicy.PauseAtFull), staleJournal) shouldBe
+        GestureBasis.evidence(verified(ChargePolicy.PauseAtFull), null, staleJournal) shouldBe
             PolicyEvidence.UNRESTRICTED
-        GestureBasis.evidence(verified(ChargePolicy.FixedLimit(100)), staleJournal) shouldBe
+        GestureBasis.evidence(verified(ChargePolicy.FixedLimit(100)), null, staleJournal) shouldBe
             PolicyEvidence.UNRESTRICTED
     }
 
     @Test
     fun `without hardware evidence the journal answers`() {
-        GestureBasis.evidence(null, ChargePolicy.FixedLimit(80)) shouldBe PolicyEvidence.PROTECTIVE
-        GestureBasis.evidence(null, ChargePolicy.Unrestricted) shouldBe PolicyEvidence.UNRESTRICTED
+        GestureBasis.evidence(null, null, ChargePolicy.FixedLimit(80)) shouldBe PolicyEvidence.PROTECTIVE
+        GestureBasis.evidence(null, null, ChargePolicy.Unrestricted) shouldBe PolicyEvidence.UNRESTRICTED
     }
 
     @Test
     fun `nothing known is inconclusive, not unrestricted`() {
-        GestureBasis.evidence(null, null) shouldBe PolicyEvidence.UNKNOWN
+        GestureBasis.evidence(null, null, null) shouldBe PolicyEvidence.UNKNOWN
         GestureBasis.evidence(
+            ChargeObservation.Unknown("no readback".toCaString()),
             ChargeObservation.Unknown("no readback".toCaString()),
             null,
         ) shouldBe PolicyEvidence.UNKNOWN
+    }
+
+    @Test
+    fun `the settings readback answers where no hardware signal exists`() {
+        // The ANY_LEVEL_ONLY adapters' only conclusive source. Without it these arm off the journal
+        // alone, so a limit removed in the OEM's settings would keep arming the gesture.
+        val staleJournal = ChargePolicy.FixedLimit(80)
+        GestureBasis.evidence(null, readback(ChargePolicy.FixedLimit(80)), null) shouldBe
+            PolicyEvidence.PROTECTIVE
+        GestureBasis.evidence(null, readback(ChargePolicy.Unrestricted), staleJournal) shouldBe
+            PolicyEvidence.UNRESTRICTED
+        GestureBasis.evidence(null, readback(ChargePolicy.PauseAtFull), staleJournal) shouldBe
+            PolicyEvidence.UNRESTRICTED
+        // A FAILED read must not be answered from the journal. This is the whole point of the
+        // source: the journal says "Amply last wrote a limit", which is exactly the claim a
+        // readback exists to override, so trusting it here would keep arming the gesture after the
+        // user removed the limit in the OEM's own settings. Inconclusive is the honest answer, and
+        // it costs only a re-arm on the next tick that reads successfully.
+        GestureBasis.evidence(
+            null,
+            ChargeObservation.Unknown("no readback".toCaString()),
+            staleJournal,
+        ) shouldBe PolicyEvidence.UNKNOWN
+    }
+
+    // The asymmetry between the two conclusive sources, pinned: a non-Verified HARDWARE decode is an
+    // ordinary reading (no charging-policy state while unplugged, ambiguous in NORMAL), so it still
+    // falls through to the journal — Pixel depends on that and must not change.
+    @Test
+    fun `an inconclusive hardware decode still falls through to the journal`() {
+        GestureBasis.evidence(
+            ChargeObservation.Unknown("powered NORMAL".toCaString()),
+            null,
+            ChargePolicy.FixedLimit(80),
+        ) shouldBe PolicyEvidence.PROTECTIVE
+    }
+
+    // Null settings means "no sync source on this adapter", which is not a failure and hands the
+    // question to the journal as before. Only a non-null non-Verified is a failed read.
+    @Test
+    fun `no sync source is not a failed read`() {
+        GestureBasis.evidence(null, null, ChargePolicy.FixedLimit(80)) shouldBe PolicyEvidence.PROTECTIVE
+    }
+
+    @Test
+    fun `limitPercent is source-agnostic, the caller is what withholds the readback`() {
+        // limitPercent itself only asks whether the observation is Verified, so a settings readback
+        // would name a percent perfectly well. What is deliberate lives one level up: the service
+        // passes only the hardware decode, because every adapter that has a readback renders the
+        // any-level copy and never names a percent, and feeding it here would also widen the
+        // limit-hold basis's `verifiedLimitPercent` input.
+        GestureBasis.limitPercent(readback(ChargePolicy.FixedLimit(80))) shouldBe 80
+        GestureBasis.limitPercent(null) shouldBe null
     }
 
     @Test

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenGestureTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardScreenGestureTest.kt
@@ -76,6 +76,49 @@ class DashboardScreenGestureTest {
         compose.onAllNodesWithContentDescription(string(R.string.action_settings)).assertCountEquals(1)
     }
 
+    // Found on a real SM-G781B: the off-state copy promised a hold that One UI never reports AND
+    // named 80% while the card directly above it read "85% limit". An adapter that can only arm
+    // any-level must describe that, in the off state too.
+    @Test
+    fun `an any-level-only device describes the basis it will actually use`() {
+        render(
+            state = DashboardUiState(
+                onboardingComplete = true,
+                quickFullChargeEnabled = false,
+                charging = ChargingState(
+                    adapterResolved = true,
+                    reconnectSupported = true,
+                    reconnectAnyLevelOnly = true,
+                ),
+            ),
+        )
+
+        compose.onNode(hasScrollAction())
+            .performScrollToNode(hasText(string(R.string.dashboard_reconnect_title)))
+        compose.onNodeWithText(string(R.string.dashboard_reconnect_body_off_any_level)).assertExists()
+        compose.onAllNodesWithText(string(R.string.dashboard_reconnect_body_off)).assertCountEquals(0)
+    }
+
+    // The hold wording survives where the hold can actually happen (Pixel with the sub-option off).
+    @Test
+    fun `a full-support device keeps the limit-hold wording`() {
+        render(
+            state = DashboardUiState(
+                onboardingComplete = true,
+                quickFullChargeEnabled = false,
+                charging = ChargingState(
+                    adapterResolved = true,
+                    reconnectSupported = true,
+                    reconnectAnyLevelOnly = false,
+                ),
+            ),
+        )
+
+        compose.onNode(hasScrollAction())
+            .performScrollToNode(hasText(string(R.string.dashboard_reconnect_title)))
+        compose.onNodeWithText(string(R.string.dashboard_reconnect_body_off)).assertExists()
+    }
+
     @Test
     fun `the hero states the policy and is not a navigation surface`() {
         render(

--- a/app/src/test/java/eu/darken/amply/main/ui/settings/ChargingSettingsScreenTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/settings/ChargingSettingsScreenTest.kt
@@ -39,6 +39,7 @@ class ChargingSettingsScreenTest {
     private fun screen(
         gestureEnabled: Boolean = true,
         anyLevelEnabled: Boolean = false,
+        anyLevelOnly: Boolean = false,
         canEnableGesture: Boolean = true,
         availablePolicies: List<ChargePolicy> = emptyList(),
         selectedPolicyIds: List<String> = emptyList(),
@@ -50,6 +51,7 @@ class ChargingSettingsScreenTest {
         ChargingSettingsScreen(
             gestureEnabled = gestureEnabled,
             anyLevelEnabled = anyLevelEnabled,
+            anyLevelOnly = anyLevelOnly,
             canEnableGesture = canEnableGesture,
             availablePolicies = availablePolicies,
             selectedPolicyIds = selectedPolicyIds,
@@ -116,6 +118,29 @@ class ChargingSettingsScreenTest {
         compose.onNodeWithText(string(R.string.settings_reconnect_any_level_title)).performClick()
 
         compose.runOnIdle { changed shouldBe null }
+    }
+
+    // On an ANY_LEVEL_ONLY adapter the gesture already runs any-level, so the sub-option is not a
+    // choice: the row must not render at all, and the master toggle must stay usable on its own.
+    @Test
+    fun `an any-level-only device replaces the sub-option with a statement`() {
+        screen(anyLevelOnly = true)
+
+        compose.onNodeWithText(string(R.string.settings_reconnect_any_level_title)).assertDoesNotExist()
+        compose.onNodeWithText(string(R.string.settings_reconnect_any_level_hint)).assertDoesNotExist()
+        compose.onNodeWithText(string(R.string.settings_reconnect_any_level_only_hint))
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `an any-level-only device still switches the gesture itself`() {
+        var changed: Boolean? = null
+        screen(anyLevelOnly = true, gestureEnabled = false, onGestureEnabledChange = { changed = it })
+
+        compose.onNodeWithText(string(R.string.settings_reconnect_enabled_title)).performClick()
+
+        compose.runOnIdle { changed shouldBe true }
     }
 
     @Test


### PR DESCRIPTION
## What changed

The reconnect gesture (a quick unplug and replug that starts a one-time full charge) is now available on Samsung, OnePlus/Oppo/Realme, Xiaomi HyperOS 3 and LineageOS, where it was previously hidden and only offered on Pixel.

On those devices the gesture works whenever a protective charge policy is set, at any battery level, because they report that a limit is configured but never that it is actively holding. The app says so on the dashboard card and in Settings > Charging, and the "Any charge level" sub-switch does not appear there since it is the only mode those devices can use.

It stays unavailable on GrapheneOS, where the charge limit is read once when the cable goes in, so the gesture's change could not take effect until the next replug. It also stays unavailable on Xiaomi HyperOS 2, whose only protective mode has never been observed to hold the battery, leaving the gesture nothing to lift.

Pixel behaviour is unchanged, including the opt-in "Any charge level" switch.

## Technical Context

- `ChargingAdapter.reconnectGestureSupported: Boolean` becomes `reconnectGestureSupport: ReconnectSupport` (NONE / ANY_LEVEL_ONLY / FULL). The boolean predated the any-level basis and gated the feature before that path was ever consulted; the limit-hold basis genuinely cannot arm off-Pixel, because it reads `EXTRA_CHARGING_STATUS == 4` and only Pixel and GrapheneOS implement `decodeHardware`. Confirmed on hardware: an SM-X210 capping at 80% reports `Charging state: 0`.
- On `ANY_LEVEL_ONLY` the any-level basis is forced on regardless of the stored sub-setting. Honouring an "off" there would leave the master toggle on with no basis that could ever arm, which is the failure this change exists to remove.
- `GestureBasis.evidence()` gains the synchronous settings readback as a second conclusive source. This is load-bearing, not defensive: on a fresh install the write journal is empty, and the device pass shows `policyEvidence=PROTECTIVE` arriving with no journal to read, so without it the gesture would never arm on a device Amply had not yet written to.
- The readback's null is overloaded and the caller must disambiguate it. `syncReadback()` returns null both for "this adapter has no sync source" and for "the read failed" (`readObservationOrNull` swallows the failure), and those take opposite branches: no source hands the question to the journal, a failed read must not, or a limit removed in the OEM's own settings would keep arming the gesture. Sync-readback adapters therefore always pass an observation, substituting an explicit `Unknown`. A non-Verified *hardware* decode deliberately still falls through, being an ordinary reading that Pixel depends on.
- Worth reviewing closely: the readback runs on the dispatch path, so its failure must degrade rather than propagate. `TimeoutCancellationException` is a `CancellationException`, `DispatchCoordinator` rethrows those, and that would kill the battery-evaluation consumer for the life of the service and strand a later session with no restore ticks. The catch is ordered accordingly.
- Being `enforcementIsConditional` is deliberately *not* disqualifying. Pixel arms on Adaptive today, and OnePlus and HyperOS 3 now will too, since adaptive charging does hold below full before the usual unplug. HyperOS 2 is excluded on the narrower ground that Adaptive is its only protective mode and its hold is unobserved there.
- Verified on device. Simulated plug transitions (`dumpsys battery`) on Tab A9+ (One UI 8), S20 FE (One UI 4.1) and Pixel 8 as a regression: arm, trigger, session override and restore to the exact prior policy, with the Pixel still arming on the limit-hold basis (`anyLevelBasis=false`).
- Confirmed with a real cable pull on the S20 FE, which is the part a simulation cannot reach since it moves no current. Unplug to replug 7.8s; `protect_battery` 1 to 0; charge current +647mA and the level climbed 84 to 86, past the 85% cap; restore wrote 1 back and the current inverted to -357mA at the same 86%. So the cap is hardware-enforced and the gesture genuinely lifts it.

## Test coverage, stated plainly

Real-current behaviour is proven on the Samsung **legacy** adapter only. Samsung modern was simulated; OnePlus/ColorOS, Xiaomi HyperOS 3 and LineageOS are untested here because no such device was available.

That is considered acceptable rather than ignored: the gesture's write is the same `sessionOverridePolicy` write that the already-shipped "Charge to 100% once" session performs on those adapters, and each is qualified for that in the ledger. This PR changes *when* the write is triggered, not what it does, so it introduces no new per-OEM hardware risk. What would still be worth a real-cable pass, if one of those devices turns up, is Samsung modern's `PauseAtFull` override, which is the one session-override policy that differs from the plain Unrestricted write the others use.
