### PR TITLE
Charging: Don't call a GrapheneOS charge limit active until confirmed

### DIFF
--- a/.claude/skills/device-qualification/SKILL.md
+++ b/.claude/skills/device-qualification/SKILL.md
@@ -206,11 +206,15 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
         only suppressors are unplugged samples, a running Amply full-charge session, and a guided run — a ROM
         charging past a cap it still honours is none of those. A refutation is terminal for the build identity,
         so the first recalibration would switch the controls off on a device whose cap works, permanently.
-    - **The protective direction is UNTESTED, and it is the open safety question.** Both observed failures wrote
+    - **The protective direction is UNRESOLVED, and it is the open safety question.** Both observed failures wrote
       the limit *off* while the ROM kept enforcing, which leaves the battery protected and merely makes the UI
       dishonest. Whether a write turning the limit *on* is equally ignored — which would mean Amply claims
-      protection that is not enforced — has never been run by anyone. Asked of the reporter 2026-08-25. Do not
-      widen, re-qualify, or relax anything on this ROM until it is answered.
+      protection that is not enforced — was asked of the reporter 2026-08-25 and **run on 2026-08-27**: the
+      battery charged past a cap that had been written externally moments earlier. That **settles nothing**. The
+      result is equally consistent with the ROM ignoring the external write and with the periodic recalibration
+      charge to 100% described above, which climbs past a cap the ROM *is* honouring, and no signal in the run
+      separates the two. Treat the question as open. Do not widen, re-qualify, or relax anything on this ROM
+      until it is answered.
   - **State 4 below the limit unverified** — evidence was sampled at the 80% hold; if the ROM reports 4 only while
     holding, a FixedLimit pending clears late (at the hold) instead of instantly. Cosmetic.
   - **A plugged restore configures but cannot enforce** — restore-at-100%, the 24h safety timeout,

--- a/.claude/skills/device-qualification/SKILL.md
+++ b/.claude/skills/device-qualification/SKILL.md
@@ -200,6 +200,12 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
       reason (a matching settings readback is treated as convergence). Nothing in the app can notice: this adapter
       does not set `enforcementEvidenceRequired`, and the passive verdict engine only detects a climb *past* a
       cap, which is the opposite direction from a ROM enforcing a cap that is configured off.
+      - **Do not answer this by setting `enforcementEvidenceRequired` on the adapter.** Beyond the direction
+        mismatch above, GrapheneOS deliberately runs a periodic recalibration charge to 100% with the limit still
+        on. `EnforcementVerdictEngine` refutes on `climbRose && percent >= cap + OVERSHOOT_ALLOWANCE`, and its
+        only suppressors are unplugged samples, a running Amply full-charge session, and a guided run — a ROM
+        charging past a cap it still honours is none of those. A refutation is terminal for the build identity,
+        so the first recalibration would switch the controls off on a device whose cap works, permanently.
     - **The protective direction is UNTESTED, and it is the open safety question.** Both observed failures wrote
       the limit *off* while the ROM kept enforcing, which leaves the battery protected and merely makes the UI
       dishonest. Whether a write turning the limit *on* is equally ignored — which would mean Amply claims
@@ -213,6 +219,13 @@ only after adding a row here. Detailed run narratives live in each adapter's lan
     (mid-session writes are ignored by design). Amply's state is correct — config protective,
     session/recovery closed, pending-until-replug hint shown — and the exposure is one charge cycle,
     bounded by the plug session the user is already in. Deliberately NOT treated as a defect.
+  - **A write made while unplugged had no honest state either** — the entry above is about writes made *during*
+    a plug session, which do get the pending-until-replug hint (`settled` requires a hardware confirmation
+    whenever the write was not demonstrably made unplugged). A write made unplugged counts as settled, so the
+    replug that follows produced a plain settings read-back and the app called that verified — exactly the claim
+    `frankel` refutes. Now a configured cap that the hardware has not confirmed is shown as set rather than in
+    effect, and the apply message says the value was saved instead of verified. This is a presentation fix only:
+    nothing here can tell the two ROM behaviours apart, so the honest state is "unconfirmed" on both.
   - **Wireless charging and secondary users**: NOT RUN (gated to system user).
 - **Oplus (OnePlus/Oppo/Realme)** — the live gate reads `ro.build.version.oplusrom`, which **does not exist on
   pre-rebrand ColorOS**, so every ColorOS 11-era build is invisible to it and lands on `OnePlusLabAdapter`. This is

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -439,14 +439,16 @@ class ChargingRepository @Inject constructor(
         if (adapter == null || !selection.support.controlEnabled) {
             val detail = selection.support.detail.toCaString()
             val observation = ChargeObservation.Unsupported(detail)
-            // Also drop the standing ready note and any hardware-unconfirmed warning: this branch
-            // means the gate just failed on a fresh selection (a capability can vanish between
-            // refresh and tap), and both fields' contracts exclude Unsupported states.
+            // Also drop the standing ready note, any hardware-unconfirmed warning and the
+            // awaiting-hardware-confirmation cap claim: this branch means the gate just failed on a
+            // fresh selection (a capability can vanish between refresh and tap), and all three
+            // fields' contracts exclude Unsupported states.
             mutableState.value = state.value.copy(
                 observation = observation,
                 message = detail,
                 adapterDetail = null,
                 unconfirmedTarget = null,
+                capAwaitsHardwareConfirmation = false,
             )
             return ApplyResult(false, observation, context.getString(selection.support.detail))
         }
@@ -472,8 +474,10 @@ class ChargingRepository @Inject constructor(
             mutableState.value = state.value.copy(
                 observation = observation,
                 message = R.string.charging_message_setup_required.toCaString(),
-                // NeedsSetup never warns (detector contract); drop a now-contradictory stale warning.
+                // NeedsSetup never warns (detector contract) and has no configured cap to qualify;
+                // drop both now-contradictory stale claims.
                 unconfirmedTarget = null,
+                capAwaitsHardwareConfirmation = false,
             )
             return ApplyResult(false, observation, "Setup required")
         }
@@ -506,14 +510,15 @@ class ChargingRepository @Inject constructor(
             log(TAG, Logging.Priority.ERROR) { "Settings write failed for ${policy.stableId}" }
             val observation = ChargeObservation.Unknown(R.string.charging_reason_write_failed.toCaString())
             // Clear any stale pending so the failure is not masked by a prior request's "applying…" cue.
-            // The old unconfirmed warning goes too: a multi-key write can fail after partially changing
-            // configuration, so the previous target is no longer a safe standing claim — the next
-            // refresh recomputes from live evidence.
+            // The old unconfirmed warning and the awaiting-hardware-confirmation cap claim go too: a
+            // multi-key write can fail after partially changing configuration, so the previous target
+            // is no longer a safe standing claim — the next refresh recomputes from live evidence.
             mutableState.value = state.value.copy(
                 busy = false,
                 observation = observation,
                 pending = null,
                 unconfirmedTarget = null,
+                capAwaitsHardwareConfirmation = false,
                 message = R.string.charging_message_write_failed.toCaString(),
             )
             return ApplyResult(false, observation, "Write failed")

--- a/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/ChargingRepository.kt
@@ -85,6 +85,12 @@ data class ChargingState(
     val syncVerification: Boolean = false,
     /** True when applying a policy needs Shizuku (system-namespace adapter WSS can't write). */
     val writeRequiresShizuku: Boolean = false,
+    /**
+     * A cap is configured and reads back, but the charging hardware has not confirmed it, on an
+     * adapter that samples the policy at plug-session start. Surfaces must present the cap as set
+     * rather than as in effect while this holds — the read-back proves storage, not enforcement.
+     */
+    val capAwaitsHardwareConfirmation: Boolean = false,
     val controlEnabled: Boolean = false,
     /**
      * Where this device sits on the "does the hardware actually enforce the cap" question, or null
@@ -516,8 +522,17 @@ class ChargingRepository @Inject constructor(
         // The physical write committed. Record it durably even under cancellation (the setting already
         // changed), and never strand busy=true nor lose the fact that the write landed. Unplugged is
         // only trusted when the samples on BOTH sides of the write agree (see pluggedBeforeWrite).
+        //
+        // ONE readout for everything hardware-derived below: plug state and the hardware decode must
+        // join on the same observation (BatteryReader's doc — never pair plug state across two sticky
+        // reads). Only taken on the latched path, the only one that consults either.
+        val afterWrite: BatteryReadout? = if (adapter.policyLatchesAtPlug) {
+            runCatching { batteryReader.read() }.getOrNull()
+        } else {
+            null
+        }
         val pluggedAtWrite: Boolean? = if (adapter.policyLatchesAtPlug) {
-            val after = runCatching { batteryReader.read().plugged?.let { it != 0 } }.getOrNull()
+            val after = afterWrite?.plugged?.let { it != 0 }
             if (pluggedBeforeWrite == false && after == false) false else true
         } else {
             null
@@ -532,14 +547,17 @@ class ChargingRepository @Inject constructor(
                 VerificationStrategy.ASYNC_HARDWARE ->
                     if (access.shizuku.ready) adapter.read(accessResolver.shizuku) else null
             } as? ChargeObservation.Verified ?: ChargeObservation.LastRequested(policy)
+            // Null off the latched path, where nothing reads it: the async arm below keeps its own
+            // readHardware(context), and the message/claim decisions short-circuit on the flag.
+            val hardwareAfterWrite = afterWrite?.let { adapter.decodeHardware(it.chargingStatus ?: 0, it.onCharger) }
+            val hardwareConfirmsTarget = hardwareConfirms(hardwareAfterWrite, policy)
             // Suppress the settling cue when there is no transition to wait for: sync-readback adapters
             // apply immediately, and async hardware may already report the target on a no-op re-apply.
             // Plug-latched adapters are the exception: their readback only proves *configuration* —
             // settled iff written unplugged (the next plug session samples it) or the hardware already
             // reports the exact target (no-op re-apply while enforcing).
             val settled = when {
-                adapter.policyLatchesAtPlug ->
-                    pluggedAtWrite == false || hardwareConfirms(adapter.readHardware(context), policy)
+                adapter.policyLatchesAtPlug -> pluggedAtWrite == false || hardwareConfirmsTarget
                 else -> when (adapter.verification) {
                     VerificationStrategy.SYNC_READBACK ->
                         (observation as? ChargeObservation.Verified)?.policy == policy
@@ -554,17 +572,27 @@ class ChargingRepository @Inject constructor(
             }
             // Timing copy lives solely in the dashboard's settling line; these must stay accurate
             // when nothing is pending (sync-readback adapters, no-op re-applies).
-            val messageRes = when {
-                pending?.awaitingReplug == true -> R.string.charging_message_applied_replug
-                observation is ChargeObservation.Verified -> R.string.charging_message_verified
-                else -> R.string.charging_message_requested
-            }
+            val messageRes = selectApplyMessageRes(
+                policyLatchesAtPlug = adapter.policyLatchesAtPlug,
+                awaitingReplug = pending?.awaitingReplug == true,
+                hardwareConfirmsTarget = hardwareConfirmsTarget,
+                observation = observation,
+            )
             val message = caString { it.getString(messageRes, policy.label.get(it)) }
             mutableState.value = state.value.copy(
                 busy = false,
                 access = access,
                 observation = observation,
                 pending = pending,
+                // This path copies the live state instead of rebuilding it, so the claim has to be
+                // recomputed here too — a stale value would stand exactly while the user watches the
+                // write land, before the next refresh.
+                capAwaitsHardwareConfirmation = capAwaitsHardwareConfirmation(
+                    policyLatchesAtPlug = adapter.policyLatchesAtPlug,
+                    observation = observation,
+                    hardware = hardwareAfterWrite,
+                    plugged = afterWrite?.onCharger == true,
+                ),
                 // A fresh write voids any prior contradiction: the detector re-arms via refresh once
                 // the new request is past its own grace threshold. Stale warnings must never render
                 // over a new request's settling phase (all three publication copies clear this).
@@ -593,6 +621,7 @@ class ChargingRepository @Inject constructor(
                 observation = ChargeObservation.LastRequested(policy),
                 pending = PendingRequest(policy, now, awaitingReplug = fallbackAwaitsReplug(adapter, pluggedAtWrite)),
                 unconfirmedTarget = null,
+                capAwaitsHardwareConfirmation = false,
             )
             settleScheduler.schedule(now)
             throw e
@@ -607,6 +636,7 @@ class ChargingRepository @Inject constructor(
                 observation = observation,
                 pending = PendingRequest(policy, now, awaitingReplug = fallbackAwaitsReplug(adapter, pluggedAtWrite)),
                 unconfirmedTarget = null,
+                capAwaitsHardwareConfirmation = false,
                 message = message,
             )
             settleScheduler.schedule(now)
@@ -746,6 +776,12 @@ class ChargingRepository @Inject constructor(
             reconnectAnyLevelOnly = adapter?.reconnectGestureSupport?.impliesAnyLevel == true,
             syncVerification = adapter?.verification == VerificationStrategy.SYNC_READBACK,
             writeRequiresShizuku = adapter?.preferShizukuForWrites == true,
+            capAwaitsHardwareConfirmation = capAwaitsHardwareConfirmation(
+                policyLatchesAtPlug = latches,
+                observation = observation,
+                hardware = hardware,
+                plugged = battery.onCharger,
+            ),
             controlEnabled = selection.support.controlEnabled,
             enforcement = selection.support.enforcement,
             contributionWanted = selection.support.contributionWanted,
@@ -992,6 +1028,49 @@ internal fun hardwareConfirms(hardware: ChargeObservation?, target: ChargePolicy
     hardware is ChargeObservation.Verified &&
         hardware.backend == BackendKind.BATTERY_HARDWARE &&
         hardware.policy == target
+
+/**
+ * Behind [ChargingState.capAwaitsHardwareConfirmation]: a cap that reads back is stored, which on a
+ * [ChargingAdapter.policyLatchesAtPlug] ROM is a weaker fact than it looks — the charging service
+ * sampled the key when the plug session started, so the value the settings provider now returns need
+ * not be the one being enforced. [hardwareConfirms] is the only signal that speaks to enforcement.
+ *
+ * It can only speak where it has one, which is what the guards are for. [ChargingAdapter.decodeHardware]
+ * reports nothing while unplugged (the sticky extra keeps its last powered value), and `Unrestricted`
+ * has no hardware representation at all — only the long-life state decodes to a Verified observation —
+ * so an unconfirmed `Unrestricted` is indistinguishable from a confirmed one and must not be doubted.
+ * The question is therefore asked of a cap, and only while plugged; everywhere else the answer is
+ * false and no surface changes.
+ */
+internal fun capAwaitsHardwareConfirmation(
+    policyLatchesAtPlug: Boolean,
+    observation: ChargeObservation,
+    hardware: ChargeObservation?,
+    plugged: Boolean,
+): Boolean {
+    if (!policyLatchesAtPlug || !plugged) return false
+    val policy = (observation as? ChargeObservation.Verified)?.policy ?: return false
+    if (policy !is ChargePolicy.FixedLimit || policy.percent >= 100) return false
+    return !hardwareConfirms(hardware, policy)
+}
+
+/**
+ * Which apply-time message is true of what the write actually achieved, ordered from the least
+ * achieved upwards: a replug is still owed; or the value is stored on a plug-latched adapter with no
+ * hardware confirmation, where "verified" would claim an effect the read-back cannot show; or the
+ * configured state was read back; or only the request itself is known.
+ */
+internal fun selectApplyMessageRes(
+    policyLatchesAtPlug: Boolean,
+    awaitingReplug: Boolean,
+    hardwareConfirmsTarget: Boolean,
+    observation: ChargeObservation,
+): Int = when {
+    awaitingReplug -> R.string.charging_message_applied_replug
+    policyLatchesAtPlug && !hardwareConfirmsTarget -> R.string.charging_message_saved_unconfirmed
+    observation is ChargeObservation.Verified -> R.string.charging_message_verified
+    else -> R.string.charging_message_requested
+}
 
 /**
  * Whether a degraded post-write fallback [PendingRequest] must carry the replug condition: only on a

--- a/app/src/main/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapter.kt
+++ b/app/src/main/java/eu/darken/amply/charging/core/adapter/GrapheneOsChargingAdapter.kt
@@ -42,6 +42,11 @@ import javax.inject.Singleton
  * capability flag: pending-until-replug verification, the session replug grace window, and
  * `reapply == apply` (there is no observer to re-trigger; the plug event is the trigger).
  *
+ * That replug is what the latch *permits*, not what it guarantees: it was qualified on one device,
+ * and on a second one an external write was still ignored across the following plug session while
+ * reading back correctly. So no surface here may promise a written value takes effect — see the
+ * qualification ledger in .claude/skills/device-qualification/ for both runs.
+ *
  * While the limit is enforcing, the device reports the same hardware signal as stock Pixel
  * (`EXTRA_CHARGING_STATUS` = 4, battery status NOT_CHARGING at the cap), so [decodeHardware]
  * provides real enforcement evidence — the only proof that beats a merely-configured readback on

--- a/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/amply/main/ui/dashboard/DashboardScreen.kt
@@ -481,13 +481,17 @@ private fun StatusCard(
     val gatedTier = state.charging.enforcement
         ?.takeIf { observation is ChargeObservation.Unsupported }
         ?.takeIf { it == EnforcementStatus.CANDIDATE || it == EnforcementStatus.REFUTED }
-    // Two independent reasons to withhold the green check, both about the same gap between "the ROM
-    // stored the policy" and "the charger is acting on it". Either one alone is disqualifying:
+    // Three independent reasons to withhold the green check, all about the same gap between "the ROM
+    // stored the policy" and "the charger is acting on it". Any one alone is disqualifying:
     //  - the policy itself may be conditional — a readback of adaptive proves the mode is set, not
     //    that it is doing anything right now;
     //  - the build's enforcement may never have been confirmed, and on these adapters no readback can
-    //    confirm it (see EnforcementVerdictEngine — observation can only ever refute).
-    val policyInEffect = observation.provesPolicyInEffect() && !enforcementUnverified
+    //    confirm it (see EnforcementVerdictEngine — observation can only ever refute);
+    //  - the ROM may have sampled the policy when this plug session started, so a stored cap the
+    //    hardware has not confirmed is not yet a cap.
+    val policyInEffect = observation.provesPolicyInEffect() &&
+        !enforcementUnverified &&
+        !state.charging.capAwaitsHardwareConfirmation
 
     // Not clickable. The card states the policy; the measurements (and the way through to them) live
     // in the charging card below. A whole-card tap here used to land on voltage and cycle counts,
@@ -581,18 +585,33 @@ private fun StatusCard(
                 color = MaterialTheme.colorScheme.tertiary,
             )
         }
-        // Standing adapter fact (write latency, Shizuku requirement, replug semantics) — only set
-        // while control is enabled, so it never repeats a gate-failure reason shown above. Hidden
-        // while a replug is pending: the transient hint below states the same fact as an instruction,
-        // and printing both would say "reconnect the charger" twice on latched adapters.
-        state.charging.adapterDetail?.takeIf { !state.charging.isAwaitingReplug() }?.let {
+        // Same gap as the note above, different cause: the value is stored and the hardware has not
+        // said it is acting on it. Neutral rather than an error colour — nothing is wrong here, the
+        // limit simply is not shown to be doing anything yet.
+        if (state.charging.capAwaitsHardwareConfirmation) {
             Spacer(Modifier.height(4.dp))
             Text(
-                it.asComposable(),
+                stringResource(R.string.dashboard_cap_unconfirmed_note),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+        // Standing adapter fact (write latency, Shizuku requirement, replug semantics) — only set
+        // while control is enabled, so it never repeats a gate-failure reason shown above. Hidden
+        // while a replug is pending: the transient hint below states the same fact as an instruction,
+        // and printing both would say "reconnect the charger" twice on latched adapters. Hidden while
+        // a cap is unconfirmed for the reverse reason: this line explains when a change is picked up,
+        // which under the note above would read as the effect the note just withheld.
+        state.charging.adapterDetail
+            ?.takeIf { !state.charging.isAwaitingReplug() && !state.charging.capAwaitsHardwareConfirmation }
+            ?.let {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    it.asComposable(),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         // Provenance, not a second policy claim: the title above already says what the policy is,
         // this says who chose it. Withheld while a session or a settling write owns the display —
         // those are the current authors, and naming a rule there would be wrong.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -144,7 +144,7 @@
     <string name="adapter_detail_requires_oplus">Requires a OnePlus, Oppo, or Realme device on ColorOS 15</string>
     <string name="adapter_detail_oplus_ready">Charging control requires Shizuku on this device</string>
     <string name="adapter_detail_requires_grapheneos">Requires GrapheneOS</string>
-    <string name="adapter_detail_grapheneos_ready">Charging control requires Shizuku; changes take effect the next time the charger is reconnected</string>
+    <string name="adapter_detail_grapheneos_ready">Charging control requires Shizuku. The system only picks up a change when you reconnect the charger.</string>
     <string name="adapter_detail_requires_lineageos">Requires a qualified LineageOS device</string>
     <string name="adapter_detail_lineageos_no_provider">LineageOS charging control is not available on this build</string>
     <string name="adapter_detail_lineageos_ready">Charging control requires Shizuku on this device</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,7 +87,7 @@
     <string name="charging_message_applying">Applying %1$s…</string>
     <string name="charging_message_write_failed">Write failed</string>
     <string name="charging_message_verified">%1$s setting verified</string>
-    <string name="charging_message_applied_replug">%1$s set: takes effect after you unplug and replug</string>
+    <string name="charging_message_applied_replug">%1$s set: reconnect the charger for the system to pick it up</string>
     <string name="charging_message_saved_unconfirmed">%1$s saved. The charging hardware hasn\'t confirmed it</string>
     <string name="charging_message_requested">%1$s requested</string>
     <string name="charging_message_shizuku_granted">Shizuku permission granted</string>
@@ -494,7 +494,7 @@
     <string name="dashboard_applying">Applying…</string>
     <string name="dashboard_device_line">%1$s · Android API %2$d</string>
     <string name="dashboard_waiting_target">Waiting for the system to switch to %1$s. This can take about 15 seconds…</string>
-    <string name="dashboard_waiting_replug">Takes effect the next time you unplug and replug the charger</string>
+    <string name="dashboard_waiting_replug">The system picks this up the next time you unplug and replug the charger</string>
     <string name="dashboard_hw_unconfirmed">The charging hardware hasn\'t confirmed %1$s yet. It may not be applying</string>
 
     <!-- Enforcement tier (adapters where a setting can read back while the hardware ignores it) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="charging_message_write_failed">Write failed</string>
     <string name="charging_message_verified">%1$s setting verified</string>
     <string name="charging_message_applied_replug">%1$s set: takes effect after you unplug and replug</string>
+    <string name="charging_message_saved_unconfirmed">%1$s saved. The charging hardware hasn\'t confirmed it</string>
     <string name="charging_message_requested">%1$s requested</string>
     <string name="charging_message_shizuku_granted">Shizuku permission granted</string>
     <string name="charging_message_shizuku_denied">Shizuku permission was not granted</string>
@@ -504,6 +505,7 @@
     <string name="dashboard_enforcement_unverified_title">Charge limit not confirmed</string>
     <string name="dashboard_enforcement_unverified_body">The controls are available, but nothing Amply can see proves the limit works on this build. It keeps watching for the opposite: if the battery is observed charging past the limit, Amply switches its charging controls back off.</string>
     <string name="dashboard_enforcement_unverified_note">Set, but not confirmed to work on this build</string>
+    <string name="dashboard_cap_unconfirmed_note">Set. The charging hardware hasn\'t confirmed the limit</string>
     <string name="dashboard_enforcement_self_qualified_title">You proved the charge limit here</string>
     <string name="dashboard_enforcement_self_qualified_body">The guided check stopped your charging at the limit, started it again, and stopped it a second time, so the charging hardware really is honouring the limit on this build. That result applies to this build only: a system update replaces it, and you can run the check again afterwards.</string>
     <string name="dashboard_enforcement_refuted_title">Charge limiting does not work on this build</string>

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryFailurePublicationTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingRepositoryFailurePublicationTest.kt
@@ -1,0 +1,184 @@
+package eu.darken.amply.charging.core
+
+import android.Manifest
+import android.app.Application
+import android.content.Context
+import android.content.pm.ProviderInfo
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.amply.battery.core.BatteryReader
+import eu.darken.amply.battery.core.BatteryUnitCalibration
+import eu.darken.amply.charging.core.access.AccessResolver
+import eu.darken.amply.charging.core.access.DirectSettingsBackend
+import eu.darken.amply.charging.core.access.LineageSettingsClient
+import eu.darken.amply.charging.core.access.ShizukuSettingsBackend
+import eu.darken.amply.charging.core.access.shizuku.ShizukuController
+import eu.darken.amply.charging.core.access.shizuku.ShizukuInstallationDetector
+import eu.darken.amply.charging.core.adapter.AdapterRegistry
+import eu.darken.amply.charging.core.adapter.GrapheneOsChargingAdapter
+import eu.darken.amply.charging.core.adapter.LineageChargingAdapter
+import eu.darken.amply.charging.core.adapter.LineageLabAdapter
+import eu.darken.amply.charging.core.adapter.OnePlusChargingAdapter
+import eu.darken.amply.charging.core.adapter.OnePlusLabAdapter
+import eu.darken.amply.charging.core.adapter.PixelChargingAdapter
+import eu.darken.amply.charging.core.adapter.SamsungLabAdapter
+import eu.darken.amply.charging.core.adapter.SamsungLegacyChargingAdapter
+import eu.darken.amply.charging.core.adapter.SamsungModernChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiHyperOs3ChargingAdapter
+import eu.darken.amply.charging.core.adapter.XiaomiLabAdapter
+import eu.darken.amply.charging.core.enforcement.BuildIdentitySource
+import eu.darken.amply.charging.core.enforcement.EnforcementEvidenceStore
+import eu.darken.amply.charging.core.qualification.QualificationEvidenceStore
+import eu.darken.amply.charging.core.qualification.QualificationRunStore
+import eu.darken.amply.common.AppDataStore
+import eu.darken.amply.common.serialization.SerializationModule
+import eu.darken.amply.fullcharge.core.FullChargeStore
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+import java.io.File
+
+/**
+ * The three failure publications in the apply path republish with `state.value.copy(...)`, so every
+ * standing claim they do not name survives them. [ChargingState.capAwaitsHardwareConfirmation] is
+ * such a claim, and the dashboard renders its note off that field alone — a stale `true` would go on
+ * saying "set, waiting for the hardware" about a policy that was never written.
+ *
+ * The fixture is a LineageOS candidate build because one device reaches all three sites: the gate
+ * refuses a fresh apply (Unsupported), the ungated restore finds no usable backend once WSS is
+ * revoked (NeedsSetup), and with WSS granted it reaches the adapter and fails there — WSS cannot
+ * write the Lineage provider (Unknown). The observation assertions are what pin each case to its
+ * intended site.
+ *
+ * The flag is seeded reflectively because nothing here can produce it honestly: it is set only for a
+ * plug-latched adapter (GrapheneOS today) whose configured cap was read back over Shizuku, which
+ * cannot be stood up on the JVM. The publications under test are adapter-independent.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36])
+class ChargingRepositoryFailurePublicationTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val storeScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    private val buildIdentity = object : BuildIdentitySource {
+        override fun current() = "test-build"
+    }
+
+    private lateinit var repository: ChargingRepository
+
+    @Before
+    fun setup() {
+        val shadowPackageManager = shadowOf(context.packageManager)
+        shadowPackageManager.setSystemFeature(DeviceInfo.FEATURE_LINEAGE_OS, true)
+        shadowPackageManager.addOrUpdateProvider(
+            ProviderInfo().apply {
+                authority = DeviceInfo.LINEAGE_SETTINGS_AUTHORITY
+                packageName = "org.lineageos.lineagesettings"
+                name = "org.lineageos.lineagesettings.LineageSettingsProvider"
+            },
+        )
+        shadowOf(context as Application).grantPermissions(Manifest.permission.WRITE_SECURE_SETTINGS)
+
+        val appDataStore = AppDataStore(
+            PreferenceDataStoreFactory.create(scope = storeScope) {
+                File(tempFolder.root, "test.preferences_pb")
+            },
+        )
+        val json = SerializationModule.json()
+        val shizukuController = ShizukuController(context, ShizukuInstallationDetector(context))
+        repository = ChargingRepository(
+            context = context,
+            registry = AdapterRegistry(
+                context = context,
+                lineage = LineageChargingAdapter(LineageSettingsClient(context)),
+                lineageLab = LineageLabAdapter(),
+                grapheneOs = GrapheneOsChargingAdapter(),
+                pixel = PixelChargingAdapter(),
+                samsungModern = SamsungModernChargingAdapter(),
+                samsungLegacy = SamsungLegacyChargingAdapter(),
+                samsungLab = SamsungLabAdapter(),
+                xiaomi = XiaomiChargingAdapter(),
+                xiaomiHyperOs3 = XiaomiHyperOs3ChargingAdapter(),
+                xiaomiLab = XiaomiLabAdapter(),
+                onePlus = OnePlusChargingAdapter(),
+                onePlusLab = OnePlusLabAdapter(),
+            ),
+            accessResolver = AccessResolver(
+                direct = DirectSettingsBackend(context),
+                shizuku = ShizukuSettingsBackend(shizukuController),
+            ),
+            preferences = ChargingPreferences(appDataStore, json),
+            shizukuController = shizukuController,
+            settleScheduler = object : SettleScheduler {
+                override fun schedule(requestedAtMillis: Long) = Unit
+            },
+            batteryReader = BatteryReader(context, BatteryUnitCalibration(context)),
+            evidenceStore = EnforcementEvidenceStore(appDataStore, buildIdentity, json),
+            qualificationStore = QualificationEvidenceStore(appDataStore, buildIdentity, json),
+            runStore = QualificationRunStore(appDataStore, json),
+            fullChargeStore = FullChargeStore(appDataStore, json),
+            buildIdentity = buildIdentity,
+        )
+    }
+
+    @After
+    fun teardown() {
+        storeScope.cancel()
+    }
+
+    private fun seedUnconfirmedCap() {
+        val published = ReflectionHelpers.getField<MutableStateFlow<ChargingState>>(repository, "mutableState")
+        published.value = published.value.copy(capAwaitsHardwareConfirmation = true)
+        repository.state.value.capAwaitsHardwareConfirmation shouldBe true
+    }
+
+    @Test
+    fun `a gate refusal drops a standing unconfirmed-cap claim`() = runTest {
+        seedUnconfirmedCap()
+
+        repository.applyPersistent(ChargePolicy.FixedLimit(80))
+            .observation.shouldBeInstanceOf<ChargeObservation.Unsupported>()
+
+        repository.state.value.capAwaitsHardwareConfirmation shouldBe false
+    }
+
+    @Test
+    fun `a missing write backend drops a standing unconfirmed-cap claim`() = runTest {
+        shadowOf(context as Application).denyPermissions(Manifest.permission.WRITE_SECURE_SETTINGS)
+        seedUnconfirmedCap()
+
+        repository.restorePersistent(ChargePolicy.FixedLimit(80))
+            .observation.shouldBeInstanceOf<ChargeObservation.NeedsSetup>()
+
+        repository.state.value.capAwaitsHardwareConfirmation shouldBe false
+    }
+
+    @Test
+    fun `a failed write drops a standing unconfirmed-cap claim`() = runTest {
+        seedUnconfirmedCap()
+
+        repository.restorePersistent(ChargePolicy.FixedLimit(80))
+            .observation.shouldBeInstanceOf<ChargeObservation.Unknown>()
+
+        repository.state.value.capAwaitsHardwareConfirmation shouldBe false
+    }
+}

--- a/app/src/test/java/eu/darken/amply/charging/core/ChargingSyncReadTest.kt
+++ b/app/src/test/java/eu/darken/amply/charging/core/ChargingSyncReadTest.kt
@@ -2,6 +2,7 @@ package eu.darken.amply.charging.core
 
 import android.content.Context
 import android.content.Intent
+import eu.darken.amply.R
 import eu.darken.amply.battery.core.BatteryReadout
 import eu.darken.amply.charging.core.access.AccessBackend
 import eu.darken.amply.charging.core.access.BackendStatus
@@ -497,6 +498,117 @@ class ChargingSyncReadTest {
             prevCandidate = first.candidate,
             prevSince = first.sinceMillis,
         ).surfaced shouldBe null
+    }
+
+    // --- capAwaitsHardwareConfirmation: a stored cap is not a cap the hardware confirmed ---
+
+    private fun awaits(
+        latches: Boolean = true,
+        observation: ChargeObservation = verified(target, BackendKind.SHIZUKU),
+        hardware: ChargeObservation? = null,
+        plugged: Boolean = true,
+    ) = capAwaitsHardwareConfirmation(
+        policyLatchesAtPlug = latches,
+        observation = observation,
+        hardware = hardware,
+        plugged = plugged,
+    )
+
+    @Test
+    fun `a plugged cap without hardware evidence awaits confirmation`() {
+        awaits() shouldBe true
+    }
+
+    @Test
+    fun `matching hardware evidence settles the cap`() {
+        awaits(hardware = verified(target, BackendKind.BATTERY_HARDWARE)) shouldBe false
+    }
+
+    @Test
+    fun `settings-level verification is not hardware evidence for the cap`() {
+        awaits(hardware = verified(target, BackendKind.SHIZUKU)) shouldBe true
+    }
+
+    @Test
+    fun `unplugged never awaits confirmation`() {
+        // decodeHardware reports nothing off the charger, so the question has no answer to wait for.
+        awaits(plugged = false) shouldBe false
+    }
+
+    @Test
+    fun `unrestricted never awaits confirmation`() {
+        // No hardware representation exists for it, so an unconfirmed one is indistinguishable from
+        // a confirmed one and must not be doubted.
+        awaits(observation = verified(other, BackendKind.SHIZUKU)) shouldBe false
+    }
+
+    @Test
+    fun `a full-charge limit is not a cap`() {
+        awaits(observation = verified(ChargePolicy.FixedLimit(100), BackendKind.SHIZUKU)) shouldBe false
+    }
+
+    @Test
+    fun `adapters that do not latch at plug are unaffected`() {
+        awaits(latches = false) shouldBe false
+    }
+
+    @Test
+    fun `only a verified configured state can await confirmation`() {
+        awaits(observation = ChargeObservation.LastRequested(target)) shouldBe false
+        awaits(observation = generic()) shouldBe false
+        awaits(observation = unrecognized()) shouldBe false
+    }
+
+    // --- selectApplyMessageRes: the message may not outrun what the write achieved ---
+
+    @Test
+    fun `a latched write without hardware confirmation says saved, not verified`() {
+        selectApplyMessageRes(
+            policyLatchesAtPlug = true,
+            awaitingReplug = false,
+            hardwareConfirmsTarget = false,
+            observation = verified(target, BackendKind.SHIZUKU),
+        ) shouldBe R.string.charging_message_saved_unconfirmed
+    }
+
+    @Test
+    fun `a latched write the hardware confirms is verified`() {
+        selectApplyMessageRes(
+            policyLatchesAtPlug = true,
+            awaitingReplug = false,
+            hardwareConfirmsTarget = true,
+            observation = verified(target, BackendKind.SHIZUKU),
+        ) shouldBe R.string.charging_message_verified
+    }
+
+    @Test
+    fun `an owed replug outranks both`() {
+        selectApplyMessageRes(
+            policyLatchesAtPlug = true,
+            awaitingReplug = true,
+            hardwareConfirmsTarget = false,
+            observation = verified(target, BackendKind.SHIZUKU),
+        ) shouldBe R.string.charging_message_applied_replug
+    }
+
+    @Test
+    fun `a non-latched verified write keeps the verified message`() {
+        selectApplyMessageRes(
+            policyLatchesAtPlug = false,
+            awaitingReplug = false,
+            hardwareConfirmsTarget = false,
+            observation = verified(target, BackendKind.SHIZUKU),
+        ) shouldBe R.string.charging_message_verified
+    }
+
+    @Test
+    fun `an unverified write is only a request`() {
+        selectApplyMessageRes(
+            policyLatchesAtPlug = false,
+            awaitingReplug = false,
+            hardwareConfirmsTarget = false,
+            observation = ChargeObservation.LastRequested(target),
+        ) shouldBe R.string.charging_message_requested
     }
 
     private class FakeBackend(override val kind: BackendKind) : AccessBackend {

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardEnforcementClaimTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardEnforcementClaimTest.kt
@@ -109,7 +109,7 @@ class DashboardEnforcementClaimTest {
     }
 
     @Test
-    fun `a hardware-confirmed cap on a latching rom keeps the affirmative card`() {
+    fun `a hardware-confirmed cap on a latching rom is not marked unconfirmed`() {
         // The state this whole change must leave reachable: a plug-latched adapter reads its cap back
         // through Shizuku (it has no other read path), and once the hardware confirms it, the card is
         // the ordinary affirmative one. Keying the withholding on the observation's backend instead of

--- a/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardEnforcementClaimTest.kt
+++ b/app/src/test/java/eu/darken/amply/main/ui/dashboard/DashboardEnforcementClaimTest.kt
@@ -9,6 +9,7 @@ import eu.darken.amply.charging.core.BackendKind
 import eu.darken.amply.charging.core.ChargeObservation
 import eu.darken.amply.charging.core.ChargePolicy
 import eu.darken.amply.charging.core.ChargingState
+import eu.darken.amply.common.ca.toCaString
 import io.kotest.matchers.string.shouldContain
 import org.junit.Rule
 import org.junit.Test
@@ -34,12 +35,21 @@ class DashboardEnforcementClaimTest {
 
     private fun string(res: Int): String = context.getString(res)
 
-    private fun render(observation: ChargeObservation) {
+    private fun render(
+        observation: ChargeObservation,
+        capAwaitsHardwareConfirmation: Boolean = false,
+        adapterDetail: Int? = null,
+    ) {
         compose.setContent {
             DashboardScreenUnderTest(
                 state = DashboardUiState(
                     onboardingComplete = true,
-                    charging = ChargingState(controlEnabled = true, observation = observation),
+                    charging = ChargingState(
+                        controlEnabled = true,
+                        observation = observation,
+                        capAwaitsHardwareConfirmation = capAwaitsHardwareConfirmation,
+                        adapterDetail = adapterDetail?.toCaString(),
+                    ),
                 ),
             )
         }
@@ -96,6 +106,39 @@ class DashboardEnforcementClaimTest {
 
         compose.onNodeWithText(readbackThrough(BackendKind.SHIZUKU)).assertExists()
         compose.onNodeWithText(conditionalReadbackThrough(BackendKind.SHIZUKU)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a hardware-confirmed cap on a latching rom keeps the affirmative card`() {
+        // The state this whole change must leave reachable: a plug-latched adapter reads its cap back
+        // through Shizuku (it has no other read path), and once the hardware confirms it, the card is
+        // the ordinary affirmative one. Keying the withholding on the observation's backend instead of
+        // on the repository's flag would make that permanently unreachable, and a test feeding only
+        // BATTERY_HARDWARE observations would not notice.
+        render(
+            ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.SHIZUKU),
+            capAwaitsHardwareConfirmation = false,
+            adapterDetail = R.string.adapter_detail_grapheneos_ready,
+        )
+
+        compose.onNodeWithText(string(R.string.dashboard_cap_unconfirmed_note)).assertDoesNotExist()
+        compose.onNodeWithText(readbackThrough(BackendKind.SHIZUKU)).assertExists()
+        compose.onNodeWithText(string(R.string.adapter_detail_grapheneos_ready)).assertExists()
+    }
+
+    @Test
+    fun `an unconfirmed cap is shown as set and never as taking effect`() {
+        // Same read-back, same policy — only the hardware evidence is missing. The note has to say so,
+        // and the adapter's standing "the system picks a change up when you reconnect" line has to go
+        // with it: printed together they would answer the note with the effect it withholds.
+        render(
+            ChargeObservation.Verified(ChargePolicy.FixedLimit(80), BackendKind.SHIZUKU),
+            capAwaitsHardwareConfirmation = true,
+            adapterDetail = R.string.adapter_detail_grapheneos_ready,
+        )
+
+        compose.onNodeWithText(string(R.string.dashboard_cap_unconfirmed_note)).assertExists()
+        compose.onNodeWithText(string(R.string.adapter_detail_grapheneos_ready)).assertDoesNotExist()
     }
 
     @Test


### PR DESCRIPTION
## What changed

On GrapheneOS, Amply could show a charge limit as verified and in effect when all that had actually happened was the value being stored. The app now shows such a limit as set rather than in effect until the charging hardware confirms it, and the message after you change the setting says the value was saved rather than verified.

Copy that promised a change "takes effect" when you reconnect the charger now says the system picks the change up on reconnect. On at least one device it demonstrably does not take effect.

No behaviour changes on any other device.

Refs #49

## Technical Context

- Root cause: on this ROM the settings read-back always succeeds, so the published observation is always settings-backed and the affirmative display keyed on it. A read-back proves the value is stored, not that the charging service adopted it. Reported on a Pixel 10 in #49, where a cap cleared externally was still enforced across the following plug session.
- The evidence question is asked in one pure function and reaches the dashboard as a single boolean. It is deliberately scoped to a cap while plugged: the hardware decode reports nothing while unplugged and has no representation for unrestricted charging, so demanding confirmation in those states would be unsatisfiable.
- Rejected alternative worth recording: routing this adapter through the enforcement-evidence gate. That gate's refutation rule fires on an observed climb past the cap and has no suppressor for a ROM that deliberately charges past a cap it still honours, which is what this ROM's periodic recalibration does. It would have permanently disabled charging control on working devices.
- Deserves close review: the three failure publications in the apply path republish with a state copy, so any standing claim they do not explicitly clear survives them. The new flag is cleared at all three, with a regression test pinning each branch by observation type.
- The qualification notes are amended additively. Two pre-existing statements that an earlier draft called false turned out to be correct within their stated scope, so they stand and the new material sits beside them.
