### PR TITLE
General: Migrate Claude plugins to Clanker Cafe

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,13 @@
 {
   "enabledPlugins": {
-    "debugbadger@claude-code-cafe": true,
-    "jvm-tools@claude-code-cafe": true,
-    "devtools@claude-code-cafe": true,
-    "support@claude-code-cafe": true,
-    "frontend-design@claude-plugins-official": true
+    "debugbadger@claude-code-cafe": false,
+    "jvm-tools@claude-code-cafe": false,
+    "devtools@claude-code-cafe": false,
+    "support@claude-code-cafe": false,
+    "frontend-design@claude-plugins-official": true,
+    "debugbadger@clanker-cafe": true,
+    "jvm-tools@clanker-cafe": true,
+    "devtools@clanker-cafe": true,
+    "support@clanker-cafe": true
   }
 }


### PR DESCRIPTION
## What changed

No user-facing behavior change. Move the four project Claude plugins to Clanker Cafe.

## Technical Context

- Old plugin IDs remain explicitly disabled, with their registrations, cached versions and workflow records retained for rollback and case continuity.
- A fresh Claude session verified replacement plugins, commands, skills, agents, hooks and MCP schemas without device or service actions.
